### PR TITLE
tag_by_labels: avoid needless warning message

### DIFF
--- a/atomic_reactor/plugins/post_tag_by_labels.py
+++ b/atomic_reactor/plugins/post_tag_by_labels.py
@@ -30,7 +30,8 @@ class TagByLabelsPlugin(PostBuildPlugin):
         """
         # call parent constructor
         super(TagByLabelsPlugin, self).__init__(tasker, workflow)
-        self.log.warning("ignoring arguments %s", kwargs)
+        if kwargs:
+            self.log.warning("ignoring arguments %s", kwargs)
 
     def run(self):
         if not self.workflow.built_image_inspect:


### PR DESCRIPTION
We don't need this log message every build:

```
atomic_reactor.plugins.tag_by_labels - WARNING - ignoring arguments {}
```