### PR TITLE
Don't run any plugins after docker build failure (fixes #320)

### DIFF
--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -327,7 +327,8 @@ class DockerBuildWorkflow(object):
             self.build_failed = build_result.is_failed()
 
             if build_result.is_failed():
-                # The docker build failed
+                # The docker build failed. Finish here, just run the
+                # exit plugins (from the 'finally:' block below).
                 return build_result
 
             self.built_image_inspect = self.builder.inspect_built_image()

--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -326,8 +326,11 @@ class DockerBuildWorkflow(object):
 
             self.build_failed = build_result.is_failed()
 
-            if not build_result.is_failed():
-                self.built_image_inspect = self.builder.inspect_built_image()
+            if build_result.is_failed():
+                # The docker build failed
+                return build_result
+
+            self.built_image_inspect = self.builder.inspect_built_image()
 
             # run prepublish plugins
             prepublish_runner = PrePublishPluginsRunner(self.builder.tasker, self, self.prepublish_plugins_conf,

--- a/tests/test_inner.py
+++ b/tests/test_inner.py
@@ -591,7 +591,6 @@ def test_workflow_plugin_error(fail_at):
     assert watch_exit.was_called()
 
 
-@pytest.mark.xfail(reason='#320')
 def test_workflow_docker_build_error():
     """
     This is a test for what happens when the docker build fails.

--- a/tests/test_inner.py
+++ b/tests/test_inner.py
@@ -117,6 +117,22 @@ class PreRaises(RaisesMixIn, PreBuildPlugin):
     key = 'pre_raises'
 
 
+class PostRaises(RaisesMixIn, PostBuildPlugin):
+    """
+    This plugin must run and cause the build to abort.
+    """
+
+    key = 'post_raises'
+
+
+class PrePubRaises(RaisesMixIn, PrePublishPlugin):
+    """
+    This plugin must run and cause the build to abort.
+    """
+
+    key = 'prepub_raises'
+
+
 class WatchedMixIn(object):
     """
     Mix-in class for plugins we want to watch.
@@ -208,14 +224,14 @@ def test_workflow():
                                                       'args': {
                                                           'watcher': watch_pre
                                                       }}],
-                                   postbuild_plugins=[{'name': 'post_watched',
-                                                       'args': {
-                                                           'watcher': watch_post
-                                                       }}],
                                    prepublish_plugins=[{'name': 'prepub_watched',
                                                         'args': {
                                                             'watcher': watch_prepub,
                                                         }}],
+                                   postbuild_plugins=[{'name': 'post_watched',
+                                                       'args': {
+                                                           'watcher': watch_post
+                                                       }}],
                                    exit_plugins=[{'name': 'exit_watched',
                                                   'args': {
                                                       'watcher': watch_exit
@@ -471,14 +487,14 @@ def test_autorebuild_stop_prevents_build():
                                    prebuild_plugins=[{'name': 'stopstopstop',
                                                       'args': {
                                                       }}],
-                                   postbuild_plugins=[{'name': 'post_watched',
-                                                       'args': {
-                                                           'watcher': watch_post
-                                                       }}],
                                    prepublish_plugins=[{'name': 'prepub_watched',
                                                         'args': {
                                                             'watcher': watch_prepub,
                                                         }}],
+                                   postbuild_plugins=[{'name': 'post_watched',
+                                                       'args': {
+                                                           'watcher': watch_post
+                                                       }}],
                                    exit_plugins=[{'name': 'exit_watched',
                                                   'args': {
                                                       'watcher': watch_exit
@@ -494,7 +510,8 @@ def test_autorebuild_stop_prevents_build():
     assert workflow.autorebuild_canceled == True
 
 
-def test_workflow_errors():
+@pytest.mark.parametrize('fail_at', ['pre', 'prepub', 'post', 'exit'])
+def test_workflow_plugin_error(fail_at):
     """
     This is a test for what happens when plugins fail.
 
@@ -508,42 +525,69 @@ def test_workflow_errors():
     fake_builder = MockInsideBuilder()
     flexmock(InsideBuilder).new_instances(fake_builder)
     watch_pre = Watcher()
+    watch_prepub = Watcher()
     watch_post = Watcher()
     watch_exit = Watcher()
+    prebuild_plugins = [{'name': 'pre_watched',
+                         'args': {
+                             'watcher': watch_pre,
+                         }}]
+    prepublish_plugins = [{'name': 'prepub_watched',
+                           'args': {
+                               'watcher': watch_prepub,
+                           }}]
+    postbuild_plugins = [{'name': 'post_watched',
+                          'args': {
+                              'watcher': watch_post
+                          }}]
+    exit_plugins = [{'name': 'exit_watched',
+                     'args': {
+                         'watcher': watch_exit
+                     }}]
+
+    # Insert a failing plugin into one of the build phases
+    if fail_at == 'pre':
+        prebuild_plugins.insert(0, {'name': 'pre_raises', 'args': {}})
+    elif fail_at == 'prepub':
+        prepublish_plugins.insert(0, {'name': 'prepub_raises', 'args': {}})
+    elif fail_at == 'post':
+        postbuild_plugins.insert(0, {'name': 'post_raises', 'args': {}})
+    elif fail_at == 'exit':
+        exit_plugins.insert(0, {'name': 'exit_raises', 'args': {}})
+    else:
+        # Typo in the parameter list?
+        assert False
+
     workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image',
-                                   prebuild_plugins=[{'name': 'pre_raises',
-                                                      'args': {}},
-                                                     {'name': 'pre_watched',
-                                                      'args': {
-                                                          'watcher': watch_pre
-                                                      }}],
-                                   postbuild_plugins=[{'name': 'post_watched',
-                                                       'args': {
-                                                           'watcher': watch_post
-                                                       }}],
-                                   exit_plugins=[{'name': 'exit_raises',
-                                                  'args': {}
-                                                  },
-                                                 {'name': 'exit_watched',
-                                                  'args': {
-                                                      'watcher': watch_exit
-                                                  }}],
+                                   prebuild_plugins=prebuild_plugins,
+                                   prepublish_plugins=prepublish_plugins,
+                                   postbuild_plugins=postbuild_plugins,
+                                   exit_plugins=exit_plugins,
                                    plugin_files=[this_file])
 
-    with pytest.raises(PluginFailedException):
+    # Failures in any phase except 'exit' cause the build process to
+    # abort.
+    if fail_at == 'exit':
         workflow.build_docker_image()
+    else:
+        with pytest.raises(PluginFailedException):
+            workflow.build_docker_image()
 
-    # A pre-build plugin caused the build to fail, so post-build
-    # plugins should not run.
-    assert not watch_post.was_called()
+    # The pre-build phase should only complete if there were no
+    # earlier plugin failures.
+    assert watch_pre.was_called() == (fail_at != 'pre')
+
+    # The prepublish phase should only complete if there were no
+    # earlier plugin failures.
+    assert watch_prepub.was_called() == (fail_at not in ('pre', 'prepub'))
+
+    # The post-build phase should only complete if there were no
+    # earlier plugin failures.
+    assert watch_post.was_called() == (fail_at not in ('pre', 'prepub', 'post'))
 
     # But all exit plugins should run, even if one of them also raises
     # an exception.
     assert watch_exit.was_called()
-
-    # Other than exit plugins, any unexpected plugin failure stops the
-    # whole build immediately.
-    assert not watch_pre.was_called()
 
 
 class ExitUsesSource(ExitWatched):


### PR DESCRIPTION
This pull request includes more thorough testing for plugin failures, as well as a new test for docker build failure handling.