### PR TITLE
compress: log compression ratio

### DIFF
--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -567,3 +567,12 @@ def get_build_json():
     except KeyError:
         logger.error("No $BUILD env variable. Probably not running in build container")
         raise
+
+# copypasted and slightly modified from
+# http://stackoverflow.com/questions/1094841/reusable-library-to-get-human-readable-version-of-file-size/1094933#1094933
+def human_size(num, suffix='B'):
+    for unit in ['','Ki','Mi','Gi','Ti','Pi','Ei','Zi']:
+        if abs(num) < 1024.0:
+            return "%3.2f %s%s" % (num, unit, suffix)
+        num /= 1024.0
+    return "%.2f %s%s" % (num, 'Yi', suffix)

--- a/tests/docker_mock.py
+++ b/tests/docker_mock.py
@@ -251,7 +251,7 @@ def mock_docker(build_should_fail=False,
     class GetImageResult(object):
         data = b''
         def __init__(self):
-            self.fp = open('/dev/null', 'rb')
+            self.fp = open(__file__, 'rb')
         def __getattr__(self, attr):
             return getattr(self, self.fp, attr)
         def __enter__(self):

--- a/tests/plugins/test_compress.py
+++ b/tests/plugins/test_compress.py
@@ -33,7 +33,7 @@ class TestCompress(object):
         ('lzma', False, 'xz'),
         ('gzip', True, 'gz'),
     ])
-    def test_compress(self, tmpdir, method, load_exported_image, extension):
+    def test_compress(self, tmpdir, caplog, method, load_exported_image, extension):
         if MOCK:
             mock_docker()
 
@@ -64,4 +64,8 @@ class TestCompress(object):
             workflow.source.tmpdir,
             EXPORTED_COMPRESSED_IMAGE_NAME_TEMPLATE.format(extension))
         assert os.path.exists(compressed_img)
-        assert workflow.exported_image_sequence[-1]['path'] == compressed_img
+        metadata = workflow.exported_image_sequence[-1]
+        assert metadata['path'] == compressed_img
+        assert 'uncompressed_size' in metadata
+        assert isinstance(metadata['uncompressed_size'], int)
+        assert ", ratio: " in caplog.text()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -22,7 +22,7 @@ import docker
 from atomic_reactor.util import ImageName, \
     wait_for_command, clone_git_repo, LazyGit, figure_out_dockerfile, render_yum_repo, \
     process_substitutions, get_checksums, print_version_of_tools, get_version_of_tools, \
-    get_preferred_label_key
+    get_preferred_label_key, human_size
 from tests.constants import DOCKERFILE_GIT, INPUT_IMAGE, MOCK, DOCKERFILE_SHA1
 from tests.util import requires_internet
 
@@ -207,3 +207,21 @@ def test_print_versions_of_tools():
 def test_preferred_labels(labels, name, expected):
     result = get_preferred_label_key(labels, name)
     assert result == expected
+
+@pytest.mark.parametrize('size_input,expected', [
+    (0, "0.00 B"),
+    (1, "1.00 B"),
+    (-1, "-1.00 B"),
+    (1536, "1.50 KiB"),
+    (-1024, "-1.00 KiB"),
+    (204800, "200.00 KiB"),
+    (6983516, "6.66 MiB"),
+    (14355928186, "13.37 GiB"),
+    (135734710448947, "123.45 TiB"),
+    (1180579814801204129310965, "999.99 ZiB"),
+    (1074589982539051580812825722, "888.88 YiB"),
+    (4223769947617154742438477168, "3493.82 YiB"),
+    (-4223769947617154742438477168, "-3493.82 YiB"),
+])
+def test_human_size(size_input, expected):
+    assert human_size(size_input) == expected


### PR DESCRIPTION
Closes #423.
Or do we want the uncompressed size in metadata as well?