### PR TITLE
Revert to using old label set in plugins

### DIFF
--- a/atomic_reactor/plugins/exit_sendmail.py
+++ b/atomic_reactor/plugins/exit_sendmail.py
@@ -41,7 +41,7 @@ class SendMailPlugin(ExitPlugin):
                     # optional arguments follow
                     "submitter": "John Smith <jsmith@mycompany.com>",
                     "pdc_verify_cert": true,
-                    "pdc_component_df_label": "com.redhat.component",
+                    "pdc_component_df_label": "BZComponent",
                     "pdc_contact_role": "Devel_Owner"
                 }
         }]
@@ -61,7 +61,7 @@ class SendMailPlugin(ExitPlugin):
     PDC_CONTACT_ROLE = 'Devel_Owner'
 
     def __init__(self, tasker, workflow, send_on=None, url=None, submitter='unknown', pdc_url=None,
-                 pdc_verify_cert=True, pdc_component_df_label="com.redhat.component", pdc_secret_path=None,
+                 pdc_verify_cert=True, pdc_component_df_label="BZComponent", pdc_secret_path=None,
                  pdc_contact_role=None, smtp_uri=None, from_address=None,
                  error_addresses=None):
         """

--- a/atomic_reactor/plugins/post_tag_by_labels.py
+++ b/atomic_reactor/plugins/post_tag_by_labels.py
@@ -14,9 +14,9 @@ __all__ = ('TagByLabelsPlugin', )
 
 class TagByLabelsPlugin(PostBuildPlugin):
     """
-    Use labels name, version and release of final image and create tags:
-     * name:version
-     * name:version-release
+    Use labels Name, Version and Release of final image and create tags:
+     * Name:Version
+     * Name:Version-Release
     """
     key = "tag_by_labels"
     is_allowed_to_fail = False
@@ -46,9 +46,9 @@ class TagByLabelsPlugin(PostBuildPlugin):
             except KeyError:
                 raise RuntimeError("Missing label '%s'." % label_name)
 
-        name = get_label("name")
-        version = get_label("version")
-        release = get_label("release")
+        name = get_label("Name")
+        version = get_label("Version")
+        release = get_label("Release")
 
         unique_tag = self.workflow.builder.image.tag
 

--- a/atomic_reactor/plugins/pre_add_dockerfile.py
+++ b/atomic_reactor/plugins/pre_add_dockerfile.py
@@ -11,8 +11,8 @@ Include user-provided Dockerfile in the /root/buildinfo/
 This is accomplished by appending an ADD command to it.
 Name of the Dockerfile is changed to include N-V-R of the build.
 N-V-R is specified either by nvr argument OR from
-name/version/release labels in Dockerfile.
-If you run add_labels_in_dockerfile to add name/version/release labels
+Name/Version/Release labels in Dockerfile.
+If you run add_labels_in_dockerfile to add Name/Version/Release labels
 you have to run it BEFORE this one.
 
 
@@ -26,9 +26,9 @@ or
 
 [{
    'name': 'add_labels_in_dockerfile',
-   'args': {'labels': {'name': 'jboss-eap-6-docker',
-                       'version': '6.4',
-                       'release': '77'}}
+   'args': {'labels': {'Name': 'jboss-eap-6-docker',
+                       'Version': '6.4',
+                       'Release': '77'}}
 },
 {
    'name': 'add_dockerfile'
@@ -55,7 +55,7 @@ class AddDockerfilePlugin(PreBuildPlugin):
         :param tasker: DockerTasker instance
         :param workflow: DockerBuildWorkflow instance
         :param nvr: name-version-release, will be appended to Dockerfile-.
-                    If not specified, try to get it from name, version, release labels.
+                    If not specified, try to get it from Name, Version, Release labels.
         :param destdir: directory in the image to put Dockerfile-N-V-R into
         :param use_final_dockerfile: bool, when set to True, uses final version of processed dockerfile,
                                      when set to False, uses Dockerfile from time when this plugin was executed
@@ -71,7 +71,7 @@ class AddDockerfilePlugin(PreBuildPlugin):
             version = get_preferred_label(labels, 'version')
             release = get_preferred_label(labels, 'release')
             if name is None or version is None or release is None:
-                raise ValueError("You have to specify either nvr arg or name/version/release labels.")
+                raise ValueError("You have to specify either nvr arg or Name/Version/Release labels.")
             nvr = "{0}-{1}-{2}".format(name, version, release)
             nvr = nvr.replace("/", "-")
         self.df_name = '{0}-{1}'.format(DOCKERFILE_FILENAME, nvr)

--- a/atomic_reactor/plugins/pre_assert_labels.py
+++ b/atomic_reactor/plugins/pre_assert_labels.py
@@ -6,7 +6,7 @@ This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 
 
-Make sure Dockerfile contains name/version/release
+Make sure Dockerfile contains Name/Version/Release
 (or others if specified) labels.
 """
 
