### PR TITLE
Do all image pushing from tag_and_push plugin

### DIFF
--- a/atomic_reactor/build.py
+++ b/atomic_reactor/build.py
@@ -129,35 +129,6 @@ class InsideBuilder(LastLogger, BuilderStateMachine):
         build_result = BuildResult(command_result, self.image_id)
         return build_result
 
-    def push_built_image(self, registry, insecure=False):
-        """
-        push built image to provided registry
-
-        :param registry: str
-        :param insecure: bool, allow connecting to registry over plain http
-        :return: str, image
-        """
-        logger.info("pushing built image '%s' to registry '%s'", self.image, registry)
-        self._ensure_is_built()
-        if not registry:
-            logger.warning("no registry specified; skipping")
-            return
-
-        if self.image.registry and self.image.registry != registry:
-            logger.error("registry in image name doesn't match provided target registry, "
-                         "image registry = '%s', target = '%s'",
-                         self.image.registry, registry)
-            raise RuntimeError(
-                "Registry in image name doesn't match target registry. Image: '%s', Target: '%s'"
-                % (self.image.registry, registry))
-
-        target_image = self.image.copy()
-        target_image.registry = registry
-
-        response = self.tasker.tag_and_push_image(self.image, target_image, insecure=insecure)
-        self.tasker.remove_image(target_image)
-        return response
-
     def inspect_base_image(self):
         """
         inspect base image

--- a/atomic_reactor/plugins/post_tag_and_push.py
+++ b/atomic_reactor/plugins/post_tag_and_push.py
@@ -6,6 +6,8 @@ This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
 
+from copy import deepcopy
+
 from atomic_reactor.plugin import PostBuildPlugin
 
 
@@ -20,24 +22,40 @@ class TagAndPushPlugin(PostBuildPlugin):
     key = "tag_and_push"
     is_allowed_to_fail = False
 
-    def __init__(self, tasker, workflow, **kwargs):
+    def __init__(self, tasker, workflow, registries):
         """
         constructor
 
         :param tasker: DockerTasker instance
         :param workflow: DockerBuildWorkflow instance
