### PR TITLE
New bump_release pre-build plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora:latest
 # e2fsprogs -- docker @ F20 wants it
-RUN yum -y install docker-io git python-docker-py python-setuptools GitPython e2fsprogs koji python-pip python-backports-lzma osbs
+RUN yum -y install docker-io git python-docker-py python-setuptools python-pygit2 e2fsprogs koji python-pip python-backports-lzma osbs gssproxy
 RUN mkdir /tmp/atomic-reactor
 ADD . /tmp/atomic-reactor
 RUN cd /tmp/atomic-reactor && python setup.py install

--- a/atomic-reactor.spec
+++ b/atomic-reactor.spec
@@ -95,6 +95,8 @@ Requires:       python-dockerfile-parse
 Requires:       python-backports-lzma
 # Due to CopyBuiltImageToNFSPlugin, might be moved to subpackage later.
 Requires:       nfs-utils
+# Due to BumpReleasePlugin
+Requires:       python-pygit2
 Provides:       python-dock = %{version}-%{release}
 Obsoletes:      python-dock < %{dock_obsolete_vr}
 
@@ -115,6 +117,8 @@ Requires:       python3-setuptools
 Requires:       python3-dockerfile-parse
 # Due to CopyBuiltImageToNFSPlugin, might be moved to subpackage later.
 Requires:       nfs-utils
+# Due to BumpReleasePlugin
+Requires:       python3-pygit2
 Provides:       python3-dock = %{version}-%{release}
 Obsoletes:      python3-dock < %{dock_obsolete_vr}
 

--- a/atomic_reactor/plugins/pre_bump_release.py
+++ b/atomic_reactor/plugins/pre_bump_release.py
@@ -70,8 +70,6 @@ class BumpReleasePlugin(PreBuildPlugin):
     key = "bump_release"
     can_fail = False  # We really want to stop the process
 
