### PR TITLE
pulp_sync: new delete_from_registry parameter

### DIFF
--- a/atomic_reactor/plugins/post_pulp_sync.py
+++ b/atomic_reactor/plugins/post_pulp_sync.py
@@ -90,6 +90,7 @@ class PulpSyncPlugin(PostBuildPlugin):
     def __init__(self, tasker, workflow,
                  pulp_registry_name,
                  docker_registry,
+                 delete_from_registry=False,
                  pulp_secret_path=None,
                  username=None, password=None,
                  dockpulp_loglevel=None):
@@ -101,6 +102,8 @@ class PulpSyncPlugin(PostBuildPlugin):
         :param pulp_registry_name: str, name of pulp registry to use,
                specified in /etc/dockpulp.conf
         :param docker_registry: str, URL of docker registry to sync from
+        :param delete_from_registry: bool, whether to delete the image
+               from the docker v2 registry after sync
         :param pulp_secret_path: path to pulp.cer and pulp.key
         :param username: pulp username, used in preference to
                certificate and key
@@ -122,6 +125,10 @@ class PulpSyncPlugin(PostBuildPlugin):
             except (ValueError, TypeError) as ex:
                 self.log.error("Can't set provided log level %r: %r",
                                dockpulp_loglevel, ex)
+
+        if delete_from_registry:
+            self.log.error("will not delete from registry as instructed: "
+                           "not implemented")
 
     def set_auth(self, pulp):
         if self.username and self.password:

--- a/tests/plugins/test_pulp_sync.py
+++ b/tests/plugins/test_pulp_sync.py
@@ -274,3 +274,28 @@ class TestPostPulpSync(object):
             assert len(errors) >= 1
         else:
             assert not errors
+
+    def test_delete_not_implemented(self, caplog):
+        """
+        Should log an error (but not raise an exception) when
+        delete_from_registry is True.
+        """
+        mockpulp = MockPulp()
+        (flexmock(mockpulp)
+            .should_receive('syncRepo')
+            .and_return([{'id':''}]))
+        flexmock(dockpulp).should_receive('Pulp').and_return(mockpulp)
+        plugin = PulpSyncPlugin(tasker=None,
+                                workflow=self.workflow(['prod/myrepository']),
+                                pulp_registry_name='pulp',
+                                docker_registry='http://registry.example.com',
+                                delete_from_registry=True,
+                                username='username', password='password')
+
+        plugin.run()
+
+        errors = [record.getMessage() for record in caplog.records()
+                  if record.levelname == 'ERROR']
+
+        assert [message for message in errors
+                if 'not implemented' in message]


### PR DESCRIPTION
Currently not implemented. Logs an error if set but does not raise an exception.