### PR TITLE
prevent store_metadata_in_osv3 failure when pull_base_image fails

### DIFF
--- a/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
+++ b/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
@@ -132,6 +132,11 @@ class StoreMetadataInOSv3Plugin(ExitPlugin):
         except AttributeError:
             commit_id = ""
 
+        try:
+            base_image_id = self.workflow.base_image_inspect['Id']
+        except docker.errors.NotFound:
+            base_image_id = ""
+
         labels = {
             "dockerfile": self.get_pre_result(CpDockerfilePlugin.key),
             "artefacts": self.get_pre_result(DistgitFetchArtefactsPlugin.key),
@@ -139,7 +144,7 @@ class StoreMetadataInOSv3Plugin(ExitPlugin):
             "rpm-packages": "\n".join(self.get_post_result(PostBuildRPMqaPlugin.key)),
             "repositories": json.dumps(self.get_repositories()),
             "commit_id": commit_id,
-            "base-image-id": self.workflow.base_image_inspect['Id'],
+            "base-image-id": base_image_id,
             "base-image-name": self.workflow.builder.base_image.to_str(),
             "image-id": self.workflow.builder.image_id,
             "digests": json.dumps(self.get_pullspecs(self.get_digests())),


### PR DESCRIPTION
Getting the base_image_inspect property invokes docker.Client().inspect_image(), which can fail.