### PR TITLE
setup dockpulp logging

### DIFF
--- a/atomic_reactor/plugins/post_push_to_pulp.py
+++ b/atomic_reactor/plugins/post_push_to_pulp.py
@@ -8,6 +8,7 @@ of the BSD license. See the LICENSE file for details.
 
 from __future__ import print_function, unicode_literals
 from dockpulp import setup_logger
+from atomic_reactor import set_logging
 
 """
 Push built image to pulp registry
@@ -75,6 +76,8 @@ class PulpUploader(object):
         # U/N & password has bigger prio than secret cert
         self.username = username
         self.password = password
+
+        set_logging("dockpulp")
 
     def _check_file(self):
         # Sanity-check image


### PR DESCRIPTION
sample:

```
2015-10-19 05:51:52,106 - atomic_reactor.plugins.pulp_push - INFO - checking image before upload
2015-10-19 05:51:52,111 - atomic_reactor.plugins.pulp_push - INFO - SOURCE_SECRET_PATH=/var/run/secrets/openshift.io/source from environment
2015-10-19 05:51:52,111 - atomic_reactor.plugins.pulp_push - INFO - repo_tags_mapping = {...}
2015-10-19 05:51:52,115 - dockpulp - DEBUG - remote host is https://...
2015-10-19 05:51:52,115 - dockpulp - DEBUG - calling post on https://.../pulp/api/v2/repositories/search/
2015-10-19 05:51:52,115 - dockpulp - DEBUG - kwargs: {'verify': False, 'cert': (u'/var/run/secrets/openshift.io/source/pulp.cer', u'/var/run/secrets/openshift.io/source/pulp.key'), 'data': '
{"fields": ["id"], "criteria": {"filters": {"id": {...}}}}'}
/usr/lib/python2.7/site-packages/requests/packages/urllib3/util/ssl_.py:100: InsecurePlatformWarning: A true SSLContext object is not available. This prevents urllib3 from configuring SSL ap
propriately and may cause certain SSL connections to fail. For more information, see https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning.
  InsecurePlatformWarning
/usr/lib/python2.7/site-packages/requests/packages/urllib3/connectionpool.py:789: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly 
advised. See: https://urllib3.readthedocs.org/en/latest/security.html
  InsecureRequestWarning)
2015-10-19 05:51:53,647 - dockpulp - DEBUG - raw response data:
2015-10-19 05:51:53,647 - dockpulp - DEBUG - []
...
```
