### PR TITLE
exit_store_metadata_in_osv3: pass oauth url to get token if use_auth

### DIFF
--- a/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
+++ b/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
@@ -125,9 +125,12 @@ class StoreMetadataInOSv3Plugin(ExitPlugin):
         # initial setup will use host based auth: apache will be set to accept everything
         # from specific IP and will set specific X-Remote-User for such requests
         # FIXME: remove `openshift_uri` once osbs-client is released
+        config_kwargs = {}
+        if self.use_auth:
+            config_kwargs["openshift_oauth_url"] = "{}/oauth/authorize".format(self.url)
         osbs_conf = Configuration(conf_file=None, openshift_uri=self.url, openshift_url=self.url,
                                   use_auth=self.use_auth, verify_ssl=self.verify_ssl,
-                                  namespace=metadata.get('namespace', None))
+                                  namespace=metadata.get('namespace', None), **config_kwargs)
         osbs = OSBS(osbs_conf, osbs_conf)
 
         try:


### PR DESCRIPTION
Sometimes a weird error occured on slow envs and long builds:
```
2016-03-14 12:34:12,385 - atomic_reactor.plugin - INFO - running plugin instance with args: '{u'url': u'https://10.3.9.133:8443/', u'verify_ssl': False, u'use_auth': True}'
2016-03-14 12:34:12,386 - atomic_reactor.plugins.store_metadata_in_osv3 - INFO - build id = atomic-reactor-dockerfile-test-master-11
2016-03-14 12:34:13,493 - osbs.core - ERROR - [401] 'Location' header is missing in response, cannot retrieve token
2016-03-14 12:34:13,726 - atomic_reactor.plugin - DEBUG - Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/atomic_reactor-1.6.3-py2.7.egg/atomic_reactor/plugin.py", line 203, in run
    plugin_response = plugin_instance.run()
  File "/usr/lib/python2.7/site-packages/atomic_reactor-1.6.3-py2.7.egg/atomic_reactor/plugins/exit_store_metadata_in_osv3.py", line 166, in run
    osbs.set_annotations_on_build(build_id, labels, **kwargs)
  File "/usr/lib/python2.7/site-packages/osbs/api.py", line 39, in catch_exceptions
    raise OsbsException(cause=ex, traceback=sys.exc_info()[2])
OsbsException: ValueError(u'Token was not retrieved successfully.',)

Original traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/osbs/api.py", line 28, in catch_exceptions
    return func(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/osbs/api.py", line 315, in set_annotations_on_build
    return self.os.set_annotations_on_build(build_id, annotations, namespace=namespace)
  File "/usr/lib/python2.7/site-packages/osbs/core.py", line 328, in set_annotations_on_build
    build_json = self._get(url).json()
  File "/usr/lib/python2.7/site-packages/osbs/core.py", line 85, in _get
    headers, kwargs = self._request_args(with_auth, **kwargs)
  File "/usr/lib/python2.7/site-packages/osbs/core.py", line 77, in _request_args
    raise ValueError("Token was not retrieved successfully.")
ValueError(u'Token was not retrieved successfully.',)

2016-03-14 12:34:13,733 - atomic_reactor.plugin - WARNING - plugin 'store_metadata_in_osv3' raised an exception: OsbsException caused by ValueError(u'Token was not retrieved successfully.',)

```

This PR will make sure that store_metadata_in_osv3 plugin gets an auth token if use_auth is True