### PR TITLE
Fix label alias overrides

### DIFF
--- a/atomic_reactor/plugins/pre_add_labels_in_df.py
+++ b/atomic_reactor/plugins/pre_add_labels_in_df.py
@@ -130,7 +130,7 @@ class AddLabelsPlugin(PreBuildPlugin):
 
         for old, new in self.aliases.items():
             if old in all_labels:
-                if new in all_labels:
+                if new in df_labels:
                     if all_labels[old] != all_labels[new]:
                         self.log.warning("labels %r=%r and %r=%r should probably have same value",
                                          old, all_labels[old], new, all_labels[new])

--- a/tests/plugins/test_add_labels.py
+++ b/tests/plugins/test_add_labels.py
@@ -87,6 +87,14 @@ EXPECTED_OUTPUT7 = [r"""FROM fedora
 LABEL "label2"="df value"
 LABEL "labelnew"="df value"
 """]
+EXPECTED_OUTPUT8 = [r"""FROM fedora
+LABEL "label1"="df value"
+LABEL "label2"="df value"
+""", r"""FROM fedora
+LABEL "label2"="df value"
+LABEL "label1"="df value"
+""",
+]
 
 @pytest.mark.parametrize('df_content, labels_conf_base, labels_conf, dont_overwrite, aliases, expected_output', [
     (DF_CONTENT, LABELS_CONF_BASE, LABELS_CONF, [], {}, EXPECTED_OUTPUT),
@@ -100,7 +108,7 @@ LABEL "labelnew"="df value"
     (DF_CONTENT_SINGLE_LINE, LABELS_CONF_BASE, LABELS_CONF_ONE, [], {"label2": "labelnew"}, EXPECTED_OUTPUT6),
     (DF_CONTENT_LABEL, LABELS_CONF_BASE, LABELS_BLANK, [], {"label2": "labelnew"}, EXPECTED_OUTPUT7),
     (DF_CONTENT_LABEL, LABELS_CONF_BASE, LABELS_BLANK, [], {"label2": "labelnew", "x": "y"}, EXPECTED_OUTPUT7),
-    (DF_CONTENT_LABEL, LABELS_CONF_BASE, LABELS_BLANK, [], {"label2": "label1"}, DF_CONTENT_LABEL),
+    (DF_CONTENT_LABEL, LABELS_CONF_BASE, LABELS_BLANK, [], {"label2": "label1"}, EXPECTED_OUTPUT8),
 ])
 def test_add_labels_plugin(tmpdir, docker_tasker,
                            df_content, labels_conf_base, labels_conf, dont_overwrite, aliases, expected_output):


### PR DESCRIPTION
When the base image has the new name for a label and the Dockerfile has the old name, we must add the new name in as well in order to override the inherited value.

If we don't do this, built images will have names corresponding to their parents.