### PR TITLE
Log warnings issued by the warnings module

### DIFF
--- a/atomic_reactor/cli/main.py
+++ b/atomic_reactor/cli/main.py
@@ -265,6 +265,13 @@ class CLI(object):
     def run(self):
         self.set_arguments()
         args = self.parser.parse_args()
+        try:
+            # Capture any warning.warn() calls and log them
+            logging.captureWarnings(True)
+        except AttributeError:
+            # Python 2.6 doesn't have captureWarnings()
+            pass
+
         if args.verbose:
             set_logging(level=logging.DEBUG)
         elif args.quiet:


### PR DESCRIPTION
The `docker` module uses the `warnings` module for deprecation messages. Make sure these get logged.