### PR TITLE
Avoid reporting duplicate pulp registries

### DIFF
--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -183,7 +183,7 @@ class PushConf(object):
     def __init__(self):
         self._registries = {
             "docker": [],
-            "pulp": [],
+            "pulp": {},  # name -> PulpRegistry
         }
 
     def add_docker_registry(self, registry_uri, insecure=False):
@@ -201,7 +201,7 @@ class PushConf(object):
         if crane_uri is None:
             raise RuntimeError("registry URI cannot be None")
         r = PulpRegistry(name, crane_uri)
-        self._registries["pulp"].append(r)
+        self._registries["pulp"][name] = r
         return r
 
     @property
@@ -214,7 +214,7 @@ class PushConf(object):
 
     @property
     def pulp_registries(self):
-        return self._registries["pulp"]
+        return [registry for registry in self._registries["pulp"].values()]
 
     @property
     def all_registries(self):

--- a/atomic_reactor/plugins/exit_koji_promote.py
+++ b/atomic_reactor/plugins/exit_koji_promote.py
@@ -392,10 +392,6 @@ class KojiPromotePlugin(ExitPlugin):
             image.registry = registry.uri
             pullspec = image.to_str()
 
-            # avoid duplicates
-            if pullspec in output_images:
-                continue
-
             output_images.append(image.to_str())
 
             digest = digests.get(image.to_str(registry=False))


### PR DESCRIPTION
This can happen when using both v1 and v2 Docker Registry APIs.
Previously the `koji_promote` plugin was explicitly avoiding duplicate registries. This logic has now been moved to `PushConf`.