### PR TITLE
bump_release: always set push.default

### DIFF
--- a/atomic_reactor/plugins/pre_bump_release.py
+++ b/atomic_reactor/plugins/pre_bump_release.py
@@ -164,8 +164,8 @@ class BumpReleasePlugin(PreBuildPlugin):
     def bump(self, repo, branch):
         # Look in the git repository
         remote = repo.remotes['origin']
+        repo.config['push.default'] = 'simple'
         if self.push_url:
-            repo.config['push.default'] = 'simple'
             remote.push_url = self.push_url
             remote.save()
 


### PR DESCRIPTION
We should set `push.default` regardless of whether `push_url` is set. If we don't, we get a warning message:

```
warning: push.default is unset; its implicit value has changed in
Git 2.0 from 'matching' to 'simple'. To squelch this message
and maintain the traditional behavior, use:

  git config --global push.default matching

To squelch this message and adopt the new behavior now, use:

  git config --global push.default simple

When push.default is set to 'matching', git will push local branches
to the remote branches that already exist with the same name.

Since Git 2.0, Git defaults to the more conservative 'simple'
behavior, which only pushes the current branch to the corresponding
remote branch that 'git pull' uses to update the current branch.

See 'git help config' and search for 'push.default' for further information.
(the 'simple' mode was introduced in Git 1.7.11. Use the similar mode
'current' instead of 'simple' if you sometimes use older versions of Git)
```
