### PR TITLE
Spec fixes & move exit_sendmail into rebuilds subpackage

### DIFF
--- a/atomic-reactor.spec
+++ b/atomic-reactor.spec
@@ -226,7 +226,7 @@ cp -a docs/manpage/atomic-reactor.1 %{buildroot}%{_mandir}/man1/
 %exclude %{python2_sitelib}/atomic_reactor/plugins/post_import_image.py*
 %exclude %{python2_sitelib}/atomic_reactor/plugins/pre_bump_release.py*
 %exclude %{python2_sitelib}/atomic_reactor/plugins/pre_check_and_set_rebuild.py*
-%exclude %{python2_sitelib}/atomic_reactor/plugins/pre_stop_autorebuild_if_disabled.py
+%exclude %{python2_sitelib}/atomic_reactor/plugins/pre_stop_autorebuild_if_disabled.py*
 
 %{python2_sitelib}/atomic_reactor-%{version}-py2.*.egg-info
 %dir %{_datadir}/%{name}
@@ -245,7 +245,7 @@ cp -a docs/manpage/atomic-reactor.1 %{buildroot}%{_mandir}/man1/
 %{python2_sitelib}/atomic_reactor/plugins/post_import_image.py*
 %{python2_sitelib}/atomic_reactor/plugins/pre_bump_release.py*
 %{python2_sitelib}/atomic_reactor/plugins/pre_check_and_set_rebuild.py*
-%{python2_sitelib}/atomic_reactor/plugins/pre_stop_autorebuild_if_disabled.py
+%{python2_sitelib}/atomic_reactor/plugins/pre_stop_autorebuild_if_disabled.py*
 
 
 %if 0%{?with_python3}

