### PR TITLE
[do not merge yet] Exit plugin for removing BuildConfig on failure

### DIFF
--- a/atomic_reactor/plugins/exit_remove_buildconfig.py
+++ b/atomic_reactor/plugins/exit_remove_buildconfig.py
@@ -1,0 +1,84 @@
+"""
+Copyright (c) 2015 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+from __future__ import unicode_literals
+
+import json
+import os
+
+from osbs.api import OSBS
+from osbs.conf import Configuration
+
+from atomic_reactor.plugin import ExitPlugin
+
+
+class RemoveBuildConfigPlugin(ExitPlugin):
+    """
+    Remove BuildConfig that triggered this build on failure.
+
+    If this OpenShift Build has failed, remove the BuildConfig for it.
+
+    Details:
+
+    The Build hasn't finished yet, of course, but by this point we can
+    find out whether it will be marked as failed by checking the state
+    of the workflow.
+    """
+
+    key = "remove_buildconfig"
+    can_fail = False
+
+    def __init__(self, tasker, workflow, url, verify_ssl=True, use_auth=True):
+        """
+        constructor
+
+        :param workflow: DockerBuildWorkflow instance
+        :param url: str, URL to OSv3 instance
+        :param verify_ssl: bool, verify SSL certificate?
+        :param use_auth: bool, initiate authentication with openshift?
+        """
+        # call parent constructor
+        super(RemoveBuildConfigPlugin, self).__init__(tasker, workflow)
+        self.url = url
+        self.verify_ssl = verify_ssl
+        self.use_auth = use_auth
+
+    def run(self):
+        if not self.workflow.build_process_failed:
+            # Nothing to do
+            return
+
+        try:
+            build_json = json.loads(os.environ["BUILD"])
+        except KeyError:
+            self.log.error("No $BUILD env variable. "
+                           "Probably not running in build container.")
+            raise
+
+        metadata = build_json.get("metadata", {})
+        kwargs = {}
+        if 'namespace' in metadata:
+            kwargs['namespace'] = metadata['namespace']
+
+        labels = metadata.get("labels", {})
+        try:
+            my_buildconfig = labels["buildconfig"]
+        except KeyError:
+            self.log.error("No BuildConfig for this Build")
+            raise
+
+        # initial setup will use host based auth: apache will be set
+        # to accept everything from specific IP and will set specific
+        # X-Remote-User for such requests
+        osbs_conf = Configuration(conf_file=None, openshift_uri=self.url,
+                                  use_auth=self.use_auth,
+                                  verify_ssl=self.verify_ssl)
+        osbs = OSBS(osbs_conf, osbs_conf)
+
+        self.log.debug("Deleting my BuildConfig (%s)", my_buildconfig)
+        osbs.delete_buildconfig(my_buildconfig, **kwargs)

--- a/tests/plugins/test_remove_buildconfig.py
+++ b/tests/plugins/test_remove_buildconfig.py
@@ -1,0 +1,155 @@
+"""
+Copyright (c) 2015 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+from __future__ import unicode_literals
+
+import json
+import os
+
+from atomic_reactor.core import DockerTasker
+from atomic_reactor.inner import DockerBuildWorkflow
+from atomic_reactor.plugin import ExitPluginsRunner, PluginFailedException
+from atomic_reactor.util import ImageName
+from tests.constants import INPUT_IMAGE, SOURCE
+from atomic_reactor.plugins.exit_remove_buildconfig import RemoveBuildConfigPlugin
+
+from osbs.api import OSBS
+from flexmock import flexmock
+import pytest
+
+
+class X(object):
+    image_id = INPUT_IMAGE
+    git_dockerfile_path = None
+    git_path = None
+    base_image = ImageName(repo="qwe", tag="asd")
+
+
+def prepare(build_process_failed=False):
+    """
+    Boiler-plate test set-up
+    """
+
+    tasker = DockerTasker()
+    workflow = DockerBuildWorkflow(SOURCE, "test-image")
+    setattr(workflow, 'builder', X())
+    setattr(workflow.builder, 'image_id', 'asd123')
+    setattr(workflow.builder, 'source', X())
+    setattr(workflow.builder.source, 'dockerfile_path', None)
+    setattr(workflow.builder.source, 'path', None)
+    setattr(workflow, 'plugin_failed', build_process_failed)
+
+    flexmock(OSBS)
+
+    # No-op implementation until implemented in osbs-client
+    setattr(OSBS, 'delete_buildconfig', lambda **kwargs: None)
+
+    flexmock(OSBS, delete_buildconfig=lambda name: None)
+
+    runner = ExitPluginsRunner(tasker, workflow, [{
+        'name': RemoveBuildConfigPlugin.key,
+        'args': {
+            'url': '',
+            'verify_ssl': False,
+            'use_auth': False
+        }}])
+
+    return runner
+
+
+def must_not_be_called(*_, **__):
+    """
+    Set as implementation for methods than must not be called
+    """
+
+    assert False
+
+
+def test_bad_setup():
+    """
+    Try all the early-fail paths.
+    """
+
+    runner = prepare(build_process_failed=True)
+
+    flexmock(OSBS, delete_buildconfig=must_not_be_called)
+
+    # No build JSON
+    with pytest.raises(PluginFailedException):
+        runner.run()
+
+    # No metadata
+    os.environ["BUILD"] = json.dumps({})
+    with pytest.raises(PluginFailedException):
+        runner.run()
+
+
+class Collect(object):
+    """
+    Collect the values a method is called with.
+    """
+
+    def __init__(self):
+        self.called_with = []
+
+    def called(self, *args, **kwargs):
+        """
+        Set this as the implementation for the method to watch.
+        """
+        self.called_with.append((args, kwargs))
+
+
+def test_failed():
+    """
+    Test what happens when Build failed.
+    """
+
+    runner = prepare(build_process_failed=True)
+
+    my_buildconfig_id = 'my-buildconfig-id'
+    my_namespace = 'namespace'
+
+    collect = Collect()
+    flexmock(OSBS, delete_buildconfig=collect.called)
+
+    os.environ["BUILD"] = json.dumps({
+        "metadata": {
+            "namespace": my_namespace,
+            "labels": {
+                "buildconfig": my_buildconfig_id
+            }
+        }
+    })
+
+    # Build failing
+    runner.run()
+
+    # Our own BuildConfig is deleted
+    assert collect.called_with == [((my_buildconfig_id,),
+                                    {'namespace': my_namespace})]
+
+
+def test_succeeded():
+    """
+    Test what happens when the Build succeeded, i.e. a normal run.
+    """
+
+    runner = prepare(build_process_failed=False)
+
+    flexmock(OSBS, delete_buildconfig=must_not_be_called)
+
+    # Build succeeding
+    os.environ["BUILD"] = json.dumps({
+        "metadata": {
+            "namespace": "default",
+            "labels": {
+                "buildconfig": "my-buildconfig-id",
+            }
+        }
+    })
+    runner.run()


### PR DESCRIPTION
Do not merge yet.

This plugin will be used when osbs-client creates BuildConfigs instead of Builds. It uses anticipated support in osbs-client for deleting BuildConfigs. As osbs-client doesn't have API for BuildConfigs yet, some parts of this plugin are subject to change.