### PR TITLE
Create exit_sendmail plugin

### DIFF
--- a/atomic_reactor/plugins/exit_sendmail.py
+++ b/atomic_reactor/plugins/exit_sendmail.py
@@ -33,11 +33,14 @@ class SendMailPlugin(ExitPlugin):
                     "send_on": ["auto_canceled", "auto_fail"],
                     "url": "https://openshift-instance.com",
                     "pdc_url": "https://pdc-instance.com",
-                    "pdc_verify_cert": true,
-                    "pdc_component_df_label": "BZComponent",
+                    # pdc_secret_path is filled in automatically by osbs-client
+                    "pdc_secret_path": "/path/to/file/with/pdc/token",
                     "smtp_url": "smtp-server.com",
                     "from_address": "osbs@mycompany.com",
-                    "error_addresses": ["admin@mycompany.com"]
+                    "error_addresses": ["admin@mycompany.com"],
+                    # optional arguments follow
+                    "pdc_verify_cert": true,
+                    "pdc_component_df_label": "BZComponent"
                 }
         }]
     """
@@ -55,7 +58,7 @@ class SendMailPlugin(ExitPlugin):
     PDC_TOKEN_FILE = 'pdc.token'
 
     def __init__(self, tasker, workflow, send_on=None, url=None, pdc_url=None,
-                 pdc_verify_cert=True, pdc_component_df_label=None, pdc_secret_path=None,
+                 pdc_verify_cert=True, pdc_component_df_label="BZComponent", pdc_secret_path=None,
                  smtp_url=None, from_address=None, error_addresses=None):
         """
         constructor

--- a/atomic_reactor/plugins/exit_sendmail.py
+++ b/atomic_reactor/plugins/exit_sendmail.py
@@ -32,6 +32,7 @@ class SendMailPlugin(ExitPlugin):
                     "send_on": ["auto_canceled", "auto_fail"],
                     "url": "https://openshift-instance.com",
                     "pdc_url": "https://pdc-instance.com",
+                    "pdc_verify_cert": true,
                     "pdc_component_df_label": "BZComponent",
                     "smtp_url": "smtp-server.com",
                     "from_address": "osbs@mycompany.com",
