### PR TITLE
Ability to run plugin even on failure

### DIFF
--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -253,6 +253,8 @@ class DockerBuildWorkflow(object):
         self.exit_plugins_conf = exit_plugins
         self.prebuild_results = {}
         self.postbuild_results = {}
+        self.build_failed = False
+        self.plugin_failed = False
         self.plugin_files = plugin_files
 
         self.kwargs = kwargs
@@ -281,6 +283,13 @@ class DockerBuildWorkflow(object):
         if kwargs:
             logger.warning("unprocessed keyword arguments: %s", kwargs)
 
+    @property
+    def build_process_failed(self):
+        """
+        Has any aspect of the build process failed?
+        """
+        return self.build_failed or self.plugin_failed
+
     def build_docker_image(self):
         """
         build docker image
@@ -308,6 +317,8 @@ class DockerBuildWorkflow(object):
 
             build_result = self.builder.build()
             self.build_logs = build_result.logs
+
+            self.build_failed = build_result.is_failed()
 
             if not build_result.is_failed():
                 self.built_image_inspect = self.builder.inspect_built_image()

--- a/atomic_reactor/plugin.py
+++ b/atomic_reactor/plugin.py
@@ -277,6 +277,27 @@ class PostBuildPluginsRunner(BuildPluginsRunner):
         self.plugins_results = workflow.postbuild_results
         super(PostBuildPluginsRunner, self).__init__(dt, workflow, 'PostBuildPlugin', plugins_conf, *args, **kwargs)
 
+    def create_instance_from_plugin(self, plugin_class, plugin_conf):
+        instance = super(PostBuildPluginsRunner, self).create_instance_from_plugin(plugin_class, plugin_conf)
+        if isinstance(instance, ExitPlugin):
+            logger.error("running exit plugin '%s' as post-build plugin", plugin_class.key)
+
+        return instance
+
+
+class ExitPlugin(PostBuildPlugin):
+    """
+    Plugin base class for plugins which should be run just before
+    exit. It is flavored with DockerTasker and DockerBuildWorkflow instances.
+    """
+
+
+class ExitPluginsRunner(BuildPluginsRunner):
+    def __init__(self, dt, workflow, plugins_conf, *args, **kwargs):
+        logger.info("initializing runner of exit plugins")
+        super(ExitPluginsRunner, self).__init__(dt, workflow, 'ExitPlugin',
+                                                plugins_conf, *args, **kwargs)
+
 
 class InputPlugin(Plugin):
 

--- a/atomic_reactor/plugin.py
+++ b/atomic_reactor/plugin.py
@@ -146,6 +146,9 @@ class PluginsRunner(object):
         plugin_instance = plugin_class(**plugin_conf)
         return plugin_instance
 
+    def on_plugin_failed(self):
+        pass
+
     def run(self):
         """
         run all requested plugins
@@ -184,6 +187,7 @@ class PluginsRunner(object):
                 logger.debug(traceback.format_exc())
                 if not plugin_can_fail:
                     failed_msgs.append(msg)
+                    self.on_plugin_failed()
                 else:
                     logger.info("error is not fatal, continuing...")
                 plugin_response = ex
@@ -209,6 +213,9 @@ class BuildPluginsRunner(PluginsRunner):
         self.dt = dt
         self.workflow = workflow
         super(BuildPluginsRunner, self).__init__(plugin_class_name, plugins_conf, *args, **kwargs)
+
+    def on_plugin_failed(self):
+        self.workflow.plugin_failed = True
 
     def _translate_special_values(self, obj_to_translate):
         """

--- a/atomic_reactor/plugins/exit_remove_built_image.py
+++ b/atomic_reactor/plugins/exit_remove_built_image.py
@@ -8,7 +8,7 @@ of the BSD license. See the LICENSE file for details.
 
 Remove built image (this only makes sense if you store the image in some registry first)
 """
