### PR TITLE
Move push_tar_to_pulp into atomic-reactor codebase

### DIFF
--- a/atomic_reactor/plugins/post_push_to_pulp.py
+++ b/atomic_reactor/plugins/post_push_to_pulp.py
@@ -135,8 +135,7 @@ class PulpUploader(object):
             new_repos.append(new_repo_key)
         return new_repos
 
-    def do_push_tar_to_pulp(self, p, repos_tags_mapping, tarfile, missing_repos_info={},
-                            repo_prefix="redhat-"):
+    def do_push_tar_to_pulp(self, p, repos_tags_mapping, tarfile, repo_prefix="redhat-"):
         """
         repos_tags_mapping is mapping between repo-ids, registry-ids and tags
         which should be applied to those repos, expected structure:
@@ -166,15 +165,8 @@ class PulpUploader(object):
         missing_repos = set(repos) - set(found_repo_ids)
         self.log.info("Missing repos: %s" % missing_repos)
         for repo in missing_repos:
-            kwargs = {}
-            #print missing_repos_info
-            if repo in missing_repos_info:
-                kwargs = {"title": missing_repos_info[repo].get("title"),
-                          "desc": missing_repos_info[repo].get("desc")}
-                #print kwargs
             p.createRepo(repo, "/pulp/docker/%s" % repo,
                          registry_id=mod_repos_tags_mapping[repo]["registry-id"],
-                         desc=kwargs.get("desc"), title=kwargs.get("title"),
                          prefix_with=repo_prefix)
 
         top_layer = dockpulp.imgutils.get_top_layer(pulp_md)

--- a/tests/plugins/test_pulp.py
+++ b/tests/plugins/test_pulp.py
@@ -64,7 +64,29 @@ def prepare(check_repo_retval=0):
      .should_receive('set_certs')
      .with_args(object, object))
     (flexmock(dockpulp.Pulp)
-     .should_receive('push_tar_to_pulp')
+     .should_receive('getRepos')
+     .with_args(list, fields=list)
+     .and_return([
+         {"id": "redhat-image-name1"},
+         {"id": "redhat-prefix-image-name2"}
+      ]))
+    (flexmock(dockpulp.Pulp)
+     .should_receive('createRepo'))
+    (flexmock(dockpulp.Pulp)
+     .should_receive('upload')
+     .with_args(unicode))
+    (flexmock(dockpulp.Pulp)
+     .should_receive('copy')
+     .with_args(unicode, unicode))
+    (flexmock(dockpulp.Pulp)
+     .should_receive('updateRepo')
+     .with_args(unicode, dict))
+    (flexmock(dockpulp.Pulp)
+     .should_receive('crane')
+     .with_args(list, wait=True)
+     .and_return([2, 3, 4]))
+    (flexmock(dockpulp.Pulp)
+     .should_receive('')
      .with_args(object, object)
      .and_return([1, 2, 3]))
     (flexmock(dockpulp.Pulp)
@@ -105,8 +127,8 @@ def test_pulp_source_secret(tmpdir, check_repo_retval, should_raise):
     runner.run()
     assert PulpPushPlugin.key is not None
     images = [i.to_str() for i in workflow.postbuild_results[PulpPushPlugin.key]]
-    assert "registry.example.com/image-name1" in images
-    assert "registry.example.com/prefix/image-name2" in images
+    assert "registry.example.com/image-name1:latest" in images
+    assert "registry.example.com/prefix/image-name2:latest" in images
     assert "registry.example.com/image-name3:asd" in images
 
 
@@ -129,6 +151,6 @@ def test_pulp_service_account_secret(tmpdir):
 
     runner.run()
     images = [i.to_str() for i in workflow.postbuild_results[PulpPushPlugin.key]]
-    assert "registry.example.com/image-name1" in images
-    assert "registry.example.com/prefix/image-name2" in images
+    assert "registry.example.com/image-name1:latest" in images
+    assert "registry.example.com/prefix/image-name2:latest" in images
     assert "registry.example.com/image-name3:asd" in images


### PR DESCRIPTION
This should work with release-engineering/dockpulp master.

I tried to do some refactoring and broke the changes into multiple commits to make review easier. It would probably be better to squash them before merging.