@@ -30,7 +30,7 @@ class AssertLabelsPlugin(PreBuildPlugin):
         # call parent constructor
         super(AssertLabelsPlugin, self).__init__(tasker, workflow)
 
-        self.required_labels = required_labels or ['name', 'version', 'release']
+        self.required_labels = required_labels or ['Name', 'Version', 'Release']
 
     def run(self):
         """

--- a/atomic_reactor/plugins/pre_bump_release.py
+++ b/atomic_reactor/plugins/pre_bump_release.py
@@ -80,7 +80,7 @@ class GitRepo(object):
 class BumpReleasePlugin(PreBuildPlugin):
     """Git branch management plugin
 
-    For rebuilds, push a new commit incrementing the "release" label.
+    For rebuilds, push a new commit incrementing the Release label.
 
     For initial builds, verify the branch is at the specified commit
     hash.
@@ -240,15 +240,11 @@ class BumpReleasePlugin(PreBuildPlugin):
         if self.push_url:
             repo.git(['remote', 'set-url', '--push', remote, self.push_url])
 
-        # Find out which label to use - we can't rely on pre_add_labels_in_df adding alias as it
-        # will run after the bump plugin
-        # XXX: remove the logic after transition to the new label set
+        # Bump the Release label
         df_path = self.workflow.builder.df_path
         parser = DockerfileParser(df_path)
-
         label_key = get_preferred_label_key(parser.labels, 'release')
 
-        # Bump the release label
         attrs, key = self.find_current_release(parser, label_key)
         next_release = self.get_next_release(attrs[key])
         self.log.info("New Release: %s", next_release)

--- a/tests/plugins/test_add_dockerfile.py
+++ b/tests/plugins/test_add_dockerfile.py
@@ -103,7 +103,7 @@ def test_adddockerfile_nvr_from_labels(tmpdir, docker_tasker):
     df_content = """
 FROM fedora
 RUN yum install -y python-django
-LABEL name="jboss-eap-6-docker" "version"="6.4" "release"=77
+LABEL Name="jboss-eap-6-docker" "Version"="6.4" "Release"=77
 CMD blabla"""
     df = DockerfileParser(str(tmpdir))
     df.content = df_content
@@ -126,13 +126,7 @@ CMD blabla"""
     assert "ADD Dockerfile-jboss-eap-6-docker-6.4-77 /root/buildinfo/Dockerfile-jboss-eap-6-docker-6.4-77" in df.content
 
 
-@pytest.mark.parametrize('add_labels, aliases', [
-    ({'name': 'jboss-eap-6-docker', 'version': '6.4', 'release': '77'},
-     None),
-    ({'Name': 'jboss-eap-6-docker', 'Version': '6.4', 'Release': '77'},
-     {'Name': 'name', 'Version': 'version', 'Release': 'release'}),
-])
-def test_adddockerfile_nvr_from_labels2(tmpdir, docker_tasker, add_labels, aliases):
+def test_adddockerfile_nvr_from_labels2(tmpdir, docker_tasker):
     df_content = """
 FROM fedora
 RUN yum install -y python-django