--- a/atomic-reactor.spec
+++ b/atomic-reactor.spec
@@ -263,7 +263,12 @@ cp -a docs/manpage/atomic-reactor.1 %{buildroot}%{_mandir}/man1/
 %{python3_sitelib}/atomic_reactor/cli
 %{python3_sitelib}/atomic_reactor/plugins
 %{python3_sitelib}/atomic_reactor/__pycache__/*.py*
-%exclude %{python3_sitelib}/atomic_reactor/plugins/pre_koji.py*
+%exclude %{python3_sitelib}/atomic_reactor/plugins/pre_koji.py
+%exclude %{python3_sitelib}/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
+%exclude %{python3_sitelib}/atomic_reactor/plugins/post_import_image.py
+%exclude %{python3_sitelib}/atomic_reactor/plugins/pre_bump_release.py
+%exclude %{python3_sitelib}/atomic_reactor/plugins/pre_check_and_set_rebuild.py
+%exclude %{python3_sitelib}/atomic_reactor/plugins/pre_stop_autorebuild_if_disabled.py
 %exclude %{python3_sitelib}/atomic_reactor/plugins/__pycache__/pre_koji*.py*
 %exclude %{python3_sitelib}/atomic_reactor/plugins/__pycache__/exit_store_metadata_in_osv3*.py*
 %exclude %{python3_sitelib}/atomic_reactor/plugins/__pycache__/post_import_image*.py*
@@ -282,17 +287,19 @@ cp -a docs/manpage/atomic-reactor.1 %{buildroot}%{_mandir}/man1/
 
 
 %files -n python3-atomic-reactor-koji
-%{python3_sitelib}/atomic_reactor/plugins/pre_koji.py*
+%{python3_sitelib}/atomic_reactor/plugins/pre_koji.py
 %{python3_sitelib}/atomic_reactor/plugins/__pycache__/pre_koji*.py*
 
 
 %files -n python3-atomic-reactor-metadata
-%{python3_sitelib}/atomic_reactor/plugins/exit_store_metadata_in_osv3.py*
+%{python3_sitelib}/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
 %{python3_sitelib}/atomic_reactor/plugins/__pycache__/exit_store_metadata_in_osv3*.py*
 
 %files -n python3-atomic-reactor-rebuilds
-%{python3_sitelib}/atomic_reactor/plugins/exit_store_metadata_in_osv3.py*
-%{python3_sitelib}/atomic_reactor/plugins/__pycache__/exit_store_metadata_in_osv3*.py*
+%{python3_sitelib}/atomic_reactor/plugins/post_import_image.py
+%{python3_sitelib}/atomic_reactor/plugins/pre_bump_release.py
+%{python3_sitelib}/atomic_reactor/plugins/pre_check_and_set_rebuild.py
+%{python3_sitelib}/atomic_reactor/plugins/pre_stop_autorebuild_if_disabled.py
 %{python3_sitelib}/atomic_reactor/plugins/__pycache__/post_import_image*.py*
 %{python3_sitelib}/atomic_reactor/plugins/__pycache__/pre_bump_release*.py*
 %{python3_sitelib}/atomic_reactor/plugins/__pycache__/pre_check_and_set_rebuild*.py*

--- a/atomic-reactor.spec
+++ b/atomic-reactor.spec
@@ -35,9 +35,9 @@ BuildRequires:  python2-devel
 BuildRequires:  python-setuptools
 
 %if 0%{?with_python3}
-Requires:       python3-atomic-reactor
+Requires:       python3-atomic-reactor = %{version}-%{release}
 %else
-Requires:       python-atomic-reactor
+Requires:       python-atomic-reactor = %{version}-%{release}
 %endif
 Requires:       git >= 1.7.10
 

--- a/atomic-reactor.spec
+++ b/atomic-reactor.spec
@@ -222,6 +222,7 @@ cp -a docs/manpage/atomic-reactor.1 %{buildroot}%{_mandir}/man1/
 %{python2_sitelib}/atomic_reactor/cli
 %{python2_sitelib}/atomic_reactor/plugins
 %exclude %{python2_sitelib}/atomic_reactor/plugins/pre_koji.py*
+%exclude %{python2_sitelib}/atomic_reactor/plugins/exit_sendmail.py*
 %exclude %{python2_sitelib}/atomic_reactor/plugins/exit_store_metadata_in_osv3.py*
 %exclude %{python2_sitelib}/atomic_reactor/plugins/post_import_image.py*
 %exclude %{python2_sitelib}/atomic_reactor/plugins/pre_bump_release.py*
@@ -242,6 +243,7 @@ cp -a docs/manpage/atomic-reactor.1 %{buildroot}%{_mandir}/man1/
 %{python2_sitelib}/atomic_reactor/plugins/exit_store_metadata_in_osv3.py*
 
 %files -n python-atomic-reactor-rebuilds
+%{python2_sitelib}/atomic_reactor/plugins/exit_sendmail.py*
 %{python2_sitelib}/atomic_reactor/plugins/post_import_image.py*
 %{python2_sitelib}/atomic_reactor/plugins/pre_bump_release.py*
 %{python2_sitelib}/atomic_reactor/plugins/pre_check_and_set_rebuild.py*
@@ -264,12 +266,14 @@ cp -a docs/manpage/atomic-reactor.1 %{buildroot}%{_mandir}/man1/
 %{python3_sitelib}/atomic_reactor/plugins
 %{python3_sitelib}/atomic_reactor/__pycache__/*.py*
 %exclude %{python3_sitelib}/atomic_reactor/plugins/pre_koji.py
+%exclude %{python3_sitelib}/atomic_reactor/plugins/exit_sendmail.py
 %exclude %{python3_sitelib}/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
 %exclude %{python3_sitelib}/atomic_reactor/plugins/post_import_image.py
 %exclude %{python3_sitelib}/atomic_reactor/plugins/pre_bump_release.py
 %exclude %{python3_sitelib}/atomic_reactor/plugins/pre_check_and_set_rebuild.py
 %exclude %{python3_sitelib}/atomic_reactor/plugins/pre_stop_autorebuild_if_disabled.py
 %exclude %{python3_sitelib}/atomic_reactor/plugins/__pycache__/pre_koji*.py*
+%exclude %{python3_sitelib}/atomic_reactor/plugins/__pycache__/exit_sendmail*.py*
 %exclude %{python3_sitelib}/atomic_reactor/plugins/__pycache__/exit_store_metadata_in_osv3*.py*
 %exclude %{python3_sitelib}/atomic_reactor/plugins/__pycache__/post_import_image*.py*
 %exclude %{python3_sitelib}/atomic_reactor/plugins/__pycache__/pre_bump_release*.py*
@@ -296,10 +300,12 @@ cp -a docs/manpage/atomic-reactor.1 %{buildroot}%{_mandir}/man1/
 %{python3_sitelib}/atomic_reactor/plugins/__pycache__/exit_store_metadata_in_osv3*.py*
 
 %files -n python3-atomic-reactor-rebuilds
+%{python3_sitelib}/atomic_reactor/plugins/exit_sendmail.py
 %{python3_sitelib}/atomic_reactor/plugins/post_import_image.py
 %{python3_sitelib}/atomic_reactor/plugins/pre_bump_release.py
 %{python3_sitelib}/atomic_reactor/plugins/pre_check_and_set_rebuild.py
 %{python3_sitelib}/atomic_reactor/plugins/pre_stop_autorebuild_if_disabled.py
+%{python3_sitelib}/atomic_reactor/plugins/__pycache__/exit_sendmail*.py*
 %{python3_sitelib}/atomic_reactor/plugins/__pycache__/post_import_image*.py*
 %{python3_sitelib}/atomic_reactor/plugins/__pycache__/pre_bump_release*.py*
 %{python3_sitelib}/atomic_reactor/plugins/__pycache__/pre_check_and_set_rebuild*.py*


### PR DESCRIPTION
As @TomasTomecek noticed the exit_sendmail plugin requires pre_check_and_set_rebuild from rebuilds subpackage, so it should probably be moved into rebuilds too.