### PR TITLE
pulp_push: omit redirect-url when creating repositories on demand

### DIFF
--- a/atomic_reactor/plugins/post_push_to_pulp.py
+++ b/atomic_reactor/plugins/post_push_to_pulp.py
@@ -136,7 +136,7 @@ class PulpUploader(object):
         missing_repos = set(repos) - set(found_repo_ids)
         self.log.info("Missing repos: %s" % ", ".join(missing_repos))
         for repo in missing_repos:
-            p.createRepo(repo, "/pulp/docker/%s" % repo,
+            p.createRepo(repo, None,
                          registry_id=pulp_repos[repo].registry_id,
                          prefix_with=repo_prefix)
 


### PR DESCRIPTION
When creating a Pulp repository on demand, do not set a redirect URL. By leaving as the default value, redirects will work correctly for both V1 and V2 with the default Pulp configuration (i.e. not CDN).

Note that `dockpulp.conf` will need an additional section to allow this, something like:

```
[redirect]
myenv = no
```

(see https://github.com/release-engineering/dockpulp/commit/da3260229c738355f9e32790de331f939b92ae1c)