### PR TITLE
README.md: add link to atomic-devel list

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,3 +156,7 @@ Bear in mind that you shouldn't mix build methods: if you use _hostdocker_ metho
  * [api](https://github.com/projectatomic/atomic-reactor/blob/master/docs/api.md)
  * [build json](https://github.com/projectatomic/atomic-reactor/blob/master/docs/build_json.md)
  * [building Atomic Reactor](https://github.com/projectatomic/atomic-reactor/blob/master/docs/releasing.md)
+
+## Contact
+
+Get in touch with us via [atomic-devel@projectatomic.io](https://lists.projectatomic.io/mailman/listinfo/atomic-devel) mailing list.


### PR DESCRIPTION
As @TomasTomecek noticed the project has over 30 stars now. I guess we should have some kind of contact info in the README for people who are considering using atomic-reactor.

Which mailing list is the most suitable?