### PR TITLE
Update koji_promote for metadata spec changes

### DIFF
--- a/atomic_reactor/plugins/exit_koji_promote.py
+++ b/atomic_reactor/plugins/exit_koji_promote.py
@@ -395,8 +395,7 @@ class KojiPromotePlugin(ExitPlugin):
             # Pulp plugin not installed or not configured
             raise NotImplementedError
 
-        destination_repo = pulp_result[0].to_str()
-        tag = self.workflow.tag_conf.unique_images[0].to_str()
+        repositories = [image.to_str() for image in pulp_result]
         arch = os.uname()[4]
         metadata, output = self.get_image_output()
         metadata.update({
@@ -410,8 +409,7 @@ class KojiPromotePlugin(ExitPlugin):
                 'docker': {
                     'id': image_id,
                     'parent_id': parent_id,
-                    'destination_repo': destination_repo,
-                    'tag': tag,
+                    'repositories': repositories,
                 },
             },
         })

--- a/atomic_reactor/plugins/exit_koji_promote.py
+++ b/atomic_reactor/plugins/exit_koji_promote.py
@@ -146,10 +146,16 @@ class KojiPromotePlugin(ExitPlugin):
                 'version': field('VERSION'),
                 'release': field('RELEASE'),
                 'arch': field('ARCH'),
-                'epoch': field('EPOCH'),
                 'sigmd5': field('SIGMD5'),
                 'signature': signature,
             }
+
+            # Special handling for epoch as it must be an integer or None
+            epoch = field('EPOCH')
+            if epoch is not None:
+                epoch = int(epoch)
+
+            component_rpm['epoch'] = epoch
 
             if component_rpm['name'] != 'gpg-pubkey':
                 components.append(component_rpm)
@@ -427,7 +433,7 @@ class KojiPromotePlugin(ExitPlugin):
             # (the format we expect)
             start_time_struct = time.strptime(build_start_time,
                                               '%Y-%m-%dT%H:%M:%SZ')
-            start_time = str(int(time.mktime(start_time_struct)))
+            start_time = int(time.mktime(start_time_struct))
         except ValueError:
             self.log.error("Invalid time format (%s)", build_start_time)
             raise
@@ -453,7 +459,7 @@ class KojiPromotePlugin(ExitPlugin):
             'release': release,
             'source': "{0}#{1}".format(source.uri, source.commit_id),
             'start_time': start_time,
-            'end_time': str(int(time.time())),
+            'end_time': int(time.time()),
             'extra': {
                 'image': {},
             },

--- a/atomic_reactor/plugins/exit_koji_promote.py
+++ b/atomic_reactor/plugins/exit_koji_promote.py
@@ -401,7 +401,8 @@ class KojiPromotePlugin(ExitPlugin):
             # Pulp plugin not installed or not configured
             raise NotImplementedError
 
