### PR TITLE
Retry 'FROM' layer pull with library namespace on failure

### DIFF
--- a/atomic_reactor/plugins/pre_pull_base_image.py
+++ b/atomic_reactor/plugins/pre_pull_base_image.py
@@ -60,6 +60,14 @@ class PullBaseImagePlugin(PreBuildPlugin):
 
         pulled_base = self.tasker.pull_image(base_image_with_registry,
                                              insecure=self.parent_registry_insecure)
+        if (base_image_with_registry.namespace != 'library' and
+                not self.tasker.image_exists(base_image_with_registry.to_str())):
+            self.log.info("'%s' not found", base_image_with_registry.to_str())
+            base_image_with_registry.namespace = 'library'
+            self.log.info("trying '%s'", base_image_with_registry.to_str())
+            pulled_base = self.tasker.pull_image(base_image_with_registry,
+                                                 insecure=self.parent_registry_insecure)
+
         self.workflow.pulled_base_images.add(pulled_base)
 
         if not base_image.registry:

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -52,10 +52,6 @@ class ImageName(object):
         elif len(s) == 3:
             result.registry = s[0]
             result.namespace = s[1]
-        if result.namespace == 'library':
-            # https://github.com/projectatomic/atomic-reactor/issues/45
-            logger.debug("namespace 'library' -> ''")
-            result.namespace = None
         result.repo = s[-1]
 
         try:

--- a/tests/docker_mock.py
+++ b/tests/docker_mock.py
@@ -63,6 +63,9 @@ mock_pull_logs = \
      b'{"status":"Download complete","progressDetail":{},"id":"8c2e06607696"}',
      b'{"status":"Status: Image is up to date for localhost:5000/busybox:latest"}\r\n']
 
+mock_pull_logs_failed = \
+    [b'{"errorDetail":{"message":"Error: image ***:latest not found"},"error":"Error: image ***:latest not found"}']
+
 mock_push_logs = \
     [b'{"status":"The push refers to a repository [localhost:5000/busybox] (len: 1)"}\r\n',
      b'{"status":"Image already exists","progressDetail":{},"id":"17583c7dd0da"}\r\n',
@@ -164,6 +167,10 @@ def _docker_exception(code=404, content='not found'):
     return docker.errors.APIError(code, response)
 
 def _mock_pull(repo, tag='latest', **kwargs):
+    im = ImageName.parse(repo)
+    if im.repo == 'library-only' and im.namespace != 'library':
+        return iter(mock_pull_logs_failed)
+
     repotag = '%s:%s' % (repo, tag)
     if _find_image(repotag) is None:
         new_image = mock_image.copy()

--- a/tests/plugins/test_pull_base_image.py
+++ b/tests/plugins/test_pull_base_image.py
@@ -76,6 +76,14 @@ BASE_IMAGE_W_LIB_REG = LOCALHOST_REGISTRY + "/" + BASE_IMAGE_W_LIBRARY
      [],
      # not expected:
      [BASE_IMAGE_W_REGISTRY]),
+
+    # For this test, ensure 'library-only' is only available through
+    # the 'library' namespace. docker_mock takes care of this when
+    # mocking.
+    (LOCALHOST_REGISTRY, "library-only:latest",
+     # expected:
+     [LOCALHOST_REGISTRY + "/library/library-only:latest"],
+     [LOCALHOST_REGISTRY + "/library-only:latest"]),
 ])
 def test_pull_base_image_plugin(parent_registry, df_base, expected, not_expected):
     if MOCK:

--- a/tests/plugins/test_pull_base_image.py
+++ b/tests/plugins/test_pull_base_image.py
@@ -29,15 +29,55 @@ class MockBuilder(object):
     source = MockSource()
     base_image = None
 
-BASE_IMAGE = "ubuntu:latest"
+BASE_IMAGE = "busybox:latest"
+BASE_IMAGE_W_LIBRARY = "library/" + BASE_IMAGE
 BASE_IMAGE_W_REGISTRY = LOCALHOST_REGISTRY + "/" + BASE_IMAGE
