### PR TITLE
Avoid misuse of Build annotations

### DIFF
--- a/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
+++ b/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
@@ -16,7 +16,6 @@ from osbs.conf import Configuration
 from atomic_reactor.plugin import ExitPlugin
 from atomic_reactor.plugins.pre_return_dockerfile import CpDockerfilePlugin
 from atomic_reactor.plugins.pre_pyrpkg_fetch_artefacts import DistgitFetchArtefactsPlugin
-from atomic_reactor.plugins.post_rpmqa import PostBuildRPMqaPlugin
 from atomic_reactor.util import get_build_json
 
 
@@ -46,9 +45,6 @@ class StoreMetadataInOSv3Plugin(ExitPlugin):
 
     def get_pre_result(self, key):
         return self.get_result(self.workflow.prebuild_results.get(key, ''))
-
-    def get_post_result(self, key):
-        return self.get_result(self.workflow.postbuild_results.get(key, ''))
 
     def get_digests(self):
         """
@@ -135,8 +131,13 @@ class StoreMetadataInOSv3Plugin(ExitPlugin):
         labels = {
             "dockerfile": self.get_pre_result(CpDockerfilePlugin.key),
             "artefacts": self.get_pre_result(DistgitFetchArtefactsPlugin.key),
-            "logs": "\n".join(self.workflow.build_logs),
-            "rpm-packages": "\n".join(self.get_post_result(PostBuildRPMqaPlugin.key)),
+
+            # We no longer store the 'docker build' logs as an annotation
+            "logs": '',
+
+            # We no longer store the rpm packages as an annotation
+            "rpm-packages": '',
+
             "repositories": json.dumps(self.get_repositories()),
             "commit_id": commit_id,
             "base-image-id": self.workflow.base_image_inspect['Id'],

--- a/tests/plugins/test_store_metadata.py
+++ b/tests/plugins/test_store_metadata.py
@@ -23,6 +23,7 @@ from atomic_reactor.plugins.exit_store_metadata_in_osv3 import StoreMetadataInOS
 from atomic_reactor.plugins.pre_cp_dockerfile import CpDockerfilePlugin
 from atomic_reactor.plugins.pre_pyrpkg_fetch_artefacts import DistgitFetchArtefactsPlugin
 from atomic_reactor.util import ImageName, LazyGit
+import pytest
 from tests.constants import LOCALHOST_REGISTRY, DOCKER0_REGISTRY, TEST_IMAGE, INPUT_IMAGE
 from tests.util import is_string_type
 
@@ -114,8 +115,10 @@ def test_metadata_plugin(tmpdir):
     assert is_string_type(labels['artefacts'])
     assert "logs" in labels
     assert is_string_type(labels['logs'])
+    assert labels['logs'] == ''
     assert "rpm-packages" in labels
     assert is_string_type(labels['rpm-packages'])
+    assert labels['rpm-packages'] == ''
     assert "repositories" in labels
     assert is_string_type(labels['repositories'])
     assert "commit_id" in labels


### PR DESCRIPTION
Don't store the 'docker build' logs there.
Don't store the rpm package list there.