### PR TITLE
add_labels_in_df: label rename functionality

### DIFF
--- a/atomic_reactor/plugins/pre_add_labels_in_df.py
+++ b/atomic_reactor/plugins/pre_add_labels_in_df.py
@@ -97,13 +97,13 @@ class AddLabelsPlugin(PreBuildPlugin):
 
         for lbl in auto_labels:
             if lbl in self.labels:
-                self.log.info("label %s is set explicitly, not using generated value", lbl)
+                self.log.info("label %r is set explicitly, not using generated value", lbl)
                 continue
 
             if lbl in generated:
                 self.labels[lbl] = generated[lbl]
             else:
-                self.log.warning("requested automatic label %s is not available", lbl)
+                self.log.warning("requested automatic label %r is not available", lbl)
 
     def run(self):
         """
@@ -149,7 +149,7 @@ class AddLabelsPlugin(PreBuildPlugin):
                         continue
 
             label = '"%s"="%s"' % (escape(key), escape(value))
-            self.log.info("setting label %s", label)
+            self.log.info("setting label %r", label)
             labels.append(label)
 
         content = ""

--- a/atomic_reactor/plugins/pre_add_labels_in_df.py
+++ b/atomic_reactor/plugins/pre_add_labels_in_df.py
@@ -51,7 +51,8 @@ class AddLabelsPlugin(PreBuildPlugin):
     key = "add_labels_in_dockerfile"
 
     def __init__(self, tasker, workflow, labels, dont_overwrite=("Architecture", ),
-                 auto_labels=("build-date", "architecture", "vcs-type", "vcs-ref")):
+                 auto_labels=("build-date", "architecture", "vcs-type", "vcs-ref"),
+                 aliases=None):
         """
         constructor
 
@@ -60,6 +61,9 @@ class AddLabelsPlugin(PreBuildPlugin):
         :param labels: dict, key value pairs to set as labels; or str, JSON-encoded dict
         :param dont_overwrite: iterable, list of label keys which should not be overwritten
         :param auto_labels: iterable, list of labels to be determined automatically, if supported
+        :param aliases: dict, maps old label names to new label names - for each old name found in
+                        base image, dockerfile, or labels argument, a label with the new name is
+                        added (with the same value)
         """
         # call parent constructor
         super(AddLabelsPlugin, self).__init__(tasker, workflow)
@@ -69,6 +73,7 @@ class AddLabelsPlugin(PreBuildPlugin):
             raise RuntimeError("labels have to be dict")
         self.labels = labels
         self.dont_overwrite = dont_overwrite
+        self.aliases = aliases or {}
 
         self.generate_auto_labels(auto_labels)
 
@@ -105,12 +110,44 @@ class AddLabelsPlugin(PreBuildPlugin):
             else:
                 self.log.warning("requested automatic label %r is not available", lbl)
 
+    def add_aliases(self, base_labels, df_labels, new_labels):
+        all_labels = base_labels.copy()
+        # changing dockerfile.labels writes out modified Dockerfile - err on
+        # the safe side and make a copy
+        all_labels.update(df_labels.copy())
+        all_labels.update(new_labels)
+        applied_alias = False
+        not_applied = []
+
+        for old, new in self.aliases.items():
+            if old in all_labels:
+                if new in all_labels:
+                    if all_labels[old] != all_labels[new]:
+                        self.log.warning("labels %r=%r and %r=%r should probably have same value",
+                                         old, all_labels[old], new, all_labels[new])
+                    self.log.debug("alias label %r for %r already exists, skipping", new, old)
+                    continue
+
+                self.log.warning("adding label %r as an alias for label %r", new, old)
+                self.labels[new] = all_labels[old]
+                applied_alias = True
+            else:
+                not_applied.append(old)
+
+        # warn if we applied only some aliases
+        if applied_alias and not_applied:
+            self.log.debug("applied only some aliases, following old labels were not found: %s",
+                           ", ".join(not_applied))
+
     def run(self):
         """
         run the plugin
         """
+        base_image_labels = self.workflow.base_image_inspect["Config"]["Labels"]
         dockerfile = DockerfileParser(self.workflow.builder.df_path)
         lines = dockerfile.lines
+
+        self.add_aliases(base_image_labels, dockerfile.labels, self.labels)
 
         # correct syntax is:
         #   LABEL "key"="value" "key2"="value2"
@@ -132,7 +169,7 @@ class AddLabelsPlugin(PreBuildPlugin):
         labels = []
         for key, value in self.labels.items():
             try:
-                base_image_value = self.workflow.base_image_inspect["Config"]["Labels"][key]
+                base_image_value = base_image_labels[key]
             except KeyError:
                 self.log.info("label %r not present in base image", key)
             except (AttributeError, TypeError):

--- a/atomic_reactor/plugins/pre_assert_labels.py
+++ b/atomic_reactor/plugins/pre_assert_labels.py
@@ -19,38 +19,26 @@ class AssertLabelsPlugin(PreBuildPlugin):
     key = "assert_labels"
     is_allowed_to_fail = False  # We really want to stop the process
 
-    def __init__(self, tasker, workflow, required_labels=None, deprecated_labels=None):
+    def __init__(self, tasker, workflow, required_labels=None):
         """
         constructor
 
         :param tasker: DockerTasker instance
         :param workflow: DockerBuildWorkflow instance
         :param required_labels: list of labels that will be checked
