### PR TITLE
Support setting proxy for yum repos

### DIFF
--- a/atomic_reactor/plugins/pre_add_yum_repo_by_url.py
+++ b/atomic_reactor/plugins/pre_add_yum_repo_by_url.py
@@ -32,9 +32,14 @@ import requests
 try:
     # py2
     from urlparse import unquote, urlsplit
+    import ConfigParser as configparser
+    # We import BytesIO as StringIO as configparser can't properly write
+    from io import BytesIO, BytesIO as StringIO
 except ImportError:
     # py3
     from urllib.parse import unquote, urlsplit
+    import configparser
+    from io import BytesIO, StringIO
 
 
 class YumRepo(object):
@@ -57,22 +62,50 @@ class YumRepo(object):
         response.raise_for_status()
         self.content = response.content
 
+    def is_valid(self):
+        # Using BytesIO as configparser in 2.7 can't work with unicode
+        # see http://bugs.python.org/issue11597
+        with BytesIO(self.content) as buf:
+            self.config = configparser.ConfigParser()
+            try:
+                # Try python3 method
+                try:
+                    self.config.read_string(self.content.decode('unicode_escape'))
+                except AttributeError:
+                    # Fallback to py2 method
+                    self.config.readfp(buf)
+            except configparser.Error:
+                self.log.warn("Invalid repo file found: '%s'", self.content)
+                return False
+            else:
+                return True
+
+    def set_proxy_for_all_repos(self, proxy_name):
+        for section in self.config.sections():
+            self.config.set(section, 'proxy', proxy_name)
+
+        with StringIO() as output:
+            self.config.write(output)
+            self.content = output.getvalue()
+
 
 class AddYumRepoByUrlPlugin(PreBuildPlugin):
     key = "add_yum_repo_by_url"
     is_allowed_to_fail = False
 
-    def __init__(self, tasker, workflow, repourls):
+    def __init__(self, tasker, workflow, repourls, inject_proxy=None):
         """
         constructor
 
         :param tasker: DockerTasker instance
         :param workflow: DockerBuildWorkflow instance
         :param repourls: list of str, URLs to the repo files
+        :param inject_proxy: set proxy server for this repo
         """
         # call parent constructor
         super(AddYumRepoByUrlPlugin, self).__init__(tasker, workflow)
         self.repourls = repourls
+        self.inject_proxy = inject_proxy
 
     def run(self):
         """
@@ -83,5 +116,8 @@ class AddYumRepoByUrlPlugin(PreBuildPlugin):
                 yumrepo = YumRepo(repourl)
                 yumrepo.fetch()
                 self.log.info("fetched repo from '%s'", yumrepo.repourl)
+                if self.inject_proxy:
+                    if yumrepo.is_valid():
+                        yumrepo.set_proxy_for_all_repos(self.inject_proxy)
                 self.workflow.files[yumrepo.dst_filename] = yumrepo.content
                 self.log.debug("saving repo '%s', length %d", yumrepo.dst_filename, len(yumrepo.content))

--- a/atomic_reactor/plugins/pre_koji.py
+++ b/atomic_reactor/plugins/pre_koji.py
@@ -19,7 +19,7 @@ class KojiPlugin(PreBuildPlugin):
     key = "koji"
     is_allowed_to_fail = False
 
-    def __init__(self, tasker, workflow, target, hub, root):
+    def __init__(self, tasker, workflow, target, hub, root, proxy=None):
         """
         constructor
 
@@ -34,6 +34,7 @@ class KojiPlugin(PreBuildPlugin):
         self.target = target
         self.xmlrpc = koji.ClientSession(hub)
         self.pathinfo = koji.PathInfo(topdir=root)
