### PR TITLE
Rename can_fail to is_allowed_to_fail (fixes #92)

### DIFF
--- a/atomic_reactor/plugin.py
+++ b/atomic_reactor/plugin.py
@@ -44,7 +44,7 @@ class Plugin(object):
     # same thing goes for input: use this key for providing input for this plugin
     key = None
     # by default, if plugin fails (raises exc), execution continues
-    can_fail = True
+    is_allowed_to_fail = True
 
     def __init__(self, *args, **kwargs):
         """
@@ -191,9 +191,9 @@ class PluginsRunner(object):
 
                 raise PluginFailedException(msg)
             try:
-                plugin_can_fail = plugin_request['can_fail']
+                plugin_is_allowed_to_fail = plugin_request['is_allowed_to_fail']
             except (TypeError, KeyError):
-                plugin_can_fail = getattr(plugin_class, "can_fail", True)
+                plugin_is_allowed_to_fail = getattr(plugin_class, "is_allowed_to_fail", True)
 
             logger.debug("running plugin '%s'", plugin_name)
 
@@ -211,10 +211,10 @@ class PluginsRunner(object):
             except Exception as ex:
                 msg = "plugin '%s' raised an exception: '%s'" % (plugin_instance.key, repr(ex))
                 logger.debug(traceback.format_exc())
-                if plugin_can_fail or keep_going:
+                if plugin_is_allowed_to_fail or keep_going:
                     logger.warning(msg)
                     logger.info("error is not fatal, continuing...")
-                    if not plugin_can_fail:
+                    if not plugin_is_allowed_to_fail:
                         failed_msgs.append(msg)
                 else:
                     self.on_plugin_failed()

--- a/atomic_reactor/plugins/exit_remove_built_image.py
+++ b/atomic_reactor/plugins/exit_remove_built_image.py
@@ -18,7 +18,6 @@ __all__ = ('GarbageCollectionPlugin', )
 
 class GarbageCollectionPlugin(ExitPlugin):
     key = "remove_built_image"
-    can_fail = True
 
     def __init__(self, tasker, workflow, remove_pulled_base_image=True):
         """

--- a/atomic_reactor/plugins/post_compress.py
+++ b/atomic_reactor/plugins/post_compress.py
@@ -36,7 +36,7 @@ class CompressPlugin(PostBuildPlugin):
     ask for it by using `load_exported_image: true`.
     """
     key = 'compress'
-    can_fail = False
+    is_allowed_to_fail = False
 
     # TODO: add remove_former_image?
     def __init__(self, tasker, workflow, load_exported_image=False, method='gzip'):

--- a/atomic_reactor/plugins/post_cp_built_image_to_nfs.py
+++ b/atomic_reactor/plugins/post_cp_built_image_to_nfs.py
@@ -67,7 +67,7 @@ class CopyBuiltImageToNFSPlugin(PostBuildPlugin):
     """
 
     key = "cp_built_image_to_nfs"
-    can_fail = False
+    is_allowed_to_fail = False
 
     def __init__(self, tasker, workflow, nfs_server_path, dest_dir=None,
                  mountpoint=DEFAULT_MOUNTPOINT):

--- a/atomic_reactor/plugins/post_import_image.py
+++ b/atomic_reactor/plugins/post_import_image.py
@@ -26,7 +26,7 @@ class ImportImagePlugin(PostBuildPlugin):
     """
 
     key = "import_image"
-    can_fail = False
+    is_allowed_to_fail = False
 
     def __init__(self, tasker, workflow, imagestream, docker_image_repo,
                  url, verify_ssl=True, use_auth=True):

--- a/atomic_reactor/plugins/post_push_to_pulp.py
+++ b/atomic_reactor/plugins/post_push_to_pulp.py
@@ -170,7 +170,7 @@ class PulpUploader(object):
 
 class PulpPushPlugin(PostBuildPlugin):
     key = "pulp_push"
-    can_fail = False
+    is_allowed_to_fail = False
 
     def __init__(self, tasker, workflow, pulp_registry_name, load_squashed_image=None,
                  load_exported_image=None, image_names=None, pulp_secret_path=None,

--- a/atomic_reactor/plugins/post_tag_and_push.py
+++ b/atomic_reactor/plugins/post_tag_and_push.py
@@ -18,7 +18,7 @@ class TagAndPushPlugin(PostBuildPlugin):
     """
 
     key = "tag_and_push"
-    can_fail = False
+    is_allowed_to_fail = False
 
     def __init__(self, tasker, workflow, **kwargs):
         """

--- a/atomic_reactor/plugins/post_tag_by_labels.py
+++ b/atomic_reactor/plugins/post_tag_by_labels.py
@@ -19,7 +19,7 @@ class TagByLabelsPlugin(PostBuildPlugin):
      * Name:Version-Release
     """
     key = "tag_by_labels"
-    can_fail = False
+    is_allowed_to_fail = False
 
     def __init__(self, tasker, workflow, **kwargs):
         """

--- a/atomic_reactor/plugins/pre_add_yum_repo.py
+++ b/atomic_reactor/plugins/pre_add_yum_repo.py
@@ -19,7 +19,7 @@ from atomic_reactor.util import render_yum_repo
 
 class AddYumRepoPlugin(PreBuildPlugin):
     key = "add_yum_repo"
-    can_fail = False
+    is_allowed_to_fail = False
 
     def __init__(self, tasker, workflow, repo_name, baseurl):
         """

--- a/atomic_reactor/plugins/pre_add_yum_repo_by_url.py
+++ b/atomic_reactor/plugins/pre_add_yum_repo_by_url.py
@@ -60,7 +60,7 @@ class YumRepo(object):
 
 class AddYumRepoByUrlPlugin(PreBuildPlugin):
     key = "add_yum_repo_by_url"
-    can_fail = False
+    is_allowed_to_fail = False
 
     def __init__(self, tasker, workflow, repourls):
         """

--- a/atomic_reactor/plugins/pre_assert_labels.py
+++ b/atomic_reactor/plugins/pre_assert_labels.py
@@ -17,7 +17,7 @@ from atomic_reactor.plugin import PreBuildPlugin
 
 class AssertLabelsPlugin(PreBuildPlugin):
     key = "assert_labels"
-    can_fail = False  # We really want to stop the process
+    is_allowed_to_fail = False  # We really want to stop the process
 
     def __init__(self, tasker, workflow, required_labels=None):
         """

--- a/atomic_reactor/plugins/pre_bump_release.py
+++ b/atomic_reactor/plugins/pre_bump_release.py
@@ -51,7 +51,7 @@ class BumpReleasePlugin(PreBuildPlugin):
     """
 
     key = "bump_release"
-    can_fail = False  # We really want to stop the process
+    is_allowed_to_fail = False  # We really want to stop the process
 
     def __init__(self, tasker, workflow,
                  git_ref,

--- a/atomic_reactor/plugins/pre_check_and_set_rebuild.py
+++ b/atomic_reactor/plugins/pre_check_and_set_rebuild.py
@@ -48,7 +48,7 @@ class CheckAndSetRebuildPlugin(PreBuildPlugin):
     """
 
     key = "check_and_set_rebuild"
-    can_fail = False  # We really want to stop the process
+    is_allowed_to_fail = False  # We really want to stop the process
 
     def __init__(self, tasker, workflow, label_key, label_value,
                  url, verify_ssl=True, use_auth=True):

--- a/atomic_reactor/plugins/pre_inject_yum_repo.py
+++ b/atomic_reactor/plugins/pre_inject_yum_repo.py
@@ -107,7 +107,7 @@ def wrap_yum_commands(yum_repos, df_path):
 
 class InjectYumRepoPlugin(PreBuildPlugin):
     key = "inject_yum_repo"
-    can_fail = False
+    is_allowed_to_fail = False
 
     def __init__(self, tasker, workflow, wrap_commands=False):
         """

--- a/atomic_reactor/plugins/pre_koji.py
+++ b/atomic_reactor/plugins/pre_koji.py
@@ -18,7 +18,7 @@ from atomic_reactor.util import render_yum_repo
 
 class KojiPlugin(PreBuildPlugin):
     key = "koji"
-    can_fail = False
+    is_allowed_to_fail = False
 
     def __init__(self, tasker, workflow, target, hub, root):
         """

--- a/atomic_reactor/plugins/pre_pull_base_image.py
+++ b/atomic_reactor/plugins/pre_pull_base_image.py
@@ -15,7 +15,7 @@ from atomic_reactor.plugin import PreBuildPlugin
 
 class PullBaseImagePlugin(PreBuildPlugin):
     key = "pull_base_image"
-    can_fail = False
+    is_allowed_to_fail = False
 
     def __init__(self, tasker, workflow, parent_registry=None, parent_registry_insecure=False):
         """

--- a/atomic_reactor/plugins/pre_pyrpkg_fetch_artefacts.py
+++ b/atomic_reactor/plugins/pre_pyrpkg_fetch_artefacts.py
@@ -18,7 +18,7 @@ from atomic_reactor.plugin import PreBuildPlugin
 
 class DistgitFetchArtefactsPlugin(PreBuildPlugin):
     key = "distgit_fetch_artefacts"
-    can_fail = False
+    is_allowed_to_fail = False
 
     def __init__(self, tasker, workflow, command):
         """

--- a/atomic_reactor/plugins/pre_stop_autorebuild_if_disabled.py
+++ b/atomic_reactor/plugins/pre_stop_autorebuild_if_disabled.py
@@ -29,9 +29,9 @@ class StopAutorebuildIfDisabledPlugin(PreBuildPlugin):
     (case insensitive).
     """
     key = 'stop_autorebuild_if_disabled'
-    # set can_fail to False, so that the actual build is skipped if this plugin raises
-    #  AutoRebuildCanceledException
-    can_fail = False
+    # set is_allowed_to_fail to False, so that the actual build is skipped
+    # if this plugin raises AutoRebuildCanceledException
+    is_allowed_to_fail = False
 
     def __init__(self, tasker, workflow, config_file='.osbs-repo-config'):
         super(StopAutorebuildIfDisabledPlugin, self).__init__(tasker, workflow)

--- a/atomic_reactor/plugins/prepub_squash.py
+++ b/atomic_reactor/plugins/prepub_squash.py
@@ -53,7 +53,7 @@ class PrePublishSquashPlugin(PrePublishPlugin):
 
     key = "squash"
     # Fail the build in case of squashing error
-    can_fail = False
+    is_allowed_to_fail = False
 
     def __init__(self, tasker, workflow, tag=None, from_base=True, from_layer=None,
                  remove_former_image=True, dont_load=False):

--- a/atomic_reactor/plugins/prepub_tests_for_image.py
+++ b/atomic_reactor/plugins/prepub_tests_for_image.py
@@ -42,7 +42,7 @@ from atomic_reactor.util import LazyGit
 
 class ImageTestPlugin(PrePublishPlugin):
     key = "test_built_image"
-    can_fail = False
+    is_allowed_to_fail = False
 
     def __init__(self, tasker, workflow, git_uri, git_commit, image_id, tests_git_path="tests.py",
                  tests = None, results_dir="results", **kwargs):

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -20,14 +20,14 @@ Build plugins are requested and configured via input json: key `prebuild_plugins
 ```
 {
     "name": "plugin_name",
-    "can_fail": false,
+    "is_allowed_to_fail": false,
     "args": {
         "args1": "value"
     }
 }
 ```
 
-Order is important, because plugins are executed in the order as they are specified (one plugin can use input from another plugin). `args` are directly passed to a plugin in constructor. Any plugin with `can_fail` is set to `false` that raises an exception causes the build process to proceed directly to the stage of running exit plugins.
+Order is important, because plugins are executed in the order as they are specified (one plugin can use input from another plugin). `args` are directly passed to a plugin in constructor. Any plugin with `is_allowed_to_fail` set to `false` that raises an exception causes the build process to proceed directly to the stage of running exit plugins.
 
 
 ## Input plugins

--- a/tests/test_inner.py
+++ b/tests/test_inner.py
@@ -99,7 +99,7 @@ class RaisesMixIn(object):
     Mix-in class for plugins that should raise exceptions.
     """
 
-    can_fail = False
+    is_allowed_to_fail = False
 
     def __init__(self, tasker, workflow, *args, **kwargs):
         super(RaisesMixIn, self).__init__(tasker, workflow,
@@ -499,8 +499,8 @@ def test_workflow_errors():
     This is a test for what happens when plugins fail.
 
     When a prebuild or postbuild plugin fails, and doesn't have
-    can_fail=True set, the whole build should fail. However, all the
-    exit plugins should run.
+    is_allowed_to_fail=True set, the whole build should fail.
+    However, all the exit plugins should run.
     """
 
     this_file = inspect.getfile(PreRaises)


### PR DESCRIPTION
If I'm counting correctly we all agreed on renaming `can_fail` variable to `is_allowed_to_fail` in #92.