-from atomic_reactor.plugin import PostBuildPlugin
+from atomic_reactor.plugin import ExitPlugin
 from atomic_reactor.util import ImageName
 
 from docker.errors import APIError
@@ -16,7 +16,7 @@ from docker.errors import APIError
 __all__ = ('GarbageCollectionPlugin', )
 
 
-class GarbageCollectionPlugin(PostBuildPlugin):
+class GarbageCollectionPlugin(ExitPlugin):
     key = "remove_built_image"
     can_fail = True
 

--- a/atomic_reactor/plugins/exit_store_logs_to_file.py
+++ b/atomic_reactor/plugins/exit_store_logs_to_file.py
@@ -9,13 +9,13 @@ of the BSD license. See the LICENSE file for details.
 import json
 from atomic_reactor.constants import CONTAINER_RESULTS_JSON_PATH
 from atomic_reactor.inner import BuildResultsEncoder
-from atomic_reactor.plugin import PostBuildPlugin
+from atomic_reactor.plugin import ExitPlugin
 
 
 __all__ = ('StoreLogsToFilePlugin', )
 
 
-class StoreLogsToFilePlugin(PostBuildPlugin):
+class StoreLogsToFilePlugin(ExitPlugin):
     key = "store_logs_to_file"
 
     def __init__(self, tasker, workflow, file_path):

--- a/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
+++ b/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
@@ -13,13 +13,13 @@ import os
 from osbs.api import OSBS
 from osbs.conf import Configuration
 
-from atomic_reactor.plugin import PostBuildPlugin
+from atomic_reactor.plugin import ExitPlugin
 from atomic_reactor.plugins.pre_return_dockerfile import CpDockerfilePlugin
 from atomic_reactor.plugins.pre_pyrpkg_fetch_artefacts import DistgitFetchArtefactsPlugin
 from atomic_reactor.plugins.post_rpmqa import PostBuildRPMqaPlugin
 
 
-class StoreMetadataInOSv3Plugin(PostBuildPlugin):
+class StoreMetadataInOSv3Plugin(ExitPlugin):
     key = "store_metadata_in_osv3"
 
     def __init__(self, tasker, workflow, url, verify_ssl=True, use_auth=True):

--- a/docs/build_json.md
+++ b/docs/build_json.md
@@ -40,9 +40,11 @@ If you want to take advantage of _inner_ part logic of Atomic Reactor, you can d
  * prebuild_plugins - list of dicts, optional
   * list of plugins which are executed prior to build, order _matters_! In this case, first there is generated yum repo for koji f22 tag and then it is injected into dockerfile
  * prepublish_plugins - list of dicts, optional
-  * these plugins are executed after the prebuild plugins but before the postbuild plugins
+  * these plugins are executed after the prebuild plugins but before the image is pushed to the registry
  * postbuild_plugins - list of dicts, optional
-  * these plugins are executed last
+  * these plugins are executed after the image is pushed to the registry
+ * exit_plugins - list of dicts, optional
+  * these plugins are executed last of all and will always be run, even for a failed build
 
 Atomic Reactor is able to read this build json from various places (see input plugins in source code). There is an argument for command `inside-build` called `--input`. Currently there are 3 available inputs:
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -5,12 +5,13 @@ One of the biggest strength of Atomic Reactor is its plugin system.
 
 ## Plugin types
 