-    commit_message = "Bumped release for automated rebuild"
-
     def __init__(self, tasker, workflow,
                  git_ref,
                  author_name, author_email,
@@ -97,16 +95,11 @@ class BumpReleasePlugin(PreBuildPlugin):
         self.git_ref = git_ref
         self.author_name = author_name
         self.author_email = author_email
-        self.committer_name = committer_name
-        self.commiter_email = committer_email
-        if committer_name is None:
-            self.committer_name = author_name
-        if committer_email is None:
-            self.committer_email = author_email
-
+        self.committer_name = committer_name or author_name
+        self.committer_email = committer_email or author_email
         self.push_url = push_url
-        if commit_message is not None:
-            self.commit_message = commit_message
+        self.commit_message = (commit_message or
+                               "Bumped release for automated rebuild")
 
     def bump_local_file(self, parser, label_key, next_release):
         """

--- a/atomic_reactor/plugins/pre_bump_release.py
+++ b/atomic_reactor/plugins/pre_bump_release.py
@@ -1,0 +1,270 @@
+"""
+Copyright (c) 2015 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+from __future__ import unicode_literals
+
+import shlex
+try:
+    # py3
+    from shlex import quote
+except ImportError:
+    from pipes import quote
+
+import os
+from pygit2 import init_repository, Signature
+import subprocess
+
+from atomic_reactor.plugin import PreBuildPlugin
+from atomic_reactor.source import GitSource
+from atomic_reactor.plugins.pre_check_and_set_rebuild import is_rebuild
+from atomic_reactor.constants import PY2
+from dockerfile_parse import DockerfileParser
+
+
+def shlex_splits(value):
+    if PY2 and isinstance(value, unicode):
+        value = value.encode('utf-8')
+        splits = shlex.split(value)
+        return [split.decode('utf-8') for split in splits]
+    else:
+        return shlex.split(value)
+
+
+class BumpReleasePlugin(PreBuildPlugin):
+    """Git branch management plugin
+
+    For rebuilds, push a new commit incrementing the Release label.
+
+    For initial builds, verify the branch is at the specified commit
+    hash.
+
+    When this plugin is configured by osbs-client, the Build's source
+    git ref is actually the branch (from --git-branch), not the
+    original SHA-1. The SHA-1 specified by --git-commit is stored in
+    the configuration for this plugin.
+
+    Example configuration:
+
+    {
+      "name": "bump_release",
+      "args": {
+        "git_ref": "12345678....",
+        "author_name": "OSBS Build System",
+        "author_email": "root@example.com"
+      }
+    }
+
+    Additional optional arguments:
+    - committer_name
+    - committer_email
+    - commit_message
+    - push_url
+
+    """
+
+    key = "bump_release"
+    can_fail = False  # We really want to stop the process
+
+    commit_message = "Bumped release for automated rebuild"
+
+    def __init__(self, tasker, workflow,
+                 git_ref,
+                 author_name, author_email,
+                 committer_name=None, committer_email=None,
+                 commit_message=None,
+                 push_url=None):
+        """
+        constructor
+
+        :param tasker: DockerTasker instance
+        :param workflow: DockerBuildWorkflow instance
+        :param git_ref: str, commit hash expected on first build
+        :param author_name: str, name to use for git commits
+        :param author_email: str, email address for git commits
+        :param committer_name: str, name to use for git commits (else author's)
+        :param committer_email: str, email address for git commits (else
+                                     author's)
+        :param commit_message: str, git commit message
+        :param push_url: str, URL for push
+        """
+        # call parent constructor
+        super(BumpReleasePlugin, self).__init__(tasker, workflow)
+        self.git_ref = git_ref
+        self.author_name = author_name
+        self.author_email = author_email
+        self.committer_name = committer_name
+        self.commiter_email = committer_email
+        if committer_name is None:
+            self.committer_name = author_name
+        if committer_email is None:
+            self.committer_email = author_email
+
+        self.push_url = push_url
+        if commit_message is not None:
+            self.commit_message = commit_message
+
+    def bump_local_file(self, parser, label_key, next_release):
+        """
+        Rewrite a local Dockerfile with an incremented Release label
+        """
+
+        # Find where in the file to put the next release
+        content = startline = endline = None
+        cmd = 'LABEL'
+        for candidate in [insn for insn in parser.structure
+                          if insn['instruction'] == cmd]:
+            splits = shlex_splits(candidate['value'])
+
+            # LABEL syntax is one of two types:
+            if '=' not in splits[0]:  # LABEL name value
+                # remove (double-)quotes
+                value = candidate['value'].replace("'", "").replace('"', '')
+                words = value.split(None, 1)
+                if words[0] == label_key:
+                    # Adjust label value
+                    words[1] = next_release
+
+                    # Now reconstruct the line
+                    content = " ".join([cmd] + words) + '\n'
+                    startline = candidate['startline']
+                    endline = candidate['endline']
+                    break
+            else:  # LABEL "name"="value"
+                for token in splits:
+                    words = token.split("=", 1)
+                    if words[0] == label_key:
+                        # Adjust label value
+                        words[1] = next_release
+                        n = splits.index(token)
+                        splits[n] = "=".join(map(quote, words))
+
+                        # Now reconstruct the line
+                        content = " ".join([cmd] + splits) + '\n'
+                        startline = candidate['startline']
+                        endline = candidate['endline']
+                        break
+
+        # We know the label we're looking for is there
+        assert content and startline and endline
+
+        # Re-write the Dockerfile
+        lines = parser.lines
+        del lines[startline:endline + 1]
+        lines.insert(startline, content)
+        parser.lines = lines
+
+    @staticmethod
+    def get_next_release(current_release):
+        try:
+            return str(int(current_release) + 1)
+        except ValueError:
+            isdigit = type(current_release).isdigit
+            first_nondigit = [isdigit(x) for x in current_release].index(False)
+            n = str(int(current_release[:first_nondigit]) + 1)
+            return n + current_release[first_nondigit:]
+
+    def bump(self, repo, branch):
+        # Look in the git repository
+        remote = repo.remotes['origin']
+        if self.push_url:
+            repo.config['push.default'] = 'simple'
+            remote.push_url = self.push_url
+            remote.save()
+
+        # Bump the Release label
+        label_key = 'Release'
+        df_path = self.workflow.builder.df_path
+        parser = DockerfileParser(df_path)
+        current_release = parser.labels[label_key]
+        next_release = self.get_next_release(current_release)
+        self.log.info("New Release: %s", next_release)
+        self.bump_local_file(parser, label_key, next_release)
+
+        # Stage it
+        index = repo.index
+        index.add(os.path.basename(df_path))
+
+        # Commit the change
+        author = Signature(self.author_name, self.author_email)
+        committer = Signature(self.committer_name, self.committer_email)
+        repo.create_commit(branch.name, author, committer, self.commit_message,
+                           index.write_tree(), [repo.head.peel().hex])
+
+        # Push it
+        self.log.info("Pushing to git repository")
+        ssh_command = '/usr/bin/ssh -o StrictHostKeyChecking=no'
+        os.environ['GIT_SSH_COMMAND'] = ssh_command
+
+        # This doesn't seem to work:
+        #   remote.push([branch.name])
+        # because it uses libssh rather than /usr/bin/ssh and so krb5
+        # auth fails.
+        # Instead, run the git command to do it
+        cmd = ['/usr/bin/git', 'push', 'origin']
+        with open('/dev/null', 'r+') as devnull:
+            p = subprocess.Popen(cmd,
+                                 stdin=devnull,
+                                 stdout=subprocess.PIPE,
+                                 stderr=subprocess.STDOUT,
+                                 cwd=repo.workdir)
+
+        (output, dummy) = p.communicate()
+        status = p.wait()
+        if status != 0:
+            self.log.error("git (%d): %r", status, output)
+            raise RuntimeError("exit code %d" % status)
+
+        self.log.debug("git (success): %r", output)
+
+    def verify_branch(self, branch):
+        commit = branch.target.hex
+        if commit != self.git_ref:
+            self.log.error("Branch '%s' is at commit %s (expected %s)",
+                           branch.shorthand, commit, self.git_ref)
+            raise RuntimeError("Not at expected commit")
+
+        self.log.info("Branch '%s' is at expected commit (%s)",
+                      branch.shorthand, self.git_ref)
+
+    def run(self):
+        """
+        run the plugin
+        """
+
+        if self.workflow.build_process_failed:
+            self.log.info("Build already failed, not incrementing release")
+            return
+
+        # Ensure we can use the git repository already checked out for us
+        source = self.workflow.source
+        assert isinstance(source, GitSource)
+        repo = init_repository(source.get())
+
+        # Note: when this plugin is configured by osbs-client,
+        # source.git_commit (the Build's source git ref) comes from
+        # --git-branch not --git-commit. The value from --git-commit
+        # went into our self.git_ref.
+        branch = repo.lookup_branch(source.git_commit)
+
+        if branch is None:
+            self.log.error("Branch '%s' not found in git repo",
+                           source.git_commit)
+            raise RuntimeError("Branch '%s' not found" % source.git_commit)
+
+        # We checked out the right branch
+        assert repo.head.peel().hex == branch.target.hex
+
+        # We haven't reset it to an earlier commit
+        assert branch.target.hex == branch.upstream.target.hex
+
+        if is_rebuild(self.workflow):
+            self.log.info("Incrementing release label")
+            self.bump(repo, branch)
+        else:
+            self.log.info("Verifying branch is at specified commit")
+            self.verify_branch(branch)

--- a/images/dockerhost-builder/Dockerfile
+++ b/images/dockerhost-builder/Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora:latest
 # e2fsprogs -- docker @ F20 wants it
-RUN yum -y install docker-io git python-docker-py python-setuptools GitPython e2fsprogs koji python-backports-lzma osbs
+RUN yum -y install docker-io git python-docker-py python-setuptools python-pygit2 e2fsprogs koji python-backports-lzma osbs gssproxy
 ADD ./atomic-reactor.tar.gz /tmp/
 RUN cd /tmp/atomic-reactor-*/ && python setup.py install
 CMD ["atomic-reactor", "--verbose", "inside-build"]

--- a/images/privileged-builder/Dockerfile
+++ b/images/privileged-builder/Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora:latest
 # e2fsprogs -- docker @ F20 wants it
-RUN yum -y install docker-io git python-docker-py python-setuptools GitPython e2fsprogs koji python-backports-lzma osbs
+RUN yum -y install docker-io git python-docker-py python-setuptools python-pygit2 e2fsprogs koji python-backports-lzma osbs gssproxy
 ADD ./atomic-reactor.tar.gz /tmp/
 RUN cd /tmp/atomic-reactor-*/ && python setup.py install
 ADD ./docker.sh /tmp/docker.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 docker-py
 dockerfile-parse
+#pygit2

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -25,7 +25,14 @@ DOCKERFILE_ERROR_BUILD_PATH = os.path.join(FILES, 'docker-hello-world-error-buil
 DOCKERFILE_SUBDIR_PATH = os.path.join(FILES, 'df-in-subdir')
 DOCKERFILE_SHA1 = "6e592f1420efcd331cd28b360a7e02f669caf540"
 
-SOURCE = {'provider': 'git', 'uri': DOCKERFILE_GIT}
+SOURCE = {
+    'provider': 'git',
+    'uri': DOCKERFILE_GIT,
+    'provider_params': {
+        'git_commit': 'master',
+    }
+}
+
 MOCK_SOURCE = {'provider': 'git', 'uri': 'asd'}
 
 REGISTRY_PORT = "5000"

--- a/tests/plugins/test_bump_release.py
+++ b/tests/plugins/test_bump_release.py
@@ -1,0 +1,352 @@
+"""
+Copyright (c) 2015 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+from __future__ import unicode_literals
+
+try:
+    import pygit2
+    NO_PYGIT2 = False
+except ImportError:
+    NO_PYGIT2 = True
+    import inspect
+    import os
+    import sys
+
+    # Find our mocked pygit2 module
+    import tests.pygit2 as pygit2
+    mock_pygit2_path = os.path.dirname(os.path.dirname
+                                       (inspect.getfile(pygit2.Remote)))
+    if mock_pygit2_path not in sys.path:
+        sys.path.append(mock_pygit2_path)
+
+    # Now load it properly, the same way the plugin will
+    del pygit2
+    import pygit2
+
+import pytest
+from atomic_reactor.core import DockerTasker
+from atomic_reactor.inner import DockerBuildWorkflow
+from atomic_reactor.plugin import PreBuildPluginsRunner, PluginFailedException
+from atomic_reactor.plugins.\
+    pre_check_and_set_rebuild import CheckAndSetRebuildPlugin
+from atomic_reactor.plugins.pre_bump_release import BumpReleasePlugin
+from atomic_reactor.source import GitSource
+from atomic_reactor.util import ImageName
+from tests.constants import SOURCE
+
+from copy import deepcopy
+import os
+import shutil
+import tempfile
+import subprocess
+
+from flexmock import flexmock
+
+
+BRANCH = 'branch'
+
+
+class DFWithRelease(object):
+    def __init__(self, label=None):
+        self.path = tempfile.mkdtemp()
+        if label is None:
+            label = "LABEL Release 1"
+        self.label = label
+
+    def __fini__(self):
+        shutil.rmtree(self.path)
+
+    def __enter__(self):
+        repo = pygit2.init_repository(self.path)
+        repo.remotes.create('origin', '/dev/null')
+
+        # Set up branch 'master'
+        filename = 'Dockerfile'
+        dockerfile_path = os.path.join(self.path, filename)
+        open(dockerfile_path, mode="w+t").close()
+        index = repo.index
+        index.add(filename)
+        author = pygit2.Signature('Test', 'test@example.com')
+        committer = pygit2.Signature('Test', 'test@example.com')
+        oid = repo.create_commit('HEAD', author, committer,
+                                 '', index.write_tree(), [])
+        master = repo.head
+
+        # Now set up our branch
+        branch = repo.create_branch(BRANCH, repo.get(oid))
+        repo.checkout(refname=branch)
+        with open(dockerfile_path, mode="w+t") as dockerfile:
+            dockerfile.write('FROM baseimage\n{0}\n'.format(self.label))
+
+        index = repo.index
+        index.add(filename)
+        repo.create_commit(branch.name, author, committer,
+                           '', index.write_tree(),
+                           [repo.head.peel().hex])
+        branch.upstream = branch
+        return dockerfile_path, repo.head.peel().hex
+
+    def __exit__(self, exc, value, tb):
+        pass
+
+
+class X(object):
+    pass
+
+
+class MockRemote(object):
+    def push(self, name):
+        pass
+
+    def save(self):
+        pass
+
+
+class MockRemotesCollection(object):
+    def create(self, name, url):
+        pass
+
+    def __getitem__(self, item):
+        return MockRemote()
+
+
+class MockIndex(object):
+    def add(self, name):
+        pass
+
+    def write_tree(self):
+        pass
+
+
+class MockSignature(object):
+    def __init__(self, name, email):
+        self.name = name
+        self.email = email
+
+
+class MockCommit(object):
+    def __init__(self):
+        self.author = MockSignature('name', 'email')
+        self.committer = self.author
+        self.hex = '0'
+
+
+class MockBranch(object):
+    def __init__(self, name):
+        self.shorthand = self.name = name
+        self.target = MockCommit()
+        self.upstream = self
+
+    def peel(self):
+        return MockCommit()
+
+
+class MockRepository(object):
+    def __init__(self, *args, **kwargs):
+        self.remotes = MockRemotesCollection()
+        self.index = MockIndex()
+        self.head = flexmock()
+        commit = MockCommit()
+        self.head.should_receive('peel').and_return(commit)
+        self.config = {}
+        self.workdir = '/tmp'
+
+    def create_commit(self, name, author, committer, message, tree, parents):
+        pass
+
+    def create_branch(self, name, commit):
+        return MockBranch(name)
+
+    def lookup_branch(self, name):
+        if name == BRANCH:
+            return MockBranch(name)
+        else:
+            return None
+
+    def get(self, oid):
+        pass
+
+    def checkout(self, refname=None):
+        pass
+
+
+def maybe_mock_pygit2():
+    if NO_PYGIT2:
+        flexmock(pygit2.Remote, push=lambda name: None)
+        flexmock(pygit2, Signature=MockSignature)
+        flexmock(pygit2, init_repository=MockRepository)
+
+
+class MockedPopen(object):
+    def __init__(self, cmd, *args, **kwargs):
+        self.cmd = cmd
+
+    def __enter__(self, *args, **kwargs):
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        pass
+
+    def kill(self):
+        pass
+
+    def poll(self):
+        return 0
+
+    def wait(self):
+        return 0
+
+    def communicate(self, *args, **kwargs):
+        return ('', '')
+
+
+def fake_Popen(cmd, *args, **kwargs):
+    return MockedPopen(cmd, *args, **kwargs)
+
+
+def prepare(tmpdir, df_path, git_ref, source=None,
+            build_process_failed=False, is_rebuild=True,
+            author_name=None, author_email=None,
+            commit_message=None, git_commit=None):
+    if author_name is None:
+        author_name = "OSBS Build System"
+    if author_email is None:
+        author_email = "root@example.com"
+
+    tasker = DockerTasker()
+    source = deepcopy(SOURCE)
+    source['provider_params']['git_commit'] = git_commit or BRANCH
+    workflow = DockerBuildWorkflow(source, "test-image")
+    setattr(workflow, 'builder', X())
+    setattr(workflow.builder, 'image_id', 'asd123')
+    setattr(workflow.builder, 'base_image', ImageName(repo='Fedora', tag='22'))
+    setattr(workflow.builder, 'source', workflow.source)
+    setattr(workflow.builder, 'df_path', df_path)
+    setattr(workflow, 'plugin_failed', build_process_failed)
+    workflow.prebuild_results[CheckAndSetRebuildPlugin.key] = is_rebuild
+    flexmock(GitSource, get=lambda: os.path.dirname(df_path))
+    flexmock(subprocess, Popen=fake_Popen)
+    args = {
+        'git_ref': git_ref,
+        'author_name': author_name,
+        'author_email': author_email,
+        'commit_message': commit_message,
+        'push_url': '/',
+    }
+    for omitted in [x for x in args if args[x] is None]:
+        del args[omitted]
+    runner = PreBuildPluginsRunner(tasker, workflow,
+                                   [
+                                       {
+                                           'name': BumpReleasePlugin.key,
+                                           'args': args,
+                                       }
+                                   ])
+    return workflow, args, runner
+
+
+def test_bump_release_failed_build(tmpdir):
+    maybe_mock_pygit2()
+    with DFWithRelease() as (df_path, commit):
+        workflow, args, runner = prepare(tmpdir, df_path, commit,
+                                         build_process_failed=True)
+        original_content = open(df_path).readlines()
+        runner.run()
+        assert open(df_path).readlines() == original_content
+
+
+def test_bump_release_not_rebuild_extra_commits(tmpdir):
+    maybe_mock_pygit2()
+    with DFWithRelease() as (df_path, commit):
+        workflow, args, runner = prepare(tmpdir, df_path, "wrongcommit",
+                                         is_rebuild=False)
+        with pytest.raises(PluginFailedException):
+            runner.run()
+
+
+def test_bump_release_not_rebuild_no_extra_commits(tmpdir):
+    maybe_mock_pygit2()
+    with DFWithRelease() as (df_path, commit):
+        workflow, args, runner = prepare(tmpdir, df_path, commit,
+                                         is_rebuild=False)
+        runner.run()
+
+
+def test_bump_release_branch_not_found(tmpdir):
+    maybe_mock_pygit2()
+    with DFWithRelease() as (df_path, commit):
+        workflow, args, runner = prepare(tmpdir, df_path, commit,
+                                         git_commit='wrong')
+        with pytest.raises(PluginFailedException):
+            runner.run()
+
+
+@pytest.mark.parametrize(('label', 'expected'), [
+    # Simple case, no '=' or quotes
+    ('LABEL Release 1',
+     'LABEL Release 2'),
+
+    # No '=' but quotes
+    ('LABEL "Release" "2"',
+     'LABEL Release 3'),
+
+    # Deal with another label
+    ('LABEL Release 3\nLABEL Name foo',
+     'LABEL Release 4'),
+
+    # Simple case, '=' but no quotes
+    ('LABEL Release=1',
+     'LABEL Release=2'),
+
+    # '=' and quotes
+    ('LABEL "Release"="2"',
+     'LABEL Release=3'),
+
+    # '=', multiple labels, no quotes
+    ('LABEL Name=foo Release=3',
+     'LABEL Name=foo Release=4'),
+
+    # '=', multiple labels and quotes
+    ('LABEL Name=foo "Release"="4"',
+     'LABEL Name=foo Release=5'),
+
+    # Release that's not entirely numeric
+    ('LABEL Release=1.1',
+     'LABEL Release=2.1'),
+])
+def test_bump_release(tmpdir, label, expected):
+    maybe_mock_pygit2()
+    with DFWithRelease(label=label) as (df_path, commit):
+        workflow, args, runner = prepare(tmpdir, df_path, commit,
+                                         commit_message='foo')
+        runner.run()
+        assert open(df_path).readlines()[1].rstrip() == expected
+        repo = pygit2.init_repository(os.path.dirname(df_path))
+
+        # We're on the 'branch' branch
+        assert NO_PYGIT2 or repo.head.name == repo.lookup_branch(BRANCH).name
+
+        # and one commit ahead of where we were
+        assert NO_PYGIT2 or repo.head.peel().parents[0].hex == commit
+
+        # Examine metadata for newest commit
+        author = repo.head.peel().author
+        assert NO_PYGIT2 or author.name == args['author_name']
+        assert NO_PYGIT2 or author.email == args['author_email']
+
+        committer = repo.head.peel().committer
+        assert (NO_PYGIT2 or
+                'committer_name' not in args or
+                committer.name == args['committer_name'])
+        assert (NO_PYGIT2 or
+                'committer_email' not in args or
+                committer.email == args['committer_email'])
+
+        if 'commit_message' in args:
+            assert (NO_PYGIT2 or
+                    repo.head.peel().message == args['commit_message'])

--- a/tests/pygit2/__init__.py
+++ b/tests/pygit2/__init__.py
@@ -1,0 +1,24 @@
+"""
+Copyright (c) 2015 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+
+def init_repository(name, **kwargs):
+    raise ImportError("No module named pygit2")
+
+
+class Remote(object):
+    def __init__(self):
+        raise ImportError("No module named pygit2")
+
+    def push(self, name):
+        raise ImportError("No module named pygit2")
+
+
+class Signature(object):
+    def __init__(self, name, email):
+        raise ImportError("No module named pygit2")


### PR DESCRIPTION
Here is a plugin for incrementing the Release label on automatic rebuild.

The push URL can be configured separately to the fetch URL used for the build. The `GitSource` provider's repository is modified in-place, the push URL set, and 'git push' run.

For authentication, currently this is achieved with Kerberos using the kernel keyring's TGT. This works by making sure the gssproxy package is installed and having git call out to an ssh process. I haven't managed to get it to work using the pygit2 `remote.push()` method.

For other authentication mechanisms, we would need another secret to be provided. I think that requires having a service account configured, which is out of scope for this pull request.