@@ -154,9 +148,10 @@ CMD blabla"""
         workflow,
         [{
             'name': AddLabelsPlugin.key,
-            'args': {'labels': add_labels,
-                     'auto_labels': [],
-                     'aliases': aliases}
+            'args': {'labels': {'Name': 'jboss-eap-6-docker',
+                                'Version': '6.4',
+                                'Release': '77'},
+                     'auto_labels': []}
          },
          {
             'name': AddDockerfilePlugin.key

--- a/tests/plugins/test_assert_labels.py
+++ b/tests/plugins/test_assert_labels.py
@@ -33,7 +33,7 @@ DF_CONTENT = """
 FROM fedora
 RUN yum install -y python-django
 CMD blabla"""
-DF_CONTENT_LABELS = DF_CONTENT+'\nLABEL "name"="rainbow" "version"="123" "release"="1"'
+DF_CONTENT_LABELS = DF_CONTENT+'\nLABEL "Name"="rainbow" "Version"="123" "Release"="1"'
 
 @pytest.mark.parametrize('df_content, req_labels, expected', [
     (DF_CONTENT, None, PluginFailedException()),

--- a/tests/plugins/test_bump_release.py
+++ b/tests/plugins/test_bump_release.py
@@ -43,7 +43,7 @@ class DFWithRelease(object):
     def __init__(self, label=None, lines=None):
         self.path = tempfile.mkdtemp()
         if label is None and lines is None:
-            label = "LABEL release 1"
+            label = "LABEL Release 1"
 
         if lines is None:
             lines = ['FROM baseimage\n',
@@ -193,36 +193,36 @@ def test_bump_release_branch_not_found(tmpdir):
                     reason="pygit2 required for this test")
 @pytest.mark.parametrize(('label', 'expected'), [
     # Simple case, no '=' or quotes
-    ('LABEL release 1',
-     'LABEL release 2'),
+    ('LABEL Release 1',
+     'LABEL Release 2'),
 
     # No '=' but quotes
-    ('LABEL "release" "2"',
-     'LABEL release 3'),
+    ('LABEL "Release" "2"',
+     'LABEL Release 3'),
 
     # Deal with another label
-    ('LABEL release 3\nLABEL Name foo',
-     'LABEL release 4'),
+    ('LABEL Release 3\nLABEL Name foo',
+     'LABEL Release 4'),
 
     # Simple case, '=' but no quotes
-    ('LABEL release=1',
-     'LABEL release=2'),
+    ('LABEL Release=1',
+     'LABEL Release=2'),
 
     # '=' and quotes
-    ('LABEL "release"="2"',
-     'LABEL release=3'),
+    ('LABEL "Release"="2"',
+     'LABEL Release=3'),
 
     # '=', multiple labels, no quotes
-    ('LABEL Name=foo release=3',
-     'LABEL Name=foo release=4'),
+    ('LABEL Name=foo Release=3',
+     'LABEL Name=foo Release=4'),
 
     # '=', multiple labels and quotes
-    ('LABEL Name=foo "release"="4"',
-     'LABEL Name=foo release=5'),
+    ('LABEL Name=foo "Release"="4"',
+     'LABEL Name=foo Release=5'),
 
-    # release that's not entirely numeric
-    ('LABEL release=1.1',
-     'LABEL release=2.1'),
+    # Release that's not entirely numeric
+    ('LABEL Release=1.1',
+     'LABEL Release=2.1'),
 ])
 def test_bump_release_direct(tmpdir, label, expected):
     with DFWithRelease(label=label) as (df_path, commit):
@@ -271,7 +271,7 @@ def test_bump_release_direct(tmpdir, label, expected):
 def test_bump_release_indirect_correct(tmpdir, labelval):
     dflines = ['FROM fedora\n',
                'ENV RELEASE=1\n',
-               'LABEL release={0}\n'.format(labelval)]
+               'LABEL Release={0}\n'.format(labelval)]
     with DFWithRelease(lines=dflines) as (df_path, commit):
         dummy_workflow, dummy_args, runner = prepare(tmpdir, df_path, commit)
         labels_before = DockerfileParser(df_path, env_replace=False).labels
@@ -315,7 +315,7 @@ def test_bump_release_indirect_correct(tmpdir, labelval):
 def test_bump_release_indirect_incorrect(tmpdir, labelval):
     dflines = ['FROM fedora\n',
                'ENV RELEASE=1\n',
-               'LABEL release={0}\n'.format(labelval)]
+               'LABEL Release={0}\n'.format(labelval)]
     with DFWithRelease(lines=dflines) as (df_path, commit):
         dummy_workflow, dummy_args, runner = prepare(tmpdir, df_path, commit)
 

--- a/tests/plugins/test_tag_by_labels.py
+++ b/tests/plugins/test_tag_by_labels.py
@@ -44,9 +44,9 @@ def test_tag_by_labels_plugin(tmpdir):
     workflow.built_image_inspect = {
         "ContainerConfig": {
             "Labels": {
-                "name": TEST_IMAGE,
-                "version": version,
-                "release": release
+                "Name": TEST_IMAGE,
+                "Version": version,
+                "Release": release
             }
         }
     }


### PR DESCRIPTION
Since we don't use the new labels and label aliases are turned off (#389), prod builds end with following error:

```
2015-12-10 21:32:54,469 - atomic_reactor.plugin - DEBUG - Traceback
(most recent call last):
  File "/usr/lib/python2.7/site-packages/atomic_reactor-1.6.0-py2.7.egg/atomic_reactor/plugin.py",
line 203, in run
    plugin_response = plugin_instance.run()
  File "/usr/lib/python2.7/site-packages/atomic_reactor-1.6.0-py2.7.egg/atomic_reactor/plugins/post_tag_by_labels.py", line 49, in run
    name = get_label("name")
  File "/usr/lib/python2.7/site-packages/atomic_reactor-1.6.0-py2.7.egg/atomic_reactor/plugins/post_tag_by_labels.py", line 47, in get_label
    raise RuntimeError("Missing label '%s'." % label_name)
RuntimeError: Missing label 'name'.
```

This reverts commit 605314d. The pull request that introduced it (#349) also contains another commit (5d20f7b) which uses the new labels only if available, thus I'm leaving it unreverted (good idea?).
