### PR TITLE
Store layering metadata in OSv3 (fixes #329)

### DIFF
--- a/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
+++ b/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
@@ -108,6 +108,9 @@ class StoreMetadataInOSv3Plugin(ExitPlugin):
             "rpm-packages": "\n".join(self.get_post_result(PostBuildRPMqaPlugin.key)),
             "repositories": json.dumps(repositories),
             "commit_id": commit_id,
+            "base-image-id": self.workflow.base_image_inspect['Id'],
+            "base-image-name": self.workflow.builder.base_image.to_str(),
+            "image-id": self.workflow.builder.image_id,
         }
 
         tar_path = tar_size = tar_md5sum = tar_sha256sum = None

--- a/tests/plugins/test_store_metadata.py
+++ b/tests/plugins/test_store_metadata.py
@@ -22,6 +22,7 @@ from atomic_reactor.plugins.pre_cp_dockerfile import CpDockerfilePlugin
 from atomic_reactor.plugins.pre_pyrpkg_fetch_artefacts import DistgitFetchArtefactsPlugin
 from atomic_reactor.util import ImageName, LazyGit
 from tests.constants import LOCALHOST_REGISTRY, TEST_IMAGE, INPUT_IMAGE
+from tests.util import is_string_type
 
 
 class Y(object):
@@ -60,6 +61,7 @@ def prepare():
     workflow.tag_conf.add_unique_image("namespace/image:asd123")
 
     setattr(workflow, 'builder', X)
+    setattr(workflow, '_base_image_inspect', {'Id': '01234567'})
     workflow.build_logs = ["a", "b"]
     workflow.source.lg = LazyGit(None, commit="commit")
     flexmock(workflow.source.lg)
@@ -93,11 +95,23 @@ def test_metadata_plugin(tmpdir):
     assert StoreMetadataInOSv3Plugin.key in output
     labels = output[StoreMetadataInOSv3Plugin.key]
     assert "dockerfile" in labels
+    assert is_string_type(labels['dockerfile'])
     assert "artefacts" in labels
+    assert is_string_type(labels['artefacts'])
     assert "logs" in labels
+    assert is_string_type(labels['logs'])
     assert "rpm-packages" in labels
+    assert is_string_type(labels['rpm-packages'])
     assert "repositories" in labels
+    assert is_string_type(labels['repositories'])
     assert "commit_id" in labels
+    assert is_string_type(labels['commit_id'])
+    assert "base-image-id" in labels
+    assert is_string_type(labels['base-image-id'])
+    assert "base-image-name" in labels
+    assert is_string_type(labels['base-image-name'])
+    assert "image-id" in labels
+    assert is_string_type(labels['image-id'])
 
 
 def test_metadata_plugin_rpmqa_failure(tmpdir):
@@ -130,6 +144,9 @@ def test_metadata_plugin_rpmqa_failure(tmpdir):
     assert "rpm-packages" in labels
     assert "repositories" in labels
     assert "commit_id" in labels
+    assert "base-image-id" in labels
+    assert "base-image-name" in labels
+    assert "image-id" in labels
 
     # On rpmqa failure, rpm-packages should be empty
     assert len(labels["rpm-packages"]) == 0

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+"""
+Copyright (c) 2015 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+from __future__ import unicode_literals
+
+from six import string_types
+
+
+def is_string_type(obj):
+    """
+    Test whether obj is a string type
+
+    :param obj: object to test
+    :return: bool, whether obj is a string type
+    """
+
+    return any(isinstance(obj, strtype)
+               for strtype in string_types)


### PR DESCRIPTION
Rather than storing the base image ID and name in a dict in one "base-image" label, a separate label is used for each field, allowing for label-based queries for either value.

I've used hyphens instead of underscores in the names to be consistent with `rpm-packages`, although it is inconsistent with `commit_id`.

This hasn't been tested with a real build yet.