### PR TITLE
display versions of used tools before build

### DIFF
--- a/atomic_reactor/build.py
+++ b/atomic_reactor/build.py
@@ -9,12 +9,12 @@ of the BSD license. See the LICENSE file for details.
 Classes which implement tasks which builder has to be capable of doing.
 Logic above these classes has to set the workflow itself.
 """
+import json
 
 import logging
 from dockerfile_parse import DockerfileParser
 from atomic_reactor.core import DockerTasker, LastLogger
-from atomic_reactor.util import wait_for_command, ImageName
-
+from atomic_reactor.util import wait_for_command, ImageName, print_version_of_tools
 
 logger = logging.getLogger(__name__)
 
@@ -82,7 +82,13 @@ class InsideBuilder(LastLogger, BuilderStateMachine):
         LastLogger.__init__(self)
         BuilderStateMachine.__init__(self)
 
+        print_version_of_tools()
+
         self.tasker = DockerTasker()
+
+        info, version = self.tasker.get_info(), self.tasker.get_version()
+        logger.debug(json.dumps(info, indent=2))
+        logger.info(json.dumps(version, indent=2))
 
         # arguments for build
         self.source = source

--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -43,3 +43,13 @@ MANPAGE_AUTHORS = "Jiri Popelka <jpopelka@redhat.com>, " \
                   "Tim Waugh <twaug@redhat.com>, " \
                   "Tomas Tomecek <ttomecek@redhat.com>"
 MANPAGE_SECTION = 1
+
+
+# debug print of tools reactor uses
+
+TOOLS_USED = (
+    "docker",
+    "docker_scripts",
+    "atomic_reactor",
+    "osbs",
+)

--- a/atomic_reactor/core.py
+++ b/atomic_reactor/core.py
@@ -557,3 +557,19 @@ class DockerTasker(LastLogger):
             response = response is not None
         logger.debug("image exists: %s", response)
         return response
+
+    def get_info(self):
+        """
+        get info about used docker environment
+
+        :return: dict, json output of `docker info`
+        """
+        return self.d.info()
+
+    def get_version(self):
+        """
+        get version of used docker environment
+
+        :return: dict, json output of `docker version`
+        """
+        return self.d.version()

--- a/tests/docker_mock.py
+++ b/tests/docker_mock.py
@@ -68,6 +68,77 @@ mock_push_logs = \
     b'{"errorDetail":{"message":"Repository does not exist: localhost:5000/atomic-reactor-tests-b3a11e13d27c428f8fa2914c8c6a6d96"},' \
     b'"error":"Repository does not exist: localhost:5000/atomic-reactor-tests-b3a11e13d27c428f8fa2914c8c6a6d96"}\r\n'
 
+mock_info = {
+    'BridgeNfIp6tables': True,
+    'BridgeNfIptables': True,
+    'Containers': 18,
+    'CpuCfsPeriod': True,
+    'CpuCfsQuota': True,
+    'Debug': False,
+    'DockerRootDir': '/var/lib/docker',
+    'Driver': 'overlay',
+    'DriverStatus': [['Backing Filesystem', 'xfs']],
+    'ExecutionDriver': 'native-0.2',
+    'ExperimentalBuild': False,
+    'HttpProxy': '',
+    'HttpsProxy': '',
+    'ID': 'YC7N:MYIE:6SEL:JYLU:SRIG:PCVV:APZD:WTH4:4MGR:N4BG:CT53:ZW2O',
+    'IPv4Forwarding': True,
+    'Images': 162,
+    'IndexServerAddress': 'https://index.docker.io/v1/',
+    'InitPath': '/usr/libexec/docker/dockerinit',
+    'InitSha1': 'eb5677df79a87639f30ab5c2c01e5170abc96af2',
+    'KernelVersion': '4.1.4-200.fc22.x86_64',
+    'Labels': None,
+    'LoggingDriver': 'json-file',
+    'MemTotal': 12285665280,
+    'MemoryLimit': True,
+    'NCPU': 4,
+    'NEventsListener': 0,
+    'NFd': 15,
+    'NGoroutines': 31,
+    'Name': 'asd',
+    'NoProxy': '',
+    'OomKillDisable': True,
+    'OperatingSystem': 'Fedora 24 (Rawhide) (containerized)',
+    'RegistryConfig': {'IndexConfigs': {'127.0.0.1:5000': {'Mirrors': [],
+        'Name': '127.0.0.1:5000',
+        'Official': False,
+        'Secure': False},
+        '172.17.0.1:5000': {'Mirrors': [],
+            'Name': '172.17.0.1:5000',
+            'Official': False,
+            'Secure': False},
+        '172.17.0.2:5000': {'Mirrors': [],
+            'Name': '172.17.0.2:5000',
+            'Official': False,
+            'Secure': False},
+        '172.17.0.3:5000': {'Mirrors': [],
+            'Name': '172.17.0.3:5000',
+            'Official': False,
+            'Secure': False},
+        'docker.io': {'Mirrors': None,
+            'Name': 'docker.io',
+            'Official': True,
+            'Secure': True}},
+        'InsecureRegistryCIDRs': ['127.0.0.0/8'],
+        'Mirrors': None},
+    'SwapLimit': True,
+    'SystemTime': '2015-09-15T16:38:50.585211559+02:00'
+}
+
+mock_version = {
+    'ApiVersion': '1.21',
+    'Arch': 'amd64',
+    'BuildTime': 'Thu Sep 10 17:53:19 UTC 2015',
+    'GitCommit': 'af9b534-dirty',
+    'GoVersion': 'go1.5.1',
+    'KernelVersion': '4.1.4-200.fc22.x86_64',
+    'Os': 'linux',
+    'Version': '1.9.0-dev-fc24'
+}
+
+
 def _find_image(img, ignore_registry=False):
     global mock_images
 
@@ -160,6 +231,8 @@ def mock_docker(build_should_fail=False,
     flexmock(docker.Client, start=lambda cid, **kwargs: None)
     flexmock(docker.Client, tag=lambda img, rep, **kwargs: True)
     flexmock(docker.Client, wait=lambda cid: 1 if wait_should_fail else 0)
+    flexmock(docker.Client, version=lambda **kwargs: mock_version)
+    flexmock(docker.Client, info=lambda **kwargs: mock_info)
     class GetImageResult(object):
         data = b''
         def __init__(self):

--- a/tests/test_tasker.py
+++ b/tests/test_tasker.py
@@ -298,3 +298,21 @@ def test_build_image_from_git(temp_image_name):
     assert response is not None
     assert t.image_exists(temp_image_name)
     t.remove_image(temp_image_name)
+
+
+def test_get_info():
+    if MOCK:
+        mock_docker()
+
+    t = DockerTasker()
+    response = t.get_info()
+    assert isinstance(response, dict)
+
+
+def test_get_version():
+    if MOCK:
+        mock_docker()
+
+    t = DockerTasker()
+    response = t.get_info()
+    assert isinstance(response, dict)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -21,7 +21,7 @@ except ImportError:
 import docker
 from atomic_reactor.util import ImageName, \
     wait_for_command, clone_git_repo, LazyGit, figure_out_dockerfile, render_yum_repo, \
-    process_substitutions
+    process_substitutions, print_version_of_tools, get_version_of_tools
 from tests.constants import DOCKERFILE_GIT, INPUT_IMAGE, MOCK, DOCKERFILE_SHA1
 
 if MOCK:
@@ -153,3 +153,12 @@ def test_process_substitutions(dct, subst, expected):
     else:
         process_substitutions(dct, subst)
         assert dct == expected
+
+
+def test_get_versions_of_tools():
+    response = get_version_of_tools()
+    assert isinstance(response, dict)
+
+
+def test_print_versions_of_tools():
+    print_version_of_tools()


### PR DESCRIPTION
Fixes #131 

- [x] rewrite to use `__version__`
- [x] make sure `osbs` and `reactor` use `__version__`
- [x] make sure `docker_scripts` use `__version__`
- [x] log `docker info`, `docker version`
- [x] testz