### PR TITLE
Increase docker client timeout to 120s

### DIFF
--- a/atomic_reactor/core.py
+++ b/atomic_reactor/core.py
@@ -206,7 +206,13 @@ class BuildContainerFactory(object):
 
 
 class DockerTasker(LastLogger):
-    def __init__(self, base_url=None, **kwargs):
+    def __init__(self, base_url=None, timeout=120, **kwargs):
+        """
+        Constructor
+
+        :param base_url: str, docker connection URL
+        :param timeout: int, timeout for docker client
+        """
         super(DockerTasker, self).__init__(**kwargs)
 
         client_kwargs = {}
@@ -218,7 +224,7 @@ class DockerTasker(LastLogger):
         if hasattr(docker, 'AutoVersionClient'):
             client_kwargs['version'] = 'auto'
 
-        self.d = docker.Client(**client_kwargs)
+        self.d = docker.Client(timeout=timeout, **client_kwargs)
 
     def build_image_from_path(self, path, image, stream=False, use_cache=False, remove_im=True):
         """

--- a/tests/test_inner.py
+++ b/tests/test_inner.py
@@ -569,7 +569,8 @@ def test_workflow_plugin_error(fail_at):
     # Failures in any phase except 'exit' cause the build process to
     # abort.
     if fail_at == 'exit':
-        workflow.build_docker_image()
+        build_result = workflow.build_docker_image()
+        assert build_result and not build_result.is_failed()
     else:
         with pytest.raises(PluginFailedException):
             workflow.build_docker_image()

--- a/tests/test_tasker.py
+++ b/tests/test_tasker.py
@@ -316,3 +316,19 @@ def test_get_version():
     t = DockerTasker()
     response = t.get_info()
     assert isinstance(response, dict)
+
+
+@pytest.mark.parametrize(('timeout', 'expected_timeout'), [
+    (None, 120),
+    (60, 60),
+])
+def test_timeout(timeout, expected_timeout):
+    (flexmock(docker.Client)
+        .should_receive('__init__')
+        .with_args(version=str, timeout=expected_timeout))
+
+    kwargs = {}
+    if timeout is not None:
+        kwargs['timeout'] = timeout
+
+    t = DockerTasker(**kwargs)


### PR DESCRIPTION
The default docker client timeout is 60s. Increase this to 120s in `DockerTasker` by default. New `timeout` keyword argument in constructor allows for this to be adjusted.