### PR TITLE
Preliminary support for standard labels

### DIFF
--- a/atomic_reactor/plugins/pre_assert_labels.py
+++ b/atomic_reactor/plugins/pre_assert_labels.py
@@ -19,26 +19,38 @@ class AssertLabelsPlugin(PreBuildPlugin):
     key = "assert_labels"
     is_allowed_to_fail = False  # We really want to stop the process
 
-    def __init__(self, tasker, workflow, required_labels=None):
+    def __init__(self, tasker, workflow, required_labels=None, deprecated_labels=None):
         """
         constructor
 
         :param tasker: DockerTasker instance
         :param workflow: DockerBuildWorkflow instance
         :param required_labels: list of labels that will be checked
+        :param deprecated_labels: dictionary of deprecated labels where keys are the old labels and
+                                  values are the recommended new labels
         """
         # call parent constructor
         super(AssertLabelsPlugin, self).__init__(tasker, workflow)
 
         self.required_labels = required_labels or ['Name', 'Version', 'Release']
+        self.deprecated_labels = deprecated_labels or {}
 
     def run(self):
         """
         run the plugin
         """
         labels = DockerfileParser(self.workflow.builder.df_path).labels
+        used_deprecated_labels = set()
+
+        for old, new in self.deprecated_labels.items():
+            if labels.get(old) is not None:
+                self.log.warning("Label %r is deprecated! Please use %r as a replacement.",
+                                 old, new)
+                used_deprecated_labels.add(new)
+
         for label in self.required_labels:
-            if labels.get(label) is None:
+            if labels.get(label) is None and \
+                    label not in used_deprecated_labels:
                 msg = "Dockerfile is missing '{0}' label.".format(label)
                 self.log.error(msg)
                 raise AssertionError(msg)

--- a/atomic_reactor/source.py
+++ b/atomic_reactor/source.py
@@ -14,12 +14,18 @@ import copy
 import os
 import shutil
 import tempfile
+import collections
 
 from atomic_reactor import util
 from atomic_reactor.constants import SOURCE_DIRECTORY_NAME
 
 
 logger = logging.getLogger(__name__)
+
+
+# Intended for use as vcs-type, vcs-url and vcs-ref docker labels as defined
+# in https://github.com/projectatomic/ContainerApplicationGenericLabels
+VcsInfo = collections.namedtuple('VcsInfo', ['vcs_type', 'vcs_url', 'vcs_ref'])
 
 
 class Source(object):
@@ -53,6 +59,10 @@ class Source(object):
     def remove_tmpdir(self):
         shutil.rmtree(self.tmpdir)
 
+    def get_vcs_info(self):
+        """Returns VcsInfo namedtuple or None if not applicable."""
+        return None
+
 
 class GitSource(Source):
     def __init__(self, provider, uri, dockerfile_path=None, provider_params=None, tmpdir=None):
@@ -63,6 +73,13 @@ class GitSource(Source):
 
     def get(self):
         return self.lg.git_path
+
+    def get_vcs_info(self):
+        return VcsInfo(
+            vcs_type='git',
+            vcs_url=self.lg.git_url,
+            vcs_ref=self.lg.commit_id
+        )
 
 
 class PathSource(Source):

--- a/tests/plugins/test_add_dockerfile.py
+++ b/tests/plugins/test_add_dockerfile.py
@@ -16,8 +16,10 @@ from atomic_reactor.plugin import PreBuildPluginsRunner
 from atomic_reactor.plugins.pre_add_dockerfile import AddDockerfilePlugin
 from atomic_reactor.plugins.pre_add_labels_in_df import AddLabelsPlugin
 from atomic_reactor.util import ImageName
-from tests.constants import MOCK_SOURCE
+from tests.constants import MOCK_SOURCE, MOCK
 from tests.fixtures import docker_tasker
+if MOCK:
+    from tests.docker_mock import mock_docker
 
 
 class Y(object):
@@ -132,6 +134,9 @@ CMD blabla"""
     df = DockerfileParser(str(tmpdir))
     df.content = df_content
 
+    if MOCK:
+        mock_docker()
+
     workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image')
     flexmock(workflow, base_image_inspect={"Config": {"Labels": {}}})
     workflow.builder = X
@@ -145,7 +150,8 @@ CMD blabla"""
             'name': AddLabelsPlugin.key,
             'args': {'labels': {'Name': 'jboss-eap-6-docker',
                                 'Version': '6.4',
-                                'Release': '77'}}
+                                'Release': '77'},
+                     'auto_labels': []}
          },
          {
             'name': AddDockerfilePlugin.key


### PR DESCRIPTION
See #116 and  https://github.com/projectatomic/ContainerApplicationGenericLabels/blob/master/vendor/redhat/labels.md

The first commit extends `pre_add_labels_in_df` with couple of labels generated in the buildroot. These have to be explicitly requested in the plugin arguments. I'm not sure if it's sane to assume the docker daemon architecture is the same as the image architecture or if we want to keep it as OSBS API parameter.

Second commit introduces "deprecated labels" for the `pre_assert_labels`. The idea is that OSBS will provide dict of old->new labels and the builder will accept the old forms of required labels with a warning. This should give Dockerfile maintainers some time to start using the new labels. Example: `required_labels=["com.redhat.component"]`, `deprecated_labels={"BZComponent": "com.redhat.component"}`. The builder will allow both forms and if `BZComponent` is used warning will be printed. Question is whether there's a chance that some of the maintiners will see the warning.