### PR TITLE
koji_promote: allow blocksize to be specified

### DIFF
--- a/atomic_reactor/plugins/exit_koji_promote.py
+++ b/atomic_reactor/plugins/exit_koji_promote.py
@@ -77,7 +77,7 @@ class KojiPromotePlugin(ExitPlugin):
         :param koji_proxy_user: str, user to log in as (requires hub config)
         :param koji_principal: str, Kerberos principal (must specify keytab)
         :param koji_keytab: str, keytab name (must specify principal)
-        :param metadata_only: bool, whether to omit the v1 image
+        :param metadata_only: bool, whether to omit the 'docker save' image
         """
         super(KojiPromotePlugin, self).__init__(tasker, workflow)
 


### PR DESCRIPTION
If we had a configuration file, we could use that. We don't though, so I've added the ability to specify this using a plugin parameter.

The koji client default for upload blocksize is 1Mb. We'll most likely want to use a larger blocksize, e.g. 10Mb.