-        :param deprecated_labels: dictionary of deprecated labels where keys are the old labels and
-                                  values are the recommended new labels
         """
         # call parent constructor
         super(AssertLabelsPlugin, self).__init__(tasker, workflow)
 
         self.required_labels = required_labels or ['Name', 'Version', 'Release']
-        self.deprecated_labels = deprecated_labels or {}
 
     def run(self):
         """
         run the plugin
         """
         labels = DockerfileParser(self.workflow.builder.df_path).labels
-        used_deprecated_labels = set()
-
-        for old, new in self.deprecated_labels.items():
-            if labels.get(old) is not None:
-                self.log.warning("Label %r is deprecated! Please use %r as a replacement.",
-                                 old, new)
-                used_deprecated_labels.add(new)
-
         for label in self.required_labels:
-            if labels.get(label) is None and \
-                    label not in used_deprecated_labels:
+            if labels.get(label) is None:
                 msg = "Dockerfile is missing '{0}' label.".format(label)
                 self.log.error(msg)
                 raise AssertionError(msg)

--- a/tests/plugins/test_assert_labels.py
+++ b/tests/plugins/test_assert_labels.py
@@ -35,15 +35,12 @@ RUN yum install -y python-django
 CMD blabla"""
 DF_CONTENT_LABELS = DF_CONTENT+'\nLABEL "Name"="rainbow" "Version"="123" "Release"="1"'
 
-@pytest.mark.parametrize('df_content, req_labels, depr_labels, expected', [
-    (DF_CONTENT, None, None, PluginFailedException()),
-    (DF_CONTENT_LABELS, None, None, None),
-    (DF_CONTENT_LABELS, ['xyz'], None, PluginFailedException()),
-    (DF_CONTENT_LABELS, ['unicorn'], {'Name': 'unicorn'}, None),
-    (DF_CONTENT_LABELS, ['n', 'v', 'r'], {'Name': 'n', 'Version': 'v', 'Release': 'r'}, None),
-    (DF_CONTENT_LABELS, ['unicorn'], {'unicorn': 'Name'}, PluginFailedException()),
+@pytest.mark.parametrize('df_content, req_labels, expected', [
+    (DF_CONTENT, None, PluginFailedException()),
+    (DF_CONTENT_LABELS, None, None),
+    (DF_CONTENT_LABELS, ['xyz'], PluginFailedException())
 ])
-def test_assertlabels_plugin(tmpdir, docker_tasker, df_content, req_labels, depr_labels, expected):
+def test_assertlabels_plugin(tmpdir, docker_tasker, df_content, req_labels, expected):
     df = DockerfileParser(str(tmpdir))
     df.content = df_content
 
@@ -57,7 +54,7 @@ def test_assertlabels_plugin(tmpdir, docker_tasker, df_content, req_labels, depr
         workflow,
         [{
             'name': AssertLabelsPlugin.key,
-            'args': {'required_labels': req_labels, 'deprecated_labels': depr_labels}
+            'args': {'required_labels': req_labels}
         }]
     )
 


### PR DESCRIPTION
This should address problem brought up in https://github.com/projectatomic/osbs-client/pull/266#issuecomment-145532579

When migrating to the new label set, we'll provide a dictionary that maps old labels to new ones. When old label is present but new one is not, the `add_labels_in_df` adds the new label. We'll also change the plugins that use the labels to use the new set. This replaces the *deprecated labels* mechanism that was added to `assert_labels` plugin in #337 / a2a7b09 (am I blind or is the plugin actually unused?).

Please note that the `add_labels_in_df` plugin will have to be moved in front of `bump_release` plugin in `inputs/prod_inner.json`.