-@pytest.mark.parametrize('df_base,parent_registry,expected_w_reg,expected_wo_reg', [
-    (BASE_IMAGE,            LOCALHOST_REGISTRY, True, True),
-    (BASE_IMAGE_W_REGISTRY, LOCALHOST_REGISTRY, True, True),
-    (BASE_IMAGE,            None,               False, True),
-    (BASE_IMAGE_W_REGISTRY, None,               True, True),
+BASE_IMAGE_W_LIB_REG = LOCALHOST_REGISTRY + "/" + BASE_IMAGE_W_LIBRARY
+@pytest.mark.parametrize(('parent_registry',
+                          'df_base',     # the base image is always expected
+                          'expected',    # additional expected images
+                          'not_expected' # additional images not expected
+), [
+    #expected_w_reg,expected_w_lib_reg,expected_wo_reg', [
+    (LOCALHOST_REGISTRY, BASE_IMAGE,
+     # expected:
+     [BASE_IMAGE_W_REGISTRY],
+     # not expected:
+     [BASE_IMAGE_W_LIB_REG]),
+
+    (LOCALHOST_REGISTRY, BASE_IMAGE_W_REGISTRY,
+     # expected:
+     [BASE_IMAGE_W_REGISTRY],
+     # not expected:
+     [BASE_IMAGE_W_LIB_REG]),
+
+    (None, BASE_IMAGE,
+     # expected:
+     [],
+     # not expected:
+     [BASE_IMAGE_W_REGISTRY, BASE_IMAGE_W_LIB_REG]),
+
+    (None, BASE_IMAGE_W_REGISTRY,
+     # expected:
+     [BASE_IMAGE_W_REGISTRY],
+     # not expected:
+     [BASE_IMAGE_W_LIB_REG]),
+
+    # Tests with explicit "library" namespace:
+
+    (LOCALHOST_REGISTRY, BASE_IMAGE_W_LIB_REG,
+     # expected:
+     [],
+     # not expected:
+     [BASE_IMAGE_W_REGISTRY]),
+
+    (None, BASE_IMAGE_W_LIB_REG,
+     # expected:
+     [],
+     # not expected:
+     [BASE_IMAGE_W_REGISTRY]),
 ])
-def test_pull_base_image_plugin(df_base, parent_registry, expected_w_reg, expected_wo_reg):
+def test_pull_base_image_plugin(parent_registry, df_base, expected, not_expected):
     if MOCK:
         mock_docker(remember_images=True)
 
@@ -46,8 +86,11 @@ def test_pull_base_image_plugin(df_base, parent_registry, expected_w_reg, expect
     workflow.builder = MockBuilder()
     workflow.builder.base_image = ImageName.parse(df_base)
 
-    assert not tasker.image_exists(BASE_IMAGE)
-    assert not tasker.image_exists(BASE_IMAGE_W_REGISTRY)
+    expected = set(expected)
+    expected.add(df_base)
+    all_images = set(expected).union(not_expected)
+    for image in all_images:
+        assert not tasker.image_exists(image)
 
     runner = PreBuildPluginsRunner(
         tasker,
@@ -60,16 +103,19 @@ def test_pull_base_image_plugin(df_base, parent_registry, expected_w_reg, expect
 
     runner.run()
 
-    assert tasker.image_exists(BASE_IMAGE) == expected_wo_reg
-    assert tasker.image_exists(BASE_IMAGE_W_REGISTRY) == expected_w_reg
+    for image in expected:
+        assert tasker.image_exists(image)
 
-    try:
-        tasker.remove_image(BASE_IMAGE)
-        tasker.remove_image(BASE_IMAGE_W_REGISTRY)
-    except:
-        pass
+    for image in not_expected:
+        assert not tasker.image_exists(image)
+
+    for image in all_images:
+        try:
+            tasker.remove_image(image)
+        except:
+            pass
 
 
 def test_pull_base_wrong_registry():
     with pytest.raises(PluginFailedException):
-        test_pull_base_image_plugin(BASE_IMAGE_W_REGISTRY, 'localhost:1234', True, False)
+        test_pull_base_image_plugin('localhost:1234', BASE_IMAGE_W_REGISTRY, [], [])

--- a/tests/test_tasker.py
+++ b/tests/test_tasker.py
@@ -261,17 +261,6 @@ def test_get_image_info_by_name_tag_in_name():
     assert len(response) == 1
 
 
-# https://github.com/projectatomic/atomic-reactor/issues/45
-def test_get_image_info_by_name_tag_in_name_library():
-    if MOCK:
-        mock_docker()
-
-    t = DockerTasker()
-    image_name = ImageName.parse("library/busybox")
-    response = t.get_image_info_by_image_name(image_name)
-    assert len(response) == 1
-
-
 def test_get_image_info_by_name_tag_in_name_nonexisten(temp_image_name):
     if MOCK:
         mock_docker()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -42,6 +42,7 @@ TEST_DATA = {
     "registry:5000/image-name": ImageName(registry="registry:5000", repo="image-name"),
     "fedora:20": ImageName(repo="fedora", tag="20"),
     "prefix/image-name:1": ImageName(namespace="prefix", repo="image-name", tag="1"),
+    "library/fedora:20": ImageName(namespace="library", repo="fedora", tag="20"),
     }
 
 


### PR DESCRIPTION
The library/ prefix is only special for Docker Hub. Stripping it out actually breaks V2 pulls for base images that are published as library/repo.