### PR TITLE
'raise' rather than 'return' in plugins' run() to fail early.

### DIFF
--- a/atomic_reactor/plugins/post_cp_built_image_to_nfs.py
+++ b/atomic_reactor/plugins/post_cp_built_image_to_nfs.py
@@ -102,8 +102,7 @@ class CopyBuiltImageToNFSPlugin(PostBuildPlugin):
             raise RuntimeError('no exported image to upload to nfs')
         source_path = self.workflow.exported_image_sequence[-1].get("path")
         if not source_path or not os.path.isfile(source_path):
-            self.log.error("squashed image does not exist: %s", source_path)
-            return
+            raise RuntimeError("squashed image does not exist: %s", source_path)
 
         self.mount_nfs()
 

--- a/atomic_reactor/plugins/pre_change_from_in_df.py
+++ b/atomic_reactor/plugins/pre_change_from_in_df.py
@@ -39,7 +39,7 @@ class ChangeFromPlugin(PreBuildPlugin):
             base_image_id = self.workflow.base_image_inspect['Id']
         except KeyError:
             self.log.error("Id is missing in inspection: '%s'", self.workflow.base_image_inspect)
-            return
+            raise
         self.log.debug("using base image '%s', id '%s'", base_image, base_image_id)
         for line in fileinput.input(self.workflow.builder.df_path, inplace=1):
             re_match = re.match(r"^FROM .+$", line)

--- a/atomic_reactor/plugins/pre_inject_yum_repo.py
+++ b/atomic_reactor/plugins/pre_inject_yum_repo.py
@@ -130,10 +130,8 @@ class InjectYumRepoPlugin(PreBuildPlugin):
         run the plugin
         """
         # dict comprehension is syntax error on 2.6
-        yum_repos = {}
-        for key, value in self.workflow.files.items():
-            if key.startswith(YUM_REPOS_DIR):
-                yum_repos[key] = value
+        yum_repos = dict((k, v) for (k, v) in self.workflow.files.items()
+                                           if k.startswith(YUM_REPOS_DIR))
         if self.wrap_commands:
             wrap_yum_commands(yum_repos, self.workflow.builder.df_path)
         else:

--- a/atomic_reactor/plugins/prepub_tests_for_image.py
+++ b/atomic_reactor/plugins/prepub_tests_for_image.py
@@ -76,8 +76,7 @@ class ImageTestPlugin(PrePublishPlugin):
 
         """
         if not self.image_id:
-            self.log.warning("no image_id specified (build probably failed)")
-            return
+            raise RuntimeError("no image_id specified (build probably failed)")
         tmpdir = tempfile.mkdtemp()
         g = LazyGit(self.git_uri, self.git_commit, tmpdir)
         with g:


### PR DESCRIPTION
The first commit is unrelated, I just spotted it when checking the plugins.

The second commit (which I'm expecting to be changing according to the comments in PR, that's why it's second) is about failing early rather then silently returning from run(). There's not a big difference if the plugin's can_fail is True (in which case the workflow continues anyway), but better to be consistent.
I'm however not sure in the `prepub_tests_for_image` case - whether it'd be better to fail (after this commit) if there's no image to test or continue (prior to the commit). I'm open to discussion.