### PR TITLE
Fix add_labels plugin for single-line dockerfiles

### DIFF
--- a/atomic_reactor/plugins/pre_add_labels_in_df.py
+++ b/atomic_reactor/plugins/pre_add_labels_in_df.py
@@ -117,8 +117,13 @@ class AddLabelsPlugin(PreBuildPlugin):
         content = ""
         if labels:
             content = 'LABEL ' + " ".join(labels)
-            # put it before last instruction
-            lines.insert(-1, content + '\n')
+            num_lines = len(lines)
+            if num_lines < 2:
+                # ensure label is after FROM if its the only instruction in the Docker
+                lines.append('\n' + content + '\n')
+            else:
+                # put it before last instruction
+                lines.insert(-1, content + '\n')
 
             dockerfile.lines = lines
 


### PR DESCRIPTION
Fixes this error

```
2015-09-24 08:00:39,293 - atomic_reactor.build - DEBUG - using dockerfile:
LABEL "vcs_ref"="407bf1790a8d119c5d0f55f247a558cade2cb050"
FROM nodejs:0.10

2015-09-24 08:00:39,293 - atomic_reactor.core - INFO - building image 'fh-registry.usersys.redhat.com/fh-mbaas:2.0.3' from path '/tmp/tmp8Sbhps/source'
2015-09-24 08:00:39,419 - atomic_reactor.build - DEBUG - build is submitted, waiting for it to finish
2015-09-24 08:00:39,419 - atomic_reactor.util - INFO - wait_for_command
2015-09-24 08:00:39,420 - atomic_reactor.util - DEBUG - Step 0 : LABEL "vcs_ref" "407bf1790a8d119c5d0f55f247a558cade2cb050"
2015-09-24 08:00:39,420 - atomic_reactor.util - ERROR - {"errorDetail":{"message":"Please provide a source image with `from` prior to commit"},"error":"Please provide a source image with `from` prior to commit"}
```

In this case I am relying on a base image that has `ONBUILD` and `CMD` statements to do all the heavywork, therefore my Dockerfile is minimal i.e.
```Dockerfile
FROM nodejs:0.10
```