### PR TITLE
Remove the remaining mentions of dock

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -11,7 +11,7 @@ modification, are permitted provided that the following conditions are met:
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
 
-* Neither the name of dock nor the names of its
+* Neither the name of atomic-reactor nor the names of its
   contributors may be used to endorse or promote products derived from
   this software without specific prior written permission.
 

--- a/atomic_reactor/plugins/input_osv3.py
+++ b/atomic_reactor/plugins/input_osv3.py
@@ -38,7 +38,7 @@ class OSv3InputPlugin(InputPlugin):
         git_ref = os.environ.get('SOURCE_REF', None)
         image = os.environ['OUTPUT_IMAGE']
         self.target_registry = os.environ.get('OUTPUT_REGISTRY', None)
-        self.plugins_json = os.environ.get('DOCK_PLUGINS', '{}')
+        self.plugins_json = os.environ.get('ATOMIC_REACTOR_PLUGINS', os.environ.get('DOCK_PLUGINS', '{}'))
         self.plugins_json = json.loads(self.plugins_json)
 
         self.preprocess_plugins()

--- a/atomic_reactor/plugins/prepub_tests_for_image.py
+++ b/atomic_reactor/plugins/prepub_tests_for_image.py
@@ -50,7 +50,7 @@ class ImageTestPlugin(PrePublishPlugin):
         constructor
 
         :param tasker: DockerTasker instance
-        :param workflow: DockurBuildWorkflow instance
+        :param workflow: DockerBuildWorkflow instance
         :param git_uri: str, URI to git repo (URL, path -- this is passed to 'git clone')
         :param image_id: str, ID of image to process
         :param tests_git_path: str, relative path within git repo to file with tests (default=tests.py)

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,16 +1,16 @@
 # API
 
-dock has proper python API. You can use it in your scripts or services without invoking shell:
+atomic-reactor has proper python API. You can use it in your scripts or services without invoking shell:
 
 ```python
-from dock.api import build_image_in_privileged_container
+from atomic_reactor.api import build_image_in_privileged_container
 response = build_image_in_privileged_container(
     "privileged-buildroot",
     source={
         'provider': 'git',
         'uri': 'https://github.com/TomasTomecek/docker-hello-world.git',
     }
-    image="dock-test-image",
+    image="atomic-reactor-test-image",
 )
 ```
 
@@ -53,7 +53,7 @@ All rights reserved.
 This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 
-Python API for dock. This is the official way of interacting with dock.
+Python API for atomic-reactor. This is the official way of interacting with atomic-reactor.
 
 ### Functions
 **build\_image\_here**(source, image, parent\_registry=None, target\_registries=None, parent\_registry\_insecure=False, target\_registries\_insecure=False, \*\*kwargs):

--- a/tests/plugins/test_input_osv3.py
+++ b/tests/plugins/test_input_osv3.py
@@ -50,7 +50,7 @@ def test_prebuild_plugins_rewrite(prebuild_json, expected_json):
         'SOURCE_REF': 'master',
         'OUTPUT_IMAGE': 'asdf:fdsa',
         'OUTPUT_REGISTRY': 'localhost:5000',
-        'DOCK_PLUGINS': json.dumps(plugins_json),
+        'ATOMIC_REACTOR_PLUGINS': json.dumps(plugins_json),
     }
     flexmock(os, environ=mock_env)
 
@@ -91,12 +91,13 @@ def test_postbuild_plugins_rewrite(output_registry, postbuild_json, expected_jso
         'SOURCE_REF': 'master',
         'OUTPUT_IMAGE': 'asdf:fdsa',
         'OUTPUT_REGISTRY': output_registry,
-        'DOCK_PLUGINS': json.dumps(plugins_json),
+        'ATOMIC_REACTOR_PLUGINS': json.dumps(plugins_json),
     }
     flexmock(os, environ=mock_env)
 
     plugin = OSv3InputPlugin()
     assert plugin.run()['postbuild_plugins'] == expected_json
+
 
 def test_doesnt_fail_if_no_plugins():
     mock_env = {
@@ -105,7 +106,7 @@ def test_doesnt_fail_if_no_plugins():
         'SOURCE_REF': 'master',
         'OUTPUT_IMAGE': 'asdf:fdsa',
         'OUTPUT_REGISTRY': 'localhost:5000',
-        'DOCK_PLUGINS': '{}',
+        'ATOMIC_REACTOR_PLUGINS': '{}',
     }
     flexmock(os, environ=mock_env)
 
@@ -125,9 +126,29 @@ def test_sets_selflink(build, expected):
         'SOURCE_REF': 'master',
         'OUTPUT_IMAGE': 'asdf:fdsa',
         'OUTPUT_REGISTRY': 'localhost:5000',
-        'DOCK_PLUGINS': '{}',
+        'ATOMIC_REACTOR_PLUGINS': '{}',
     }
     flexmock(os, environ=mock_env)
 
     plugin = OSv3InputPlugin()
     assert plugin.run()['openshift_build_selflink'] == expected
+
+
+@pytest.mark.parametrize('plugins_variable', ['ATOMIC_REACTOR_PLUGINS', 'DOCK_PLUGINS'])
+def test_plugins_variable(plugins_variable):
+    plugins_json = {
+        'postbuild_plugins': [],
+    }
+
+    mock_env = {
+        'BUILD': '{}',
+        'SOURCE_URI': 'https://github.com/foo/bar.git',
+        'SOURCE_REF': 'master',
+        'OUTPUT_IMAGE': 'asdf:fdsa',
+        'OUTPUT_REGISTRY': 'localhost:5000',
+        plugins_variable: json.dumps(plugins_json),
+    }
+    flexmock(os, environ=mock_env)
+
+    plugin = OSv3InputPlugin()
+    assert plugin.run()['postbuild_plugins'] is not None


### PR DESCRIPTION
Needed for projectatomic/osbs-client#143 - osbs still uses `DOCK_PLUGINS` in the build json.