+        :param registries: dict, keys are docker registries, values are dicts containing per-registry
+                           parameters. Currently only the "insecure" optional boolean parameter
+                           is supported which controls whether pushes are allowed over plain HTTP.
         """
         # call parent constructor
         super(TagAndPushPlugin, self).__init__(tasker, workflow)
-        self.log.warning("ignoring arguments '%s'", kwargs)
+
+        self.registries = deepcopy(registries)
 
     def run(self):
         pushed_images = []
-        for registry in self.workflow.push_conf.docker_registries:
+
+        if not self.workflow.tag_conf.unique_images:
+            self.workflow.tag_conf.add_unique_image(self.workflow.image)
+
+        for registry, registry_conf in self.registries.items():
+            insecure = registry_conf.get('insecure', False)
+            self.workflow.push_conf.add_docker_registry(registry, insecure=insecure)
+
             for image in self.workflow.tag_conf.images:
+                if image.registry:
+                    raise RuntimeError("Image name must not contain registry: %r" % image.registry)
+
                 registry_image = image.copy()
-                registry_image.registry = registry.uri
+                registry_image.registry = registry
                 self.tasker.tag_and_push_image(self.workflow.builder.image_id, registry_image,
-                                               insecure=registry.insecure, force=True)
+                                               insecure=insecure, force=True)
+
                 pushed_images.append(registry_image.to_str())
+
         return pushed_images

--- a/docs/api.md
+++ b/docs/api.md
@@ -407,12 +407,3 @@ Python API for dock. This is the official way of interacting with dock.
 
     :return: dict
 ```
-
-**push\_built\_image**(self, registry, insecure=False):
-```
-    push built image to provided registry
-
-    :param registry: str
-    :param insecure: bool, allow connecting to registry over plain http
-    :return: str, image
-```

--- a/docs/build_json.md
+++ b/docs/build_json.md
@@ -13,7 +13,6 @@ If you want to take advantage of _inner_ part logic of Atomic Reactor, you can d
         }
     },
     "image": "my-test-image",
-    "target_registries": ["registry.example2.com:5000"],
     "openshift_build_selflink": "/oapi/v1/namespaces/default/builds/build-20150826112654-1",
     "prebuild_plugins": [
         {
@@ -32,6 +31,18 @@ If you want to take advantage of _inner_ part logic of Atomic Reactor, you can d
             "name": "inject_yum_repo",
             "args": {}
         }
+    ],
+    "postbuild_plugins": [
+        {
+            "name": "tag_and_push",
+            "args": {
+                "registries": {
+                    "registry.example2.com:5000": {
+                        "insecure": true
+                    }
+                }
+            }
+        }
     ]
 }
 ```
@@ -49,7 +60,7 @@ If you want to take advantage of _inner_ part logic of Atomic Reactor, you can d
  * prepublish_plugins - list of dicts, optional
   * these plugins are executed after the prebuild plugins but before the image is pushed to the registry
  * postbuild_plugins - list of dicts, optional
-  * these plugins are executed after the image is pushed to the registry
+  * these plugins are executed after/during the image is pushed to the registry (done by the `tag_and_push` plugin). The `tag_and_push` has a `registries` argument which is a dictionary that maps target registries to registry-specific options.
  * exit_plugins - list of dicts, optional
   * these plugins are executed last of all and will always be run, even for a failed build
 

--- a/tests/plugins/test_input_osv3.py
+++ b/tests/plugins/test_input_osv3.py
@@ -15,6 +15,8 @@ from atomic_reactor.plugins.input_osv3 import OSv3InputPlugin
 import pytest
 from flexmock import flexmock
 
+from tests.constants import LOCALHOST_REGISTRY
+
 @pytest.mark.parametrize('prebuild_json,expected_json', [
     ([],
      [{ 'name': 'pull_base_image' }]
@@ -55,6 +57,46 @@ def test_prebuild_plugins_rewrite(prebuild_json, expected_json):
     plugin = OSv3InputPlugin()
     assert plugin.run()['prebuild_plugins'] == expected_json
 
+
+@pytest.mark.parametrize('output_registry,postbuild_json,expected_json', [
+    (LOCALHOST_REGISTRY,
+     [],
+     [{ 'name': 'tag_and_push', 'args': { 'registries': { LOCALHOST_REGISTRY: { 'insecure': True }}}}]
+    ),
+    (LOCALHOST_REGISTRY,
+     [{ 'name': 'tag_and_push' }],
+     [{ 'name': 'tag_and_push', 'args': { 'registries': { LOCALHOST_REGISTRY: { 'insecure': True }}}}]
+    ),
+    (LOCALHOST_REGISTRY,
+     [{ 'name': 'tag_and_push', 'args': { 'registries': { 'foo': { 'insecure': True }}}}],
+     [{ 'name': 'tag_and_push', 'args': { 'registries': { 'foo': { 'insecure': True }}}}]
+    ),
+    (None,
+     [{ 'name': 'tag_and_push', 'args': { 'registries': { 'foo': { 'insecure': True }}}}],
+     [{ 'name': 'tag_and_push', 'args': { 'registries': { 'foo': { 'insecure': True }}}}]
+    ),
+    (None,
+     [],
+     []
+    ),
+])
+def test_postbuild_plugins_rewrite(output_registry, postbuild_json, expected_json):
+    plugins_json = {
+        'postbuild_plugins': postbuild_json,
+    }
+
+    mock_env = {
+        'BUILD': '{}',
+        'SOURCE_URI': 'https://github.com/foo/bar.git',
+        'SOURCE_REF': 'master',
+        'OUTPUT_IMAGE': 'asdf:fdsa',
+        'OUTPUT_REGISTRY': output_registry,
+        'DOCK_PLUGINS': json.dumps(plugins_json),
+    }
+    flexmock(os, environ=mock_env)
+
+    plugin = OSv3InputPlugin()
+    assert plugin.run()['postbuild_plugins'] == expected_json
 
 def test_doesnt_fail_if_no_plugins():
     mock_env = {


### PR DESCRIPTION
Gets rid of the pushing logic in a-r core, `tag_and_push` is now always used instead.

The `input_osv3` plugin is modified to insert the plugin automatically in order to be backwards compatible with older osbs-client. The same is done for python API.

The tags created during pushing to registry (e.g. `localhost:5000/my/image:latest`) are removed in `exit_remove_built_image` plugin.