-        repositories = [image.to_str() for image in pulp_result]
+        repositories = [image.to_str() for image in pulp_result
+                        if image.tag != 'latest']
         arch = os.uname()[4]
         metadata, output = self.get_image_output()
         metadata.update({

--- a/tests/plugins/test_koji_promote.py
+++ b/tests/plugins/test_koji_promote.py
@@ -638,7 +638,7 @@ class TestKojiPromote(object):
                     assert image.registry
                     assert image.namespace
                     assert image.repo
-                    assert image.tag
+                    assert image.tag and image.tag != 'latest'
 
             if metadata_only:
                 assert isinstance(output['metadata_only'], bool)

--- a/tests/plugins/test_koji_promote.py
+++ b/tests/plugins/test_koji_promote.py
@@ -15,7 +15,6 @@ try:
     import koji
 except ImportError:
     import inspect
-    import os
     import sys
 
     # Find out mocked koji module
@@ -83,10 +82,17 @@ class MockedClientSession(object):
         self.server_dir = server_dir
 
 
-FAKE_RPM_OUTPUT = (b'name1;1.0;1;x86_64;0;01234567;(none);RSA/SHA256, Mon 29 Jun 2015 13:58:22 BST, Key ID abcdef01234567\n'
-                   b'gpg-pubkey;01234567;01234567;(none);(none);(none);(none);(none)\n'
-                   b'gpg-pubkey-doc;01234567;01234567;noarch;(none);(none);(none);(none)\n'
-                   b'name2;2.0;2;x86_64;0;12345678;RSA/SHA256, Mon 29 Jun 2015 13:58:22 BST, Key ID bcdef012345678;(none)\n\n')
+FAKE_RPM_OUTPUT = (
+    b'name1;1.0;1;x86_64;0;01234567;(none);'
+    b'RSA/SHA256, Mon 29 Jun 2015 13:58:22 BST, Key ID abcdef01234567\n'
+
+    b'gpg-pubkey;01234567;01234567;(none);(none);(none);(none);(none)\n'
+
+    b'gpg-pubkey-doc;01234567;01234567;noarch;(none);(none);(none);(none)\n'
+
+    b'name2;2.0;2;x86_64;0;12345678;'
+    b'RSA/SHA256, Mon 29 Jun 2015 13:58:22 BST, Key ID bcdef012345678;(none)\n'
+    b'\n')
 
 FAKE_OS_OUTPUT = 'fedora-22'
 
@@ -113,8 +119,6 @@ class MockedPopen(object):
 
 def fake_Popen(cmd, *args, **kwargs):
     return MockedPopen(cmd, *args, **kwargs)
-
-
 
 
 def is_string_type(obj):
@@ -238,12 +242,12 @@ def prepare(tmpdir, session=None, name=None, version=None, release=None,
         args['metadata_only'] = True
 
     runner = ExitPluginsRunner(tasker, workflow,
-                                    [
-                                        {
-                                            'name': KojiPromotePlugin.key,
-                                            'args': args,
-                                        },
-                                    ])
+                               [
+                                   {
+                                       'name': KojiPromotePlugin.key,
+                                       'args': args,
+                                   },
+                               ])
 
     os.environ.update({
         'BUILD': json.dumps({

--- a/tests/plugins/test_koji_promote.py
+++ b/tests/plugins/test_koji_promote.py
@@ -82,15 +82,17 @@ class MockedClientSession(object):
         self.server_dir = server_dir
 
 
+FAKE_SIGMD5 = b'0' * 32
 FAKE_RPM_OUTPUT = (
-    b'name1;1.0;1;x86_64;0;01234567;(none);'
+    b'name1;1.0;1;x86_64;0;' + FAKE_SIGMD5 + b';(none);'
     b'RSA/SHA256, Mon 29 Jun 2015 13:58:22 BST, Key ID abcdef01234567\n'
 
     b'gpg-pubkey;01234567;01234567;(none);(none);(none);(none);(none)\n'
 
-    b'gpg-pubkey-doc;01234567;01234567;noarch;(none);(none);(none);(none)\n'
+    b'gpg-pubkey-doc;01234567;01234567;noarch;(none);' + FAKE_SIGMD5 +
+    b';(none);(none)\n'
 
-    b'name2;2.0;2;x86_64;0;12345678;'
+    b'name2;2.0;2;x86_64;0;' + FAKE_SIGMD5 + b';' +
     b'RSA/SHA256, Mon 29 Jun 2015 13:58:22 BST, Key ID bcdef012345678;(none)\n'
     b'\n')
 
@@ -149,6 +151,8 @@ def check_components(components):
         assert component_rpm['version']
         assert is_string_type(component_rpm['version'])
         assert component_rpm['release']
+        epoch = component_rpm['epoch']
+        assert epoch is None or isinstance(epoch, int)
         assert is_string_type(component_rpm['arch'])
         assert component_rpm['signature'] != '(none)'
 
@@ -221,8 +225,8 @@ def prepare(tmpdir, session=None, name=None, version=None, release=None,
     setattr(workflow, 'build_failed', build_process_failed)
     workflow.prebuild_results[CheckAndSetRebuildPlugin.key] = is_rebuild
     workflow.postbuild_results[PostBuildRPMqaPlugin.key] = [
-        "name1,1.0,1,x86_64,0,2000,01234567,23000",
-        "name2,2.0,1,x86_64,0,3000,abcdef01,24000",
+        "name1,1.0,1,x86_64,0,2000," + FAKE_SIGMD5.decode() + ",23000",
+        "name2,2.0,1,x86_64,0,3000," + FAKE_SIGMD5.decode() + ",24000",
     ]
 
     args = {
@@ -406,6 +410,16 @@ class TestKojiPromote(object):
         runner.run()
 
         data = session.metadata
+        if metadata_only:
+            mdonly = set()
+            output_filename = 'koji_promote-metadata-only.json'
+        else:
+            mdonly = set(['metadata_only'])
+            output_filename = 'koji_promote.json'
+
+        with open(output_filename, 'wb') as out:
+            json.dump(data, out, sort_keys=True, indent=4)
+
         assert set(data.keys()) == set([
             'metadata_version',
             'build',
@@ -425,11 +439,6 @@ class TestKojiPromote(object):
         output_files = data['output']
         assert isinstance(output_files, list)
 
-        if metadata_only:
-            mdonly = set()
-        else:
-            mdonly = set(['metadata_only'])
-
         assert set(build.keys()) == set([
             'name',
             'version',
@@ -445,8 +454,10 @@ class TestKojiPromote(object):
         assert build['version'] == version
         assert build['release'] == release
         assert build['source'] == 'git://hostname/path#123456'
-        assert int(build['start_time']) > 0
-        assert int(build['end_time']) > 0
+        start_time = build['start_time']
+        assert isinstance(start_time, int) and start_time
+        end_time = build['end_time']
+        assert isinstance(end_time, int) and end_time
         if metadata_only:
             assert isinstance(build['metadata_only'], bool)
             assert build['metadata_only']


### PR DESCRIPTION
The output.extra.docker section of the metadata now has a string list `repositories` instead of `destination_repo` and `tag` fields.

Some of the metadata values need to be integers: `start_time`, `end_time`, `epoch` for component RPMs (unless it's None).