### PR TITLE
core,push: use wait_for_command for parsing logs

### DIFF
--- a/atomic_reactor/plugins/post_tag_and_push.py
+++ b/atomic_reactor/plugins/post_tag_and_push.py
@@ -9,7 +9,7 @@ of the BSD license. See the LICENSE file for details.
 from copy import deepcopy
 import re
 
-from atomic_reactor.plugin import PostBuildPlugin, PluginFailedException
+from atomic_reactor.plugin import PostBuildPlugin
 
 
 __all__ = ('TagAndPushPlugin', )
@@ -59,8 +59,6 @@ class TagAndPushPlugin(PostBuildPlugin):
                                                       registry_image, insecure=insecure,
                                                       force=True)
 
-                self.check_for_errors(logs, insecure=insecure)
-
                 pushed_images.append(registry_image)
 
                 digest = self.extract_digest(logs)
@@ -69,22 +67,6 @@ class TagAndPushPlugin(PostBuildPlugin):
                     push_conf_registry.digests[tag] = digest
 
         return pushed_images
-
-    def check_for_errors(self, logs, insecure=False):
-        for message in logs:
-            if 'error' in message:
-                msg = "while pushing: {0}".format(message['error'])
-                self.log.error(msg)
-                if 'errorDetail' in message:
-                    detail = message['errorDetail'].get('message')
-                    if detail:
-                        self.log.error("error detail: %s", detail)
-
-                if insecure:
-                    self.log.error("perhaps you need to provide "
-                                   "--insecure-registry to docker daemon?")
-
-                raise PluginFailedException(msg)
 
     @staticmethod
     def extract_digest(logs):

--- a/tests/plugins/test_tag_and_push.py
+++ b/tests/plugins/test_tag_and_push.py
@@ -59,7 +59,7 @@ class X(object):
 def test_tag_and_push_plugin(tmpdir, image_name, logs, should_raise):
     if MOCK:
         mock_docker()
-        flexmock(docker.Client, push=lambda iid, **kwargs: logs)
+        flexmock(docker.Client, push=lambda iid, **kwargs: iter(logs))
 
     tasker = DockerTasker()
     workflow = DockerBuildWorkflow({"provider": "git", "uri": "asd"}, TEST_IMAGE)


### PR DESCRIPTION
I've just realized this slightly conflicts with @twaugh's patch: https://github.com/projectatomic/atomic-reactor/commit/a770fdc20efda4b46ff8a9baf2031dd415994fff