+        self.proxy = proxy
 
     def run(self):
         """
@@ -65,6 +66,10 @@ class KojiPlugin(PreBuildPlugin):
         if baseurl.startswith("https://"):
             self.log.info("Ignoring certificates in the repo")
             repo['sslverify'] = 0
+
+        if self.proxy:
+            self.log.info("Setting yum proxy to %s" % self.proxy)
+            repo['proxy'] = self.proxy
 
         path = os.path.join(YUM_REPOS_DIR, self.target + ".repo")
         self.log.info("yum repo of koji target: '%s'", path)

--- a/atomic_reactor/plugins/pre_koji.py
+++ b/atomic_reactor/plugins/pre_koji.py
@@ -68,7 +68,7 @@ class KojiPlugin(PreBuildPlugin):
             repo['sslverify'] = 0
 
         if self.proxy:
-            self.log.info("Setting yum proxy to %s" % self.proxy)
+            self.log.info("Setting yum proxy to %s", self.proxy)
             repo['proxy'] = self.proxy
 
         path = os.path.join(YUM_REPOS_DIR, self.target + ".repo")

--- a/tests/plugins/test_add_yum_repo_by_url.py
+++ b/tests/plugins/test_add_yum_repo_by_url.py
@@ -12,10 +12,11 @@ from atomic_reactor.constants import YUM_REPOS_DIR
 
 from atomic_reactor.core import DockerTasker
 from atomic_reactor.inner import DockerBuildWorkflow
-from atomic_reactor.plugin import PreBuildPluginsRunner, PreBuildPlugin
+from atomic_reactor.plugin import PreBuildPluginsRunner
 from atomic_reactor.plugins.pre_add_yum_repo_by_url import AddYumRepoByUrlPlugin
 from atomic_reactor.util import ImageName
 import requests
+import pytest
 from flexmock import flexmock
 import os.path
 from tests.constants import DOCKERFILE_GIT, MOCK
@@ -49,31 +50,37 @@ def prepare():
     return tasker, workflow
 
 
-def test_no_repourls():
+@pytest.mark.parametrize('inject_proxy', [None, 'http://proxy.example.com'])
+def test_no_repourls(inject_proxy):
     tasker, workflow = prepare()
     runner = PreBuildPluginsRunner(tasker, workflow, [{
         'name': AddYumRepoByUrlPlugin.key,
-        'args': {'repourls': []}}])
+        'args': {'repourls': [], 'inject_proxy': inject_proxy}}])
     runner.run()
     assert AddYumRepoByUrlPlugin.key is not None
     assert workflow.files == {}
 
 
-def test_single_repourl():
+@pytest.mark.parametrize('inject_proxy', [None, 'http://proxy.example.com'])
+def test_single_repourl(inject_proxy):
     tasker, workflow = prepare()
     url = 'http://example.com/example%20repo.repo'
     filename = 'example repo.repo'
     runner = PreBuildPluginsRunner(tasker, workflow, [{
         'name': AddYumRepoByUrlPlugin.key,
-        'args': {'repourls': [url]}}])
+        'args': {'repourls': [url], 'inject_proxy': inject_proxy}}])
     runner.run()
+    repo_content = repocontent
+    if inject_proxy:
+        repo_content = '%sproxy = %s\n\n' % (repocontent.decode('utf-8'), inject_proxy)
     # next(iter(...)) is for py 2/3 compatibility
     assert next(iter(workflow.files.keys())) == os.path.join(YUM_REPOS_DIR, filename)
-    assert next(iter(workflow.files.values())) == repocontent
+    assert next(iter(workflow.files.values())) == repo_content
     assert len(workflow.files) == 1
 
 
-def test_multiple_repourls():
+@pytest.mark.parametrize('inject_proxy', [None, 'http://proxy.example.com'])
+def test_multiple_repourls(inject_proxy):
     tasker, workflow = prepare()
     url1 = 'http://example.com/a/b/c/myrepo.repo'
     filename1 = 'myrepo.repo'
@@ -81,10 +88,13 @@ def test_multiple_repourls():
     filename2 = 'repo-2.repo'
     runner = PreBuildPluginsRunner(tasker, workflow, [{
         'name': AddYumRepoByUrlPlugin.key,
-        'args': {'repourls': [url1, url2]}}])
+        'args': {'repourls': [url1, url2], 'inject_proxy': inject_proxy}}])
     runner.run()
+    repo_content = repocontent
+    if inject_proxy:
+        repo_content = '%sproxy = %s\n\n' % (repocontent.decode('utf-8'), inject_proxy)
     assert workflow.files[os.path.join(YUM_REPOS_DIR, filename1)]
     assert workflow.files[os.path.join(YUM_REPOS_DIR, filename2)]
-    assert workflow.files[os.path.join(YUM_REPOS_DIR, filename1)] == repocontent
-    assert workflow.files[os.path.join(YUM_REPOS_DIR, filename2)] == repocontent
+    assert workflow.files[os.path.join(YUM_REPOS_DIR, filename1)] == repo_content
+    assert workflow.files[os.path.join(YUM_REPOS_DIR, filename2)] == repo_content
     assert len(workflow.files) == 2

--- a/tests/plugins/test_koji.py
+++ b/tests/plugins/test_koji.py
@@ -97,12 +97,21 @@ class TestKoji(object):
     @pytest.mark.parametrize(('root',
                               'koji_ssl_certs',
                               'expected_string',
-                              'expected_file'), [
+                              'expected_file',
+                              'proxy'), [
         # Plain http repo
         ('http://example.com',
          False,
          None,
+         None,
          None),
+
+        # Plain http repo with proxy
+        ('http://example.com',
+         False,
+         None,
+         None,
+         'http://proxy.com'),
 
         # https with koji_ssl_certs
         # ('https://example.com',
@@ -114,7 +123,15 @@ class TestKoji(object):
         ('https://nosuchwebsiteforsure.com',
          False,
          'sslverify=0',
+         None,
          None),
+
+        # https with no cert available
+        ('https://nosuchwebsiteforsure.com',
+         False,
+         'sslverify=0',
+         None,
+         'http://proxy.com'),
 
         # https with cert available
         # ('https://example.com',
@@ -124,12 +141,13 @@ class TestKoji(object):
 
     ])
     def test_koji_plugin(self, tmpdir, root, koji_ssl_certs,
-                         expected_string, expected_file):
+                         expected_string, expected_file, proxy):
         tasker, workflow = prepare()
         args = {
             'target': KOJI_TARGET,
             'hub': '',
             'root': root,
+            'proxy': proxy
         }
 
         if koji_ssl_certs:
@@ -151,6 +169,9 @@ class TestKoji(object):
         assert "enabled=1\n" in content
         assert "name=atomic-reactor-koji-plugin-target\n" in content
         assert "baseurl=%s/repos/tag/2/$basearch\n" % root in content
+
+        if proxy:
+            assert "proxy=%s" % proxy in content
 
         if expected_string:
             assert expected_string in content

--- a/tests/plugins/test_koji.py
+++ b/tests/plugins/test_koji.py
@@ -111,7 +111,7 @@ class TestKoji(object):
          False,
          None,
          None,
-         'http://proxy.com'),
+         'http://proxy.example.com'),
 
         # https with koji_ssl_certs
         # ('https://example.com',
@@ -131,7 +131,7 @@ class TestKoji(object):
          False,
          'sslverify=0',
          None,
-         'http://proxy.com'),
+         'http://proxy.example.com'),
 
         # https with cert available
         # ('https://example.com',


### PR DESCRIPTION
* [x] Update pre_koji
* [x] Update add_yum_repo_by_url


We also have an option to verify yum repo contents (using ```configparser```) - do we want this being enabled? Currently the proxy won't be injected if the repo file is invalid - but it still will be passed to the buildroot