### PR TITLE
Allowing exit plugins to fail build #436

### DIFF
--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -382,6 +382,7 @@ class DockerBuildWorkflow(object):
                 exit_runner.run(keep_going=True)
             except PluginFailedException as ex:
                 logger.error("one or more exit plugins failed: %s", ex)
+                raise
             finally:
                 self.source.remove_tmpdir()
 


### PR DESCRIPTION
Also added NoopMixIn because switching from 'or' to 'and'
caused NotImplementedError to occur on dummy plugins.