-There are 4 types of plugins:
+There are 5 types of plugins:
 
 1. **Input** — when running Atomic Reactor inside a build container, input plugin fetches build input (it can live in [path](https://github.com/projectatomic/atomic-reactor/blob/master/atomic_reactor/plugins/input_path.py), [environment variable](https://github.com/projectatomic/atomic-reactor/blob/master/atomic_reactor/plugins/input_env.py), ...)
 2. **Pre-build** — this plugin is executed after cloning a git repo (so you can edit sources, Dockerfile, ...), prior to build
 3. **Pre-publish** — once build finishes, the built image is pushed to registry, but prior to that, pre-publish plugins are executed (time for some simple tests)
-4. **Post-build** — these are run as a last thing of build process (when build is finished and image was pushed to registries)
+4. **Post-build** — these are run when the build is finished and the image was pushed to registries
+5. **Exit** — these are run last of all, and will always run even if a previous build step failed
 
 ## Plugin configuration
 
@@ -26,7 +27,7 @@ Build plugins are requested and configured via input json: key `prebuild_plugins
 }
 ```
 
-Order is important, because plugins are executed in the order as they are specified (one plugin can use input from another plugin). `args` are directly passed to a plugin in constructor. If `can_fail` is set to `false`, once the plugin raises an exception, build process is halted.
+Order is important, because plugins are executed in the order as they are specified (one plugin can use input from another plugin). `args` are directly passed to a plugin in constructor. Any plugin with `can_fail` is set to `false` that raises an exception causes the build process to proceed directly to the stage of running exit plugins.
 
 
 ## Input plugins

--- a/tests/plugins/test_store_metadata.py
+++ b/tests/plugins/test_store_metadata.py
@@ -14,10 +14,10 @@ from copy import deepcopy
 from flexmock import flexmock
 from osbs.api import OSBS
 from atomic_reactor.inner import DockerBuildWorkflow
-from atomic_reactor.plugin import PostBuildPluginsRunner
+from atomic_reactor.plugin import ExitPluginsRunner
 from atomic_reactor.plugins.post_rpmqa import PostBuildRPMqaPlugin
 
-from atomic_reactor.plugins.post_store_metadata_in_osv3 import StoreMetadataInOSv3Plugin
+from atomic_reactor.plugins.exit_store_metadata_in_osv3 import StoreMetadataInOSv3Plugin
 from atomic_reactor.plugins.pre_cp_dockerfile import CpDockerfilePlugin
 from atomic_reactor.plugins.pre_pyrpkg_fetch_artefacts import DistgitFetchArtefactsPlugin
 from atomic_reactor.util import ImageName, LazyGit
@@ -79,7 +79,7 @@ def test_metadata_plugin(tmpdir):
         PostBuildRPMqaPlugin.key: "rpm1\nrpm2",
     }
 
-    runner = PostBuildPluginsRunner(
+    runner = ExitPluginsRunner(
         None,
         workflow,
         [{
@@ -111,7 +111,7 @@ def test_metadata_plugin_rpmqa_failure(tmpdir):
         PostBuildRPMqaPlugin.key: RuntimeError(),
     }
 
-    runner = PostBuildPluginsRunner(
+    runner = ExitPluginsRunner(
         None,
         workflow,
         [{

--- a/tests/test_inner.py
+++ b/tests/test_inner.py
@@ -1,0 +1,261 @@
+"""
+Copyright (c) 2015 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+from __future__ import unicode_literals
+
+from atomic_reactor.build import InsideBuilder
+from atomic_reactor.util import ImageName
+from atomic_reactor.plugin import PreBuildPlugin, PrePublishPlugin, PostBuildPlugin, ExitPlugin
+from atomic_reactor.plugin import PluginFailedException
+from flexmock import flexmock
+import pytest
+from tests.constants import MOCK_SOURCE
+from tests.docker_mock import mock_docker
+import inspect
+
+from atomic_reactor.inner import DockerBuildWorkflow
+
+
+class MockDockerTasker(object):
+    def inspect_image(self, name):
+        return {}
+
+
+class X(object):
+    pass
+
+
+class MockInsideBuilder(object):
+    def __init__(self):
+        self.tasker = MockDockerTasker()
+        self.base_image = ImageName(repo='Fedora', tag='22')
+        self.image_id = 'asd'
+
+    @property
+    def source(self):
+        result = X()
+        setattr(result, 'dockerfile_path', '/')
+        setattr(result, 'path', '/tmp')
+        return result
+
+    def pull_base_image(self, source_registry, insecure=False):
+        pass
+
+    def build(self):
+        result = X()
+        setattr(result, 'logs', None)
+        setattr(result, 'is_failed', lambda: False)
+        return result
+
+    def inspect_built_image(self):
+        return None
+
+
+class PreRaises(PreBuildPlugin):
+    """
+    This plugin must run and cause the build to abort.
+    """
+
+    can_fail = False
+    key = 'pre_raises'
+
+    def run(self):
+        raise RuntimeError
+
+
+class PreWatched(PreBuildPlugin):
+    """
+    A PreBuild plugin we can watch.
+    """
+
+    key = 'pre_watched'
+
+    def __init__(self, tasker, workflow, watcher, *args, **kwargs):
+        super(PreWatched, self).__init__(tasker, workflow, *args, **kwargs)
+        self.watcher = watcher
+
+    def run(self):
+        self.watcher.call()
+
+
+class PrePubWatched(PrePublishPlugin):
+    """
+    A PrePublish plugin we can watch.
+    """
+
+    key = 'prepub_watched'
+
+    def __init__(self, tasker, workflow, watcher, *args, **kwargs):
+        super(PrePubWatched, self).__init__(tasker, workflow, *args, **kwargs)
+        self.watcher = watcher
+
+    def run(self):
+        self.watcher.call()
+
+
+class PostWatched(PostBuildPlugin):
+    """
+    A PostBuild plugin we can watch.
+    """
+
+    key = 'post_watched'
+
+    def __init__(self, tasker, workflow, watcher, *args, **kwargs):
+        super(PostWatched, self).__init__(tasker, workflow, *args, **kwargs)
+        self.watcher = watcher
+
+    def run(self):
+        self.watcher.call()
+
+
+class ExitWatched(ExitPlugin):
+    """
+    An Exit plugin we can watch.
+    """
+
+    key = 'exit_watched'
+
+    def __init__(self, tasker, workflow, watcher, *args, **kwargs):
+        super(ExitWatched, self).__init__(tasker, workflow, *args, **kwargs)
+        self.watcher = watcher
+
+    def run(self):
+        self.watcher.call()
+
+
+class ExitCompat(ExitPlugin):
+    """
+    An Exit plugin called as a Post-build plugin.
+    """
+
+    key = 'store_logs_to_file'
+
+    def __init__(self, tasker, workflow, watcher, *args, **kwargs):
+        super(ExitCompat, self).__init__(tasker, workflow, *args, **kwargs)
+        self.watcher = watcher
+
+    def run(self):
+        self.watcher.call()
+
+
+class Watcher(object):
+    def __init__(self):
+        self.called = False
+
+    def call(self):
+        self.called = True
+
+    def was_called(self):
+        return self.called
+
+
+def test_workflow():
+    """
+    Test normal workflow.
+    """
+
+    this_file = inspect.getfile(PreWatched)
+    mock_docker()
+    fake_builder = MockInsideBuilder()
+    flexmock(InsideBuilder).new_instances(fake_builder)
+    watch_pre = Watcher()
+    watch_prepub = Watcher()
+    watch_post = Watcher()
+    watch_exit = Watcher()
+    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image',
+                                   prebuild_plugins=[{'name': 'pre_watched',
+                                                      'args': {
+                                                          'watcher': watch_pre
+                                                      }}],
+                                   postbuild_plugins=[{'name': 'post_watched',
+                                                       'args': {
+                                                           'watcher': watch_post
+                                                       }}],
+                                   prepublish_plugins=[{'name': 'prepub_watched',
+                                                        'args': {
+                                                            'watcher': watch_prepub,
+                                                        }}],
+                                   exit_plugins=[{'name': 'exit_watched',
+                                                  'args': {
+                                                      'watcher': watch_exit
+                                                  }}],
+                                   plugin_files=[this_file])
+
+    workflow.build_docker_image()
+
+    assert watch_pre.was_called()
+    assert watch_prepub.was_called()
+    assert watch_post.was_called()
+    assert watch_exit.was_called()
+
+
+def test_workflow_compat():
+    """
+    Some of our plugins have changed from being run post-build to
+    being run at exit. Let's test what happens when we try running an
+    exit plugin as a post-build plugin.
+    """
+
+    this_file = inspect.getfile(PreWatched)
+    mock_docker()
+    fake_builder = MockInsideBuilder()
+    flexmock(InsideBuilder).new_instances(fake_builder)
+    watch_exit = Watcher()
+    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image',
+                                   postbuild_plugins=[{'name': 'store_logs_to_file',
+                                                       'args': {
+                                                           'watcher': watch_exit
+                                                       }}],
+                                   plugin_files=[this_file])
+
+    workflow.build_docker_image()
+    assert watch_exit.was_called()
+
+
+def test_workflow_errors():
+    """
+    This is a test for what happens when plugins fail.
+
+    When a prebuild plugin fails, no postbuild plugins should run.
+    However, all the exit plugins should run.
+    """
+
+    this_file = inspect.getfile(PreRaises)
+    mock_docker()
+    fake_builder = MockInsideBuilder()
+    flexmock(InsideBuilder).new_instances(fake_builder)
+    watch_pre = Watcher()
+    watch_post = Watcher()
+    watch_exit = Watcher()
+    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image',
+                                   prebuild_plugins=[{'name': 'pre_raises',
+                                                      'args': {}},
+                                                     {'name': 'pre_watched',
+                                                      'args': {
+                                                          'watcher': watch_pre
+                                                      }}],
+                                   postbuild_plugins=[{'name': 'post_watched',
+                                                       'args': {
+                                                           'watcher': watch_post
+                                                       }}],
+                                   exit_plugins=[{'name': 'exit_watched',
+                                                  'args': {
+                                                      'watcher': watch_exit
+                                                  }}],
+                                   plugin_files=[this_file])
+
+    with pytest.raises(PluginFailedException):
+        workflow.build_docker_image()
+
+    assert not watch_post.was_called()
+    assert watch_exit.was_called()
+
+    # What about plugins in the same class, e.g. prebuild plugins,
+    # that are listed after a plugin that failed?
+    # Currently, they *do* run.
+    #assert not watch_pre.was_called()

--- a/tests/test_inner.py
+++ b/tests/test_inner.py
@@ -8,17 +8,52 @@ of the BSD license. See the LICENSE file for details.
 
 from __future__ import unicode_literals
 
+import json
 from atomic_reactor.build import InsideBuilder
 from atomic_reactor.util import ImageName
 from atomic_reactor.plugin import PreBuildPlugin, PrePublishPlugin, PostBuildPlugin, ExitPlugin
 from atomic_reactor.plugin import PluginFailedException
+import atomic_reactor.plugin
+import logging
 from flexmock import flexmock
 import pytest
 from tests.constants import MOCK_SOURCE
 from tests.docker_mock import mock_docker
 import inspect
 
+from atomic_reactor.inner import BuildResults, BuildResultsEncoder, BuildResultsJSONDecoder
 from atomic_reactor.inner import DockerBuildWorkflow
+
+
+BUILD_RESULTS_ATTRS = ['build_logs',
+                       'built_img_inspect',
+                       'built_img_info',
+                       'base_img_info',
+                       'base_plugins_output',
+                       'built_img_plugins_output']
+
+
+def test_build_results_encoder():
+    results = BuildResults()
+    expected_data = {}
+    for attr in BUILD_RESULTS_ATTRS:
+        setattr(results, attr, attr)
+        expected_data[attr] = attr
+
+    data = json.loads(json.dumps(results, cls=BuildResultsEncoder))
+    assert data == expected_data
+
+
+def test_build_results_decoder():
+    data = {}
+    expected_results = BuildResults()
+    for attr in BUILD_RESULTS_ATTRS:
+        setattr(expected_results, attr, attr)
+        data[attr] = attr
+
+    results = json.loads(json.dumps(data), cls=BuildResultsJSONDecoder)
+    for attr in set(BUILD_RESULTS_ATTRS) - set(['build_logs']):
+        assert getattr(results, attr) == getattr(expected_results, attr)
 
 
 class MockDockerTasker(object):
@@ -56,91 +91,89 @@ class MockInsideBuilder(object):
         return None
 
 
-class PreRaises(PreBuildPlugin):
+class RaisesMixIn(object):
     """
-    This plugin must run and cause the build to abort.
+    Mix-in class for plugins that should raise exceptions.
     """
 
     can_fail = False
-    key = 'pre_raises'
+
+    def __init__(self, tasker, workflow, *args, **kwargs):
+        super(RaisesMixIn, self).__init__(self, tasker, workflow,
+                                          *args, **kwargs)
 
     def run(self):
         raise RuntimeError
 
 
-class PreWatched(PreBuildPlugin):
+class PreRaises(RaisesMixIn, PreBuildPlugin):
+    """
+    This plugin must run and cause the build to abort.
+    """
+
+    key = 'pre_raises'
+
+
+class WatchedMixIn(object):
+    """
+    Mix-in class for plugins we want to watch.
+    """
+
+    def __init__(self, tasker, workflow, watcher, *args, **kwargs):
+        super(WatchedMixIn, self).__init__(self, tasker, workflow,
+                                           *args, **kwargs)
+        self.watcher = watcher
+
+    def run(self):
+        self.watcher.call()
+
+
+class PreWatched(WatchedMixIn, PreBuildPlugin):
     """
     A PreBuild plugin we can watch.
     """
 
     key = 'pre_watched'
 
-    def __init__(self, tasker, workflow, watcher, *args, **kwargs):
-        super(PreWatched, self).__init__(tasker, workflow, *args, **kwargs)
-        self.watcher = watcher
 
-    def run(self):
-        self.watcher.call()
-
-
-class PrePubWatched(PrePublishPlugin):
+class PrePubWatched(WatchedMixIn, PrePublishPlugin):
     """
     A PrePublish plugin we can watch.
     """
 
     key = 'prepub_watched'
 
-    def __init__(self, tasker, workflow, watcher, *args, **kwargs):
-        super(PrePubWatched, self).__init__(tasker, workflow, *args, **kwargs)
-        self.watcher = watcher
 
-    def run(self):
-        self.watcher.call()
-
-
-class PostWatched(PostBuildPlugin):
+class PostWatched(WatchedMixIn, PostBuildPlugin):
     """
     A PostBuild plugin we can watch.
     """
 
     key = 'post_watched'
 
-    def __init__(self, tasker, workflow, watcher, *args, **kwargs):
-        super(PostWatched, self).__init__(tasker, workflow, *args, **kwargs)
-        self.watcher = watcher
 
-    def run(self):
-        self.watcher.call()
-
-
-class ExitWatched(ExitPlugin):
+class ExitWatched(WatchedMixIn, ExitPlugin):
     """
     An Exit plugin we can watch.
     """
 
     key = 'exit_watched'
 
-    def __init__(self, tasker, workflow, watcher, *args, **kwargs):
-        super(ExitWatched, self).__init__(tasker, workflow, *args, **kwargs)
-        self.watcher = watcher
 
-    def run(self):
-        self.watcher.call()
+class ExitRaises(RaisesMixIn, ExitPlugin):
+    """
+    An Exit plugin that should raise an exception.
+    """
+
+    key = 'exit_raises'
 
 
-class ExitCompat(ExitPlugin):
+class ExitCompat(WatchedMixIn, ExitPlugin):
     """
     An Exit plugin called as a Post-build plugin.
     """
 
     key = 'store_logs_to_file'
-
-    def __init__(self, tasker, workflow, watcher, *args, **kwargs):
-        super(ExitCompat, self).__init__(tasker, workflow, *args, **kwargs)
-        self.watcher = watcher
-
-    def run(self):
-        self.watcher.call()
 
 
 class Watcher(object):
@@ -194,6 +227,29 @@ def test_workflow():
     assert watch_exit.was_called()
 
 
+class FakeLogger(object):
+    def __init__(self):
+        self.debugs = []
+        self.infos = []
+        self.warnings = []
+        self.errors = []
+
+    def log(self, logs, args):
+        logs.append(args)
+
+    def debug(self, *args):
+        self.log(self.debugs, args)
+
+    def info(self, *args):
+        self.log(self.infos, args)
+
+    def warning(self, *args):
+        self.log(self.warnings, args)
+
+    def error(self, *args):
+        self.log(self.errors, args)
+
+
 def test_workflow_compat():
     """
     Some of our plugins have changed from being run post-build to
@@ -206,6 +262,8 @@ def test_workflow_compat():
     fake_builder = MockInsideBuilder()
     flexmock(InsideBuilder).new_instances(fake_builder)
     watch_exit = Watcher()
+    fake_logger = FakeLogger()
+    atomic_reactor.plugin.logger = fake_logger
     workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image',
                                    postbuild_plugins=[{'name': 'store_logs_to_file',
                                                        'args': {
@@ -215,6 +273,53 @@ def test_workflow_compat():
 
     workflow.build_docker_image()
     assert watch_exit.was_called()
+    assert len(fake_logger.errors) > 0
+
+
+class Pre(PreBuildPlugin):
+    """
+    This plugin does nothing. It's only used for configuration testing.
+    """
+
+    key = 'pre'
+
+
+def test_plugin_errors():
+    """
+    Try bad plugin configuration.
+    """
+
+    this_file = inspect.getfile(PreRaises)
+    mock_docker()
+    fake_builder = MockInsideBuilder()
+    flexmock(InsideBuilder).new_instances(fake_builder)
+    fake_logger = FakeLogger()
+    atomic_reactor.plugin.logger = fake_logger
+
+    # No 'name' key
+    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image',
+                                   prebuild_plugins=[{'args': {}}],
+                                   plugin_files=[this_file])
+
+    workflow.build_docker_image()
+    assert len(fake_logger.errors) > 0
+
+    # No 'args' key
+    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image',
+                                   prebuild_plugins=[{'name': 'pre'}],
+                                   plugin_files=[this_file])
+
+    workflow.build_docker_image()
+    assert len(fake_logger.errors) > 0
+
+    # No such plugin
+    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image',
+                                   prebuild_plugins=[{'name': 'no plugin',
+                                                      'args': {}}],
+                                   plugin_files=[this_file])
+
+    workflow.build_docker_image()
+    assert len(fake_logger.errors) > 0
 
 
 def test_workflow_errors():
@@ -243,7 +348,10 @@ def test_workflow_errors():
                                                        'args': {
                                                            'watcher': watch_post
                                                        }}],
-                                   exit_plugins=[{'name': 'exit_watched',
+                                   exit_plugins=[{'name': 'exit_raises',
+                                                  'args': {}
+                                                  },
+                                                 {'name': 'exit_watched',
                                                   'args': {
                                                       'watcher': watch_exit
                                                   }}],
@@ -252,10 +360,14 @@ def test_workflow_errors():
     with pytest.raises(PluginFailedException):
         workflow.build_docker_image()
 
+    # A pre-build plugin caused the build to fail, so post-build
+    # plugins should not run.
     assert not watch_post.was_called()
+
+    # But all exit plugins should run, even if one of them also raises
+    # an exception.
     assert watch_exit.was_called()
 
-    # What about plugins in the same class, e.g. prebuild plugins,
-    # that are listed after a plugin that failed?
-    # Currently, they *do* run.
-    #assert not watch_pre.was_called()
+    # All plugins of the same type (e.g. pre-build) are run, even if
+    # one of them failed.
+    assert watch_pre.was_called()


### PR DESCRIPTION
Now plugins can determine whether the build has already been marked as failed.

This will be needed when we have BuildConfigs to prune.