### PR TITLE
Make squash plugin output both tar and engine image if dont_load is False

### DIFF
--- a/atomic-reactor.spec
+++ b/atomic-reactor.spec
@@ -21,7 +21,7 @@
 
 Name:           %{project}
 Version:        1.6.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 
 Summary:        Improved builder for Docker images
 Group:          Development/Tools
@@ -64,6 +64,7 @@ Requires:       python-docker-py
 Requires:       python-requests
 Requires:       python-setuptools
 Requires:       python-dockerfile-parse >= 0.0.5
+Requires:       python-docker-scripts >= 0.4.4
 Requires:       python-backports-lzma
 # Due to CopyBuiltImageToNFSPlugin, might be moved to subpackage later.
 Requires:       nfs-utils
@@ -122,6 +123,7 @@ Requires:       python3-docker-py
 Requires:       python3-requests
 Requires:       python3-setuptools
 Requires:       python3-dockerfile-parse >= 0.0.5
+Requires:       python3-docker-scripts >= 0.4.4
 # Due to CopyBuiltImageToNFSPlugin, might be moved to subpackage later.
 Requires:       nfs-utils
 Provides:       python3-dock = %{version}-%{release}
@@ -299,6 +301,9 @@ cp -a docs/manpage/atomic-reactor.1 %{buildroot}%{_mandir}/man1/
 
 
 %changelog
+* Mon Oct 19 2015 Slavek Kabrda <bkabrda@redhat.com> - 1.6.0-2
+- add requirements on python{,3}-docker-scripts
+
 * Mon Oct 19 2015 Tomas Tomecek <ttomecek@redhat.com> - 1.6.0-1
 - 1.6.0 release
 

--- a/atomic_reactor/plugins/prepub_squash.py
+++ b/atomic_reactor/plugins/prepub_squash.py
@@ -83,8 +83,8 @@ class PrePublishSquashPlugin(PrePublishPlugin):
         self.dont_load = dont_load
 
     def run(self):
-        metadata = {}
-        metadata["path"] = os.path.join(self.workflow.source.workdir, EXPORTED_SQUASHED_IMAGE_NAME)
+        metadata = {"path":
+                    os.path.join(self.workflow.source.workdir, EXPORTED_SQUASHED_IMAGE_NAME)}
 
         if self.dont_load:
             # squash the image, don't load it back to docker

--- a/atomic_reactor/plugins/prepub_squash.py
+++ b/atomic_reactor/plugins/prepub_squash.py
@@ -93,8 +93,7 @@ class PrePublishSquashPlugin(PrePublishPlugin):
         else:
             # squash the image and output both tarfile and Docker engine image
             new_id = Squash(log=self.log, image=self.image, from_layer=self.from_layer,
-                            tag=self.tag, output_path=metadata["path"], load_output_back=True
-                            ).run()
+                            tag=self.tag, output_path=metadata["path"], load_image=True).run()
             self.workflow.builder.image_id = new_id
 
         metadata.update(get_exported_image_metadata(metadata["path"]))

--- a/atomic_reactor/plugins/prepub_squash.py
+++ b/atomic_reactor/plugins/prepub_squash.py
@@ -64,7 +64,8 @@ class PrePublishSquashPlugin(PrePublishPlugin):
         :param from_layer: layer from we will squash - if specified, takes precedence over from_base
         :param tag: str, new name of the image - by default use the former one
         :param remove_former_image: bool, remove unsquashed image?
-        :param dont_load: bool, don't load squashed image into Docker, place it to `$tmpdir/image.tar` instead
+        :param dont_load: if `False` (default), squashed image is loaded into Docker *and* saved
+            to `$tmpdir/image.tar`; if `True`, squashed image is only saved as a file
         """
         super(PrePublishSquashPlugin, self).__init__(tasker, workflow)
         self.image = self.workflow.builder.image_id
@@ -82,19 +83,22 @@ class PrePublishSquashPlugin(PrePublishPlugin):
         self.dont_load = dont_load
 
     def run(self):
+        metadata = {}
+        metadata["path"] = os.path.join(self.workflow.source.workdir, EXPORTED_SQUASHED_IMAGE_NAME)
+
         if self.dont_load:
-            metadata = {}
-            self.workflow.exported_image_sequence.append(metadata)
-            metadata["path"] = \
-                os.path.join(self.workflow.source.workdir, EXPORTED_SQUASHED_IMAGE_NAME)
             # squash the image, don't load it back to docker
             Squash(log=self.log, image=self.image, from_layer=self.from_layer,
                    tag=self.tag, output_path=metadata["path"]).run()
-            metadata.update(get_exported_image_metadata(metadata["path"]))
         else:
-            # squash the image and load it back to engine
+            # squash the image and output both tarfile and Docker engine image
             new_id = Squash(log=self.log, image=self.image, from_layer=self.from_layer,
-                            tag=self.tag).run()
+                            tag=self.tag, output_path=metadata["path"], load_output_back=True
+                            ).run()
             self.workflow.builder.image_id = new_id
+
+        metadata.update(get_exported_image_metadata(metadata["path"]))
+        self.workflow.exported_image_sequence.append(metadata)
+
         if self.remove_former_image:
             self.tasker.remove_image(self.image)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 docker-py
+docker-scripts>=0.4.4
 dockerfile-parse>=0.0.5


### PR DESCRIPTION
I think we can change the squash plugin this way in preparation for the V2 workflow; outputting the file even on `dont_load=False` may be extraneous in some cases, but it doesn't break API and should be safe to do.