### PR TITLE
plugin,import_image: allow specifying build_json_dir

### DIFF
--- a/atomic_reactor/plugins/post_import_image.py
+++ b/atomic_reactor/plugins/post_import_image.py
@@ -29,7 +29,7 @@ class ImportImagePlugin(PostBuildPlugin):
     is_allowed_to_fail = False
 
     def __init__(self, tasker, workflow, imagestream, docker_image_repo,
-                 url, verify_ssl=True, use_auth=True):
+                 url, build_json_dir, verify_ssl=True, use_auth=True):
         """
         constructor
 
@@ -38,6 +38,7 @@ class ImportImagePlugin(PostBuildPlugin):
         :param imagestream: str, name of ImageStream
         :param docker_image_repo: str, image repository to import tags from
         :param url: str, URL to OSv3 instance
+        :param build_json_dir: str, path to directory with input json
         :param verify_ssl: bool, verify SSL certificate?
         :param use_auth: bool, initiate authentication with openshift?
         """
@@ -48,6 +49,7 @@ class ImportImagePlugin(PostBuildPlugin):
         self.url = url
         self.verify_ssl = verify_ssl
         self.use_auth = use_auth
+        self.build_json_dir = build_json_dir
 
     def run(self):
         try:
@@ -64,7 +66,8 @@ class ImportImagePlugin(PostBuildPlugin):
 
         osbs_conf = Configuration(openshift_uri=self.url,
                                   use_auth=self.use_auth,
-                                  verify_ssl=self.verify_ssl)
+                                  verify_ssl=self.verify_ssl,
+                                  build_json_dir=self.build_json_dir)
         osbs = OSBS(osbs_conf, osbs_conf)
 
         try:

--- a/tests/plugins/test_import_image.py
+++ b/tests/plugins/test_import_image.py
@@ -60,6 +60,7 @@ def prepare():
             'imagestream': TEST_IMAGESTREAM,
             'docker_image_repo': TEST_REPO,
             'url': '',
+            'build_json_dir': "",
             'verify_ssl': False,
             'use_auth': False
         }}])


### PR DESCRIPTION
When image stream does not exist, it needs to be created; the template for request is in `build_json_dir`

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/atomic_reactor-1.5.1-py2.7.egg/atomic_reactor/plugin.py", line 203, in run
    plugin_response = plugin_instance.run()
  File "/usr/lib/python2.7/site-packages/atomic_reactor-1.5.1-py2.7.egg/atomic_reactor/plugins/post_import_image.py", line 78, in run
    **kwargs)
  File "build/bdist.linux-x86_64/egg/osbs/api.py", line 33, in catch_exceptions
    return func(*args, **kwargs)
  File "build/bdist.linux-x86_64/egg/osbs/api.py", line 457, in create_image_stream
    img_stream_file = os.path.join(self.os_conf.get_build_json_store(), 'image_stream.json')
  File "build/bdist.linux-x86_64/egg/osbs/conf.py", line 243, in get_build_json_store
    return self._get_value("build_json_dir", GENERAL_CONFIGURATION_SECTION, "build_json_dir")
  File "build/bdist.linux-x86_64/egg/osbs/conf.py", line 90, in _get_value
    raise OsbsException("value '%s' not found" % args_key)
OsbsException: value 'build_json_dir' not found
```