### PR TITLE
parse_item: use default splitlines() method instead of regexps

### DIFF
--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -12,7 +12,6 @@ import hashlib
 import json
 import os
 from pipes import quote
-import re
 import shutil
 import subprocess
 import tempfile
@@ -165,10 +164,11 @@ class CommandResult(object):
             parsed_item = None
             line = item
 
-        for l in re.split(r"\r?\n", line, re.MULTILINE):
+        for l in line.splitlines():
             l = l.strip()
             if l:
                 logger.debug(l)
+
         self._logs.append(item)
         if parsed_item is not None:
             self._error = parsed_item.get("error", None)


### PR DESCRIPTION
This eradicates an extra re import and improves performance:
saves about a second during my tests