### PR TITLE
Don't store plugin exceptions in metadata (#239)

### DIFF
--- a/atomic_reactor/plugin.py
+++ b/atomic_reactor/plugin.py
@@ -186,7 +186,7 @@ class PluginsRunner(object):
                     failed_msgs.append(msg)
                 else:
                     logger.info("error is not fatal, continuing...")
-                plugin_response = msg
+                plugin_response = ex
 
             self.plugins_results[plugin_instance.key] = plugin_response
         if len(failed_msgs) == 1:

--- a/atomic_reactor/plugins/post_store_metadata_in_osv3.py
+++ b/atomic_reactor/plugins/post_store_metadata_in_osv3.py
@@ -37,6 +37,18 @@ class StoreMetadataInOSv3Plugin(PostBuildPlugin):
         self.verify_ssl = verify_ssl
         self.use_auth = use_auth
 
+    def get_result(self, result):
+        if isinstance(result, Exception):
+            result = ''
+
+        return result
+
+    def get_pre_result(self, key):
+        return self.get_result(self.workflow.prebuild_results.get(key, ''))
+
+    def get_post_result(self, key):
+        return self.get_result(self.workflow.postbuild_results.get(key, ''))
+
     def run(self):
         try:
             build_json = json.loads(os.environ["BUILD"])
@@ -90,10 +102,10 @@ class StoreMetadataInOSv3Plugin(PostBuildPlugin):
             commit_id = ""
 
         labels = {
-            "dockerfile": self.workflow.prebuild_results.get(CpDockerfilePlugin.key, ""),
-            "artefacts": self.workflow.prebuild_results.get(DistgitFetchArtefactsPlugin.key, ""),
+            "dockerfile": self.get_pre_result(CpDockerfilePlugin.key),
+            "artefacts": self.get_pre_result(DistgitFetchArtefactsPlugin.key),
             "logs": "\n".join(self.workflow.build_logs),
-            "rpm-packages": "\n".join(self.workflow.postbuild_results.get(PostBuildRPMqaPlugin.key, "")),
+            "rpm-packages": "\n".join(self.get_post_result(PostBuildRPMqaPlugin.key)),
             "repositories": json.dumps(repositories),
             "commit_id": commit_id,
         }

--- a/tests/plugins/test_rpmqa.py
+++ b/tests/plugins/test_rpmqa.py
@@ -1,0 +1,82 @@
+"""
+Copyright (c) 2015 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+from __future__ import unicode_literals
+
+import json
+import os
+
+import docker
+from flexmock import flexmock
+import pytest
+
+from atomic_reactor.core import DockerTasker
+from atomic_reactor.inner import DockerBuildWorkflow
+from atomic_reactor.plugin import PostBuildPluginsRunner, PluginFailedException
+from atomic_reactor.plugins.post_rpmqa import PostBuildRPMqaPlugin
+from atomic_reactor.util import ImageName
+from tests.constants import DOCKERFILE_GIT
+from tests.docker_mock import mock_docker
+
+
+TEST_IMAGE = "fedora:latest"
+SOURCE = {"provider": "git", "uri": DOCKERFILE_GIT}
+
+
+class X(object):
+    pass
+
+
+PACKAGE_LIST = [b'package1', b'package2']
+
+def mock_logs(cid, **kwargs):
+    return b"\n".join(PACKAGE_LIST)
+
+
+def test_rpmqa_plugin():
+    tasker = DockerTasker()
+    workflow = DockerBuildWorkflow(SOURCE, "test-image")
+    setattr(workflow, 'builder', X())
+    setattr(workflow.builder, 'image_id', "asd123")
+    setattr(workflow.builder, 'base_image', ImageName(repo='fedora', tag='21'))
+    setattr(workflow.builder, "source", X())
+    setattr(workflow.builder.source, 'dockerfile_path', "/non/existent")
+    setattr(workflow.builder.source, 'path', "/non/existent")
+    mock_docker()
+    flexmock(docker.Client, logs=mock_logs)
+    runner = PostBuildPluginsRunner(tasker, workflow,
+                                    [{"name": PostBuildRPMqaPlugin.key,
+                                      "args": {'image_id': TEST_IMAGE}}])
+    results = runner.run()
+    assert results is not None
+    assert results[PostBuildRPMqaPlugin.key] == ['package1', 'package2']
+
+
+def mock_logs_raise(cid, **kwargs):
+    raise RuntimeError
+
+
+def test_rpmqa_plugin_exception():
+    tasker = DockerTasker()
+    workflow = DockerBuildWorkflow(SOURCE, "test-image")
+    setattr(workflow, 'builder', X())
+    setattr(workflow.builder, 'image_id', "asd123")
+    setattr(workflow.builder, 'base_image', ImageName(repo='fedora', tag='21'))
+    setattr(workflow.builder, "source", X())
+    setattr(workflow.builder.source, 'dockerfile_path', "/non/existent")
+    setattr(workflow.builder.source, 'path', "/non/existent")
+    mock_docker()
+    flexmock(docker.Client, logs=mock_logs_raise)
+    runner = PostBuildPluginsRunner(tasker, workflow,
+                                    [{"name": PostBuildRPMqaPlugin.key,
+                                      "args": {'image_id': TEST_IMAGE}}])
+    results = runner.run()
+
+    assert results is not None
+    assert results[PostBuildRPMqaPlugin.key] is not None
+    assert isinstance(results[PostBuildRPMqaPlugin.key], Exception)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -43,24 +43,6 @@ class X(object):
     pass
 
 
-def test_rpmqa_plugin():
-    tasker = DockerTasker()
-    workflow = DockerBuildWorkflow(SOURCE, "test-image")
-    setattr(workflow, 'builder', X())
-    setattr(workflow.builder, 'image_id', "asd123")
-    setattr(workflow.builder, 'base_image', ImageName(repo='fedora', tag='21'))
-    setattr(workflow.builder, "source", X())
-    setattr(workflow.builder.source, 'dockerfile_path', "/non/existent")
-    setattr(workflow.builder.source, 'path', "/non/existent")
-    runner = PostBuildPluginsRunner(tasker, workflow,
-                                    [{"name": PostBuildRPMqaPlugin.key,
-                                      "args": {'image_id': TEST_IMAGE}}])
-    results = runner.run()
-    assert results is not None
-    assert results[PostBuildRPMqaPlugin.key] is not None
-    assert len(results[PostBuildRPMqaPlugin.key]) > 0
-
-
 class TestInputPluginsRunner(object):
     def test_substitution(self, tmpdir):
         tmpdir_path = str(tmpdir)


### PR DESCRIPTION
With this change, we store the actual exception a plugin raised, rather than a description of it. This allows the `store_metadata_in_osv3` plugin to handle that differently.

I've moved the `rpmqa` test-case out into a separate module and added a failure test-case as well. I also added a failure test-case for the metadata plugin.