### PR TITLE
Use '-' as separator in tag suffix

### DIFF
--- a/atomic_reactor/plugins/post_tag_by_labels.py
+++ b/atomic_reactor/plugins/post_tag_by_labels.py
@@ -16,7 +16,7 @@ class TagByLabelsPlugin(PostBuildPlugin):
     """
     Use labels Name, Version and Release of final image and create tags:
      * Name:Version
-     * Name:Version_Release
+     * Name:Version-Release
     """
     key = "tag_by_labels"
     can_fail = False
@@ -51,7 +51,7 @@ class TagByLabelsPlugin(PostBuildPlugin):
 
         unique_tag = self.workflow.builder.image.tag
 
-        nvr = "%s:%s_%s" % (name, version, release)
+        nvr = "%s:%s-%s" % (name, version, release)
         nv = "%s:%s" % (name, version)
         n = "%s:latest" % name
         n_unique = "%s:%s" % (name, unique_tag)

--- a/tests/plugins/test_tag_by_labels.py
+++ b/tests/plugins/test_tag_by_labels.py
@@ -71,11 +71,11 @@ def test_tag_by_labels_plugin(tmpdir):
     primary_images = [i.to_str() for i in workflow.tag_conf.primary_images]
     unique_images = [i.to_str() for i in workflow.tag_conf.unique_images]
     assert ("%s:%s" % (TEST_IMAGE, "unique_tag_123")) in images
-    assert ("%s:%s_%s" % (TEST_IMAGE, version, release)) in images
+    assert ("%s:%s-%s" % (TEST_IMAGE, version, release)) in images
     assert ("%s:%s" % (TEST_IMAGE, version)) in images
     assert ("%s:latest" % (TEST_IMAGE, )) in images
     assert ("%s:%s" % (TEST_IMAGE, "unique_tag_123")) in unique_images
-    assert ("%s:%s_%s" % (TEST_IMAGE, version, release)) in primary_images
+    assert ("%s:%s-%s" % (TEST_IMAGE, version, release)) in primary_images
     assert ("%s:%s" % (TEST_IMAGE, version)) in primary_images
     assert ("%s:latest" % (TEST_IMAGE, )) in primary_images
     tasker.remove_image(image)


### PR DESCRIPTION
Using '_' can lead to confusing names if version already contains '_'.