### PR TITLE
add python-backports-lzma as a Requirement for py2 in spec file

### DIFF
--- a/atomic-reactor.spec
+++ b/atomic-reactor.spec
@@ -92,6 +92,7 @@ Requires:       python-docker-py
 Requires:       python-requests
 Requires:       python-setuptools
 Requires:       python-dockerfile-parse
+Requires:       python-backports-lzma
 # Due to CopyBuiltImageToNFSPlugin, might be moved to subpackage later.
 Requires:       nfs-utils
 Provides:       python-dock = %{version}-%{release}


### PR DESCRIPTION
When trying to install a git snapshot build of atomic-reactor, the installation works with yum but running atomic-reactor fails with the following because python-backports-lzma is missing on the system:

```
# atomic-reactor
Traceback (most recent call last):
  File "/usr/bin/atomic-reactor", line 5, in <module>
    from pkg_resources import load_entry_point
  File "/usr/lib/python2.7/site-packages/pkg_resources.py", line 3007, in <module>
    working_set.require(__requires__)
  File "/usr/lib/python2.7/site-packages/pkg_resources.py", line 728, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python2.7/site-packages/pkg_resources.py", line 626, in resolve
    raise DistributionNotFound(req)
pkg_resources.DistributionNotFound: backports.lzma
```