### PR TITLE
Pass login/password/email to tag_and_push plugin if docker registry requires auth

### DIFF
--- a/atomic_reactor/core.py
+++ b/atomic_reactor/core.py
@@ -440,6 +440,21 @@ class DockerTasker(LastLogger):
             logger.debug('image already tagged correctly, nothing to do')
         return target_image.to_str()  # this will be the proper name, not just repo/img
 
+    def login(self, registry, login, password, email):
+        logger.info("logging in: registry '%s', login '%s', email '%s'" % (registry, login, email))
+        response = self.d.login(
+            username=login,
+            password=password,
+            email=email,
+            registry=registry)
+        if not response:
+            raise RuntimeError(
+                "Failed to login to '%s': email = '%s', login = '%s', password = '%s'" %
+                registry, email, login, password)
+        logger.debug(response)
+        if u'Status' in response and response[u'Status'] == u'Login Succeeded':
+            logger.info("login succeeded")
+
     def push_image(self, image, insecure=False):
         """
         push provided image to registry
@@ -463,7 +478,8 @@ class DockerTasker(LastLogger):
             raise RuntimeError("Failed to push image %s" % image)
         return command_result.parsed_logs
 
-    def tag_and_push_image(self, image, target_image, insecure=False, force=False):
+    def tag_and_push_image(self, image, target_image, insecure=False, force=False,
+                           login=None, password=None, email=None):
         """
         tag provided image and push it to registry
 
@@ -476,6 +492,8 @@ class DockerTasker(LastLogger):
         logger.info("tagging and pushing image '%s' as '%s'", image, target_image)
         logger.debug("image = '%s', target_image = '%s'", image, target_image)
         self.tag_image(image, target_image, force=force)
+        if login and password and email:
+            self.login(registry=target_image.registry, login=login, password=password, email=email)
         return self.push_image(target_image, insecure=insecure)
 
     def inspect_image(self, image_id):

--- a/atomic_reactor/core.py
+++ b/atomic_reactor/core.py
@@ -450,7 +450,7 @@ class DockerTasker(LastLogger):
         if not response:
             raise RuntimeError(
                 "Failed to login to '%s': email = '%s', login = '%s', password = '%s'" %
-                registry, email, login, password)
+                (registry, email, login, password))
         logger.debug(response)
         if u'Status' in response and response[u'Status'] == u'Login Succeeded':
             logger.info("login succeeded")

--- a/atomic_reactor/plugins/post_tag_and_push.py
+++ b/atomic_reactor/plugins/post_tag_and_push.py
@@ -31,8 +31,16 @@ class TagAndPushPlugin(PostBuildPlugin):
         :param tasker: DockerTasker instance
         :param workflow: DockerBuildWorkflow instance
         :param registries: dict, keys are docker registries, values are dicts containing per-registry
-                           parameters. Currently only the "insecure" optional boolean parameter
-                           is supported which controls whether pushes are allowed over plain HTTP.
+                           parameters.
+                           Params:
+                            * "insecure" optional boolean - controls whether pushes are allowed over
+                              plain HTTP.
+                            * "email" optional string - email to be used during login if registry
+                              requires authentication
+                            * "login" optional string - login to be used during login if registry
+                              requires authentication
+                            * "password" optional string - password to be used during login if
+                              registry requires authentication
         """
         # call parent constructor
         super(TagAndPushPlugin, self).__init__(tasker, workflow)
@@ -47,6 +55,9 @@ class TagAndPushPlugin(PostBuildPlugin):
 
         for registry, registry_conf in self.registries.items():
             insecure = registry_conf.get('insecure', False)
+            login = registry_conf.get('login', None)
+            password = registry_conf.get('password', None)
+            email = registry_conf.get('email', None)
             push_conf_registry = \
                 self.workflow.push_conf.add_docker_registry(registry, insecure=insecure)
 
@@ -58,7 +69,8 @@ class TagAndPushPlugin(PostBuildPlugin):
                 registry_image.registry = registry
                 logs = self.tasker.tag_and_push_image(self.workflow.builder.image_id,
                                                       registry_image, insecure=insecure,
-                                                      force=True)
+                                                      force=True,
+                                                      login=login, password=password, email=email)
 
                 pushed_images.append(registry_image)
                 defer_removal(self.workflow, registry_image)

--- a/atomic_reactor/plugins/post_tag_and_push.py
+++ b/atomic_reactor/plugins/post_tag_and_push.py
@@ -65,12 +65,11 @@ class TagAndPushPlugin(PostBuildPlugin):
                     json_secret = {}
                     with open(json_secret_path) as fd:
                         json_secret = json.load(fd)
-                    self.log.info("json_secret %s", json_secret)
                     login = json_secret[registry]['username']
                     password = json_secret[registry]['password']
                     email = json_secret[registry]['email']
                 except Exception as e:
-                    self.log.warn("exception %r", e)
+                    self.log.warn("error retrieving credentials", exc_info=True)
                     login = password = email = None
 
             for image in self.workflow.tag_conf.images:
@@ -79,7 +78,6 @@ class TagAndPushPlugin(PostBuildPlugin):
 
                 registry_image = image.copy()
                 registry_image.registry = registry
-                self.log.info("Pushing %r", registry_image)
                 logs = self.tasker.tag_and_push_image(self.workflow.builder.image_id,
                                                       registry_image, insecure=insecure,
                                                       force=True,


### PR DESCRIPTION
Fixes #465

Docker-py doesn't allow passing a conf file for push (although it does allow it for pull).

TODO:
 * [x] Make sure we can push with login/email/password
 * [x] Use Openshift secrets to store this in a secret
 * [x] Rewrite the code to use secret instead of plain config vars
 * [x] Add tests