### PR TITLE
Import docker to trap docker.errors.NotFound

### DIFF
--- a/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
+++ b/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
@@ -9,6 +9,7 @@ from __future__ import unicode_literals
 
 import json
 import os
+import docker
 
 from osbs.api import OSBS
 from osbs.conf import Configuration


### PR DESCRIPTION
Fixes
```
2016-04-13 12:31:40,432 - atomic_reactor.core - INFO - inspecting image 'rhel7.2:7.2-released'
2016-04-13 12:31:40,433 - atomic_reactor.core - DEBUG - image_id = 'rhel7.2:7.2-released'
2016-04-13 12:31:40,435 - atomic_reactor.plugin - DEBUG - Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/atomic_reactor-1.6.6-py2.7.egg/atomic_reactor/plugin.py", line 203, in run
    plugin_response = plugin_instance.run()
  File "/usr/lib/python2.7/site-packages/atomic_reactor-1.6.6-py2.7.egg/atomic_reactor/plugins/exit_store_metadata_in_osv3.py", line 133, in run
    except docker.errors.NotFound:
NameError: global name 'docker' is not defined
```