@@ -51,8 +52,8 @@ class SendMailPlugin(ExitPlugin):
     allowed_states = set([MANUAL_SUCCESS, MANUAL_FAIL, AUTO_SUCCESS, AUTO_FAIL, AUTO_CANCELED])
 
     def __init__(self, tasker, workflow, send_on=None, url=None, pdc_url=None,
-                 pdc_component_df_label=None, smtp_url=None, from_address=None,
-                 error_addresses=None):
+                 pdc_verify_cert=True, pdc_component_df_label=None, smtp_url=None,
+                 from_address=None, error_addresses=None):
         """
         constructor
 
@@ -61,6 +62,7 @@ class SendMailPlugin(ExitPlugin):
         :param url: URL to OSv3 instance where the build logs are stored
         :param send_on: list of build states when a notification should be sent
         :param pdc_url: URL of PDC to query for contact information
+        :param pdc_verify_cert: whether or not to verify SSL cert of PDC (defaults to True)
         :param pdc_component_df_label: name of Dockerfile label to use as PDC global_component
         :param smtp_url: URL of SMTP server to use to send the message (e.g. "foo.com:25")
         :param from_address: the "From" of the notification email
@@ -71,6 +73,7 @@ class SendMailPlugin(ExitPlugin):
         self.url = url
         self.send_on = send_on
         self.pdc_url = pdc_url
+        self.pdc_verify_cert = pdc_verify_cert
         self.pdc_component_df_label = pdc_component_df_label
         self.smtp_url = smtp_url
         self.from_address = from_address
@@ -152,7 +155,7 @@ class SendMailPlugin(ExitPlugin):
             r = requests.get(urljoin(self.pdc_url, 'rest_api/v1/release-components/'),
                              headers={'Authorization': 'Token %s' % self._get_pdc_token()},
                              params={'global_component': global_component},
-                             verify=False)
+                             verify=self.pdc_verify_cert)
         except requests.RequestException as e:
             self.log.error('failed to connect to PDC: %s', str(e))
             raise RuntimeError(e)

--- a/atomic_reactor/plugins/exit_sendmail.py
+++ b/atomic_reactor/plugins/exit_sendmail.py
@@ -24,8 +24,15 @@ from atomic_reactor.source import GitSource
 
 class SendMailPlugin(ExitPlugin):
     key = "sendmail"
-    allowed_states = set(['manual_success', 'manual_fail', 'auto_success', 'auto_fail',
-                          'auto_canceled'])
+
+    # symbolic constants for states
+    MANUAL_SUCCESS = 'manual_success'
+    MANUAL_FAIL = 'manual_fail'
+    AUTO_SUCCESS = 'auto_success'
+    AUTO_FAIL = 'auto_fail'
+    AUTO_CANCELED = 'auto_canceled'
+
+    allowed_states = set([MANUAL_SUCCESS, MANUAL_FAIL, AUTO_SUCCESS, AUTO_FAIL, AUTO_CANCELED])
 
     def __init__(self, tasker, workflow, send_on=None, url=None, pdc_url=None,
                  pdc_component_df_label=None, smtp_url=None, from_address=None,
@@ -57,11 +64,11 @@ class SendMailPlugin(ExitPlugin):
         should_send = False
 
         should_send_mapping = {
-            'manual_success': not rebuild and success,
-            'manual_fail': not rebuild and not success,
-            'auto_success': rebuild and success,
-            'auto_fail': rebuild and not success,
-            'auto_canceled': rebuild and canceled
+            self.MANUAL_SUCCESS: not rebuild and success,
+            self.MANUAL_FAIL: not rebuild and not success,
+            self.AUTO_SUCCESS: rebuild and success,
+            self.AUTO_FAIL: rebuild and not success,
+            self.AUTO_CANCELED: rebuild and canceled
         }
 
         for state in self.send_on:

--- a/tests/plugins/test_sendmail.py
+++ b/tests/plugins/test_sendmail.py
@@ -89,6 +89,21 @@ class TestSendMailPlugin(object):
             p._get_receivers_list()
         assert str(e.value) == 'Source is not of type "GitSource", panic!'
 
+    @pytest.mark.parametrize('value', [
+        True,
+        False
+    ])
+    def test_get_receivers_list_passes_verify_cert(self, value):
+        class WF(object):
+            source = GitSource('git', 'foo', provider_params={'git_commit': 'foo'})
+        p = SendMailPlugin(None, WF(), pdc_verify_cert=value)
+        flexmock(p).should_receive('_get_component_label').and_return('foo')
+        flexmock(requests).should_receive('get').with_args(object, headers=object, params=object,
+                                                           verify=value).and_raise(RuntimeError)
+
+        with pytest.raises(RuntimeError):
+            p._get_receivers_list()
+
     def test_get_receivers_list_request_exception(self):
         class WF(object):
             source = GitSource('git', 'foo', provider_params={'git_commit': 'foo'})

--- a/tests/plugins/test_sendmail.py
+++ b/tests/plugins/test_sendmail.py
@@ -1,0 +1,216 @@
+import smtplib
+
+from dockerfile_parse import DockerfileParser
+from flexmock import flexmock
+import pytest
+import requests
+import six
+
+from atomic_reactor.plugin import PluginFailedException
+from atomic_reactor.plugins.pre_check_and_set_rebuild import CheckAndSetRebuildPlugin
+from atomic_reactor.plugins.exit_sendmail import SendMailPlugin
+from atomic_reactor.source import GitSource
+from atomic_reactor.util import ImageName
+
+
+class TestSendMailPlugin(object):
+    def test_fails_with_unknown_states(self):
+        p = SendMailPlugin(None, None, send_on=['unknown_state', 'manual_fail'])
+        with pytest.raises(PluginFailedException) as e:
+            p.run()
+        assert str(e.value) == 'Unknown state(s) "unknown_state" for sendmail plugin'
+
+    @pytest.mark.parametrize('rebuild, success, canceled, send_on, expected', [
+        # make sure that right combinations only succeed for the specific state
+        (False, True, False, ['manual_success'], True),
+        (False, True, False, ['manual_fail', 'auto_success', 'auto_fail', 'auto_canceled'],
+         False),
+        (False, False, False, ['manual_fail'], True),
+        (False, False, False, ['manual_success', 'auto_success', 'auto_fail', 'auto_canceled'],
+         False),
+        (True, True, False, ['auto_success'], True),
+        (True, True, False, ['manual_success', 'manual_fail', 'auto_fail', 'auto_canceled'],
+         False),
+        (True, False, False, ['auto_fail'], True),
+        (True, False, False, ['manual_success', 'manual_fail', 'auto_success', 'auto_canceled'],
+         False),
+        (True, False, True, ['auto_canceled'], True),
+        # auto_fail would also give us True in this case
+        (True, False, True, ['manual_success', 'manual_fail', 'auto_success'],
+         False),
+        # also make sure that a random combination of more plugins works ok
+        (True, False, False, ['auto_fail', 'manual_success'], True)
+    ])
+    def test_should_send(self, rebuild, success, canceled, send_on, expected):
+        p = SendMailPlugin(None, None, send_on=send_on)
+        assert p._should_send(rebuild, success, canceled) == expected
+
+    def test_render_mail(self):
+        # just test a random combination of the method inputs and hope it's ok for other
+        #   combinations
+        class WF(object):
+            image = ImageName.parse('foo/bar:baz')
+            openshift_build_selflink = '/builds/blablabla'
+        p = SendMailPlugin(None, WF(), url='https://something.com')
+        subject, body = p._render_mail(True, False, False)
+        assert subject == 'Image foo/bar:baz; Status failed; Submitted by <autorebuild>'
+        assert body == '\n'.join([
+            'Image: foo/bar:baz',
+            'Status: failed',
+            'Submitted by: <autorebuild>',
+            'Logs: https://something.com/builds/blablabla/log'
+        ])
+
+    def test_get_pdc_token(self):
+        pass  # TODO
+
+    @pytest.mark.parametrize('df_labels, pdc_component_df_label, expected', [
+        ({}, 'Foo', None),
+        ({'Foo': 'Bar'}, 'Foo', 'Bar'),
+    ])
+    def test_get_component_label(self, df_labels, pdc_component_df_label, expected):
+        class WF(object):
+            class builder(object):
+                df_path = '/foo/bar'
+        p = SendMailPlugin(None, WF(), pdc_component_df_label=pdc_component_df_label)
+        flexmock(DockerfileParser, labels=df_labels)
+        if expected is None:
+            with pytest.raises(PluginFailedException):
+                p._get_component_label()
+        else:
+            assert p._get_component_label() == expected
+
+    def test_get_receivers_list_raises_unless_GitSource(self):
+        class WF(object):
+            source = None
+        p = SendMailPlugin(None, WF())
+        flexmock(p).should_receive('_get_component_label').and_return('foo')
+
+        with pytest.raises(PluginFailedException) as e:
+            p._get_receivers_list()
+        assert str(e.value) == 'Source is not of type "GitSource", panic!'
+
+    def test_get_receivers_list_request_exception(self):
+        class WF(object):
+            source = GitSource('git', 'foo', provider_params={'git_commit': 'foo'})
+        p = SendMailPlugin(None, WF())
+        flexmock(p).should_receive('_get_component_label').and_return('foo')
+        flexmock(requests).should_receive('get').and_raise(requests.RequestException('foo'))
+
+        with pytest.raises(RuntimeError) as e:
+            p._get_receivers_list()
+        assert str(e.value) == 'foo'
+
+    def test_get_receivers_list_wrong_status_code(self):
+        class WF(object):
+            source = GitSource('git', 'foo', provider_params={'git_commit': 'foo'})
+        p = SendMailPlugin(None, WF())
+        flexmock(p).should_receive('_get_component_label').and_return('foo')
+
+        class R(object):
+            status_code = 404
+            text = 'bazinga!'
+        flexmock(requests).should_receive('get').and_return(R())
+
+        with pytest.raises(RuntimeError) as e:
+            p._get_receivers_list()
+        assert str(e.value) == 'PDC returned non-200 status code (404), see referenced build log'
+
+    @pytest.mark.parametrize('pdc_response, expected', [
+        ({'results': []},
+         'Expected to find exactly 1 PDC component, found 0, see referenced build log'),
+        ({'results': [{'dist_git_branch': 'foo'}, {'dist_git_branch': 'foo'}]},
+         'Expected to find exactly 1 PDC component, found 2, see referenced build log'),
+        ({'results': [{'dist_git_branch': 'foo', 'contacts': []}]},
+         'no Build_Owner role for the component'),
+        ({'results': [{'dist_git_branch': 'foo',
+                       'contacts': [{'contact_role': 'Build_Owner', 'email': 'foo@bar.com'}]}]},
+         ['foo@bar.com']),
+        ({'results': [{'dist_git_branch': 'foo',
+                       'contacts':
+                       [{'contact_role': 'Build_Owner', 'email': 'foo@bar.com'},
+                        {'contact_role': 'Build_Owner', 'email': 'spam@spam.com'},
+                        {'contact_role': 'different', 'email': 'other@baz.com'}]}]},
+         ['foo@bar.com', 'spam@spam.com']),
+    ])
+    def test_get_receivers_pdc_actually_responds(self, pdc_response, expected):
+        class WF(object):
+            source = GitSource('git', 'foo', provider_params={'git_commit': 'foo'})
+        p = SendMailPlugin(None, WF())
+        flexmock(p).should_receive('_get_component_label').and_return('foo')
+
+        class R(object):
+            status_code = 200
+
+            def json(self):
+                return pdc_response
+        flexmock(requests).should_receive('get').and_return(R())
+
+        if isinstance(expected, str):
+            with pytest.raises(RuntimeError) as e:
+                p._get_receivers_list()
+            assert str(e.value) == expected
+        else:
+            assert p._get_receivers_list() == expected
+
+    def test_send_mail(self):
+        p = SendMailPlugin(None, None, from_address='foo@bar.com', smtp_url='smtp.spam.com')
+
+        class SMTP(object):
+            def sendmail(self, from_addr, to, msg):
+                pass
+
+            def quit(self):
+                pass
+
+        smtp_inst = SMTP()
+        flexmock(smtplib).should_receive('SMTP').and_return(smtp_inst)
+        flexmock(smtp_inst).should_receive('sendmail').\
+            with_args('foo@bar.com', ['spam@spam.com'], str)
+        flexmock(smtp_inst).should_receive('quit')
+        p._send_mail(['spam@spam.com'], 'subject', 'body')
+
+    def test_run_ok(self):
+        class WF(object):
+            build_failed = True
+            autorebuild_canceled = False
+            prebuild_results = {CheckAndSetRebuildPlugin.key: True}
+            image = ImageName.parse('repo/name')
+        receivers = ['foo@bar.com', 'x@y.com']
+        p = SendMailPlugin(None, WF(), send_on=['auto_fail'])
+
+        flexmock(p).should_receive('_should_send').with_args(True, False, False).and_return(True)
+        flexmock(p).should_receive('_get_receivers_list').and_return(receivers)
+        flexmock(p).should_receive('_send_mail').with_args(receivers, six.text_type, six.text_type)
+
+        p.run()
+
+    def test_run_fails_to_obtain_receivers(self):
+        class WF(object):
+            build_failed = True
+            autorebuild_canceled = False
+            prebuild_results = {CheckAndSetRebuildPlugin.key: True}
+            image = ImageName.parse('repo/name')
+        error_addresses = ['error@address.com']
+        p = SendMailPlugin(None, WF(), send_on=['auto_fail'], error_addresses=error_addresses)
+
+        flexmock(p).should_receive('_should_send').with_args(True, False, False).and_return(True)
+        flexmock(p).should_receive('_get_receivers_list').and_raise(RuntimeError())
+        flexmock(p).should_receive('_send_mail').with_args(error_addresses, six.text_type,
+                                                           six.text_type)
+
+        p.run()
+
+    def test_run_does_nothing_if_conditions_not_met(self):
+        class WF(object):
+            build_failed = True
+            autorebuild_canceled = False
+            prebuild_results = {CheckAndSetRebuildPlugin.key: True}
+            image = ImageName.parse('repo/name')
+        p = SendMailPlugin(None, WF(), send_on=['manual_success'])
+
+        flexmock(p).should_receive('_should_send').with_args(True, False, False).and_return(False)
+        flexmock(p).should_receive('_get_receivers_list').times(0)
+        flexmock(p).should_receive('_send_mail').times(0)
+
+        p.run()

--- a/tests/plugins/test_sendmail.py
+++ b/tests/plugins/test_sendmail.py
@@ -83,17 +83,9 @@ class TestSendMailPlugin(object):
         assert subject == exp_subject
         assert body == '\n'.join(exp_body)
 
-    def test_get_pdc_token_from_conf(self, tmpdir):
+    def test_get_pdc_token(self, tmpdir):
         tokenfile = os.path.join(str(tmpdir), SendMailPlugin.PDC_TOKEN_FILE)
         p = SendMailPlugin(None, None, pdc_secret_path=str(tmpdir))
-        with open(tokenfile, 'w') as f:
-            f.write('thisistoken')
-        assert p._get_pdc_token() == 'thisistoken'
-
-    def test_get_pdc_token_from_env(self, tmpdir, monkeypatch):
-        monkeypatch.setenv('PDC_SECRET_PATH', str(tmpdir))
-        tokenfile = os.path.join(str(tmpdir), SendMailPlugin.PDC_TOKEN_FILE)
-        p = SendMailPlugin(None, None, pdc_secret_path=None)
         with open(tokenfile, 'w') as f:
             f.write('thisistoken')
         assert p._get_pdc_token() == 'thisistoken'


### PR DESCRIPTION
This PR creates `exit_sendmail` plugin - a plugin that can be used to send notifications on various conditions. There are several todo items for this PR before I'll call it ready for merge:

- [x] Document how to call the plugin
- [x] Figure out how to securely authenticate against PDC (i.e. where to get PDC auth token from)
- [x] Add a `pdc_verify_cert` argument to specify whether or not the plugin should verify PDC SSL certificate
- [x] Make the `contact_role` to send notification to configurable (now it's hardcoded as `Build_Owner` and I'm not even sure that's the correct role)
- [x] Write tests
- [x] Figure out how to get name of user who submitted the build, assuming we're notifying after a user-submitted build (low-prio, this will most likely be done by Koji when deployed in OSBS => low prio, probably not a blocker for merging)

When this is done, we'll need to implement setting the PDC source secret in osbs-client. This can be implemented along with enabling the sendmail plugin.