### PR TITLE
koji_promote: report all pushed images

### DIFF
--- a/atomic_reactor/plugins/exit_koji_promote.py
+++ b/atomic_reactor/plugins/exit_koji_promote.py
@@ -470,7 +470,7 @@ class KojiPromotePlugin(ExitPlugin):
         release = None
         for image_name in self.workflow.tag_conf.primary_images:
             if '-' in image_name.tag:
-                name = image_name.repo
+                name = image_name.to_str(registry=False, tag=False)
                 version, release = image_name.tag.split('-', 1)
 
         if name is None or version is None or release is None:

--- a/atomic_reactor/plugins/post_tag_and_push.py
+++ b/atomic_reactor/plugins/post_tag_and_push.py
@@ -59,7 +59,7 @@ class TagAndPushPlugin(PostBuildPlugin):
                                                       registry_image, insecure=insecure,
                                                       force=True)
 
-                pushed_images.append(registry_image.to_str())
+                pushed_images.append(registry_image)
 
                 digest = self.extract_digest(logs)
                 if digest:

--- a/tests/plugins/test_koji_promote.py
+++ b/tests/plugins/test_koji_promote.py
@@ -162,7 +162,7 @@ def mock_environment(tmpdir, session=None, name=None, version=None,
     setattr(workflow.builder.source, 'path', None)
     setattr(workflow, 'tag_conf', TagConf())
     if name and version:
-        workflow.tag_conf.add_unique_image('user/{n}:{v}-timestamp'
+        workflow.tag_conf.add_unique_image('{n}:{v}-timestamp'
                                            .format(n=name,
                                                    v=version))
     if name and version and release:
@@ -273,7 +273,7 @@ class TestKojiPromote(object):
         tasker, workflow = mock_environment(tmpdir,
                                             session=session,
                                             is_rebuild=False,
-                                            name='name',
+                                            name='ns/name',
                                             version='1.0',
                                             release='1')
         runner = create_runner(tasker, workflow)
@@ -289,7 +289,9 @@ class TestKojiPromote(object):
             runner.run()
 
     def test_koji_promote_no_build_env(self, tmpdir):
-        tasker, workflow = mock_environment(tmpdir, name='name', version='1.0',
+        tasker, workflow = mock_environment(tmpdir,
+                                            name='ns/name',
+                                            version='1.0',
                                             release='1')
         runner = create_runner(tasker, workflow)
 
@@ -300,7 +302,9 @@ class TestKojiPromote(object):
             runner.run()
 
     def test_koji_promote_no_build_metadata(self, tmpdir):
-        tasker, workflow = mock_environment(tmpdir, name='name', version='1.0',
+        tasker, workflow = mock_environment(tmpdir,
+                                            name='ns/name',
+                                            version='1.0',
                                             release='1')
         runner = create_runner(tasker, workflow)
 
@@ -311,7 +315,7 @@ class TestKojiPromote(object):
 
     def test_koji_promote_invalid_creation_timestamp(self, tmpdir):
         tasker, workflow = mock_environment(tmpdir,
-                                            name='name',
+                                            name='ns/name',
                                             version='1.0',
                                             release='1')
         runner = create_runner(tasker, workflow)
@@ -328,7 +332,7 @@ class TestKojiPromote(object):
     def test_koji_promote_wrong_source_type(self, tmpdir):
         source = PathSource('path', 'file:///dev/null')
         tasker, workflow = mock_environment(tmpdir,
-                                            name='name',
+                                            name='ns/name',
                                             version='1.0',
                                             release='1',
                                             source=source)
@@ -364,7 +368,7 @@ class TestKojiPromote(object):
     def test_koji_promote_krb_args(self, tmpdir, params):
         session = MockedClientSession('')
         expectation = flexmock(session).should_receive('krb_login')
-        name = 'name'
+        name = 'ns/name'
         version = '1.0'
         release = '1'
         tasker, workflow = mock_environment(tmpdir,
@@ -392,7 +396,7 @@ class TestKojiPromote(object):
             .once())
         tasker, workflow = mock_environment(tmpdir,
                                             session=session,
-                                            name='name',
+                                            name='ns/name',
                                             version='1.0',
                                             release='1')
         runner = create_runner(tasker, workflow)
@@ -407,7 +411,7 @@ class TestKojiPromote(object):
             .once())
         tasker, workflow = mock_environment(tmpdir,
                                             session=session,
-                                            name='name',
+                                            name='ns/name',
                                             version='1.0',
                                             release='1')
         runner = create_runner(tasker, workflow, ssl_certs=True)
@@ -631,7 +635,7 @@ class TestKojiPromote(object):
     def test_koji_promote_success(self, tmpdir, apis, image_keys,
                                   metadata_only):
         session = MockedClientSession('')
-        name = 'name'
+        name = 'ns/name'
         version = '1.0'
         release = '1'
         tasker, workflow = mock_environment(tmpdir,

--- a/tests/plugins/test_koji_promote.py
+++ b/tests/plugins/test_koji_promote.py
@@ -632,7 +632,7 @@ class TestKojiPromote(object):
             mdonly = set(['metadata_only'])
 
         output_filename = 'koji_promote-{0}.json'.format(apis)
-        with open(output_filename, 'wb') as out:
+        with open(output_filename, 'w') as out:
             json.dump(data, out, sort_keys=True, indent=4)
 
         assert set(data.keys()) == set([


### PR DESCRIPTION
When reporting pushed images, don't just look at the results of the `pulp_push` plugin.

For v1: report only `pulp_push` results
For v1+v2: report `pulp_push` and `pulp_sync` results
For v2: report only `pulp_sync` results

As osbs-client will configure pulp_push and pulp_sync according to whether v1 and/or v2 is in use, all we need to do is collect the results from both pulp plugins.

If pulp is not used, report `tag_and_push` results (now modifed to return `ImageName` instances).