### PR TITLE
Storing koji build id as label.

### DIFF
--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -257,6 +257,8 @@ class DockerBuildWorkflow(object):
         self.exit_plugins_conf = exit_plugins
         self.prebuild_results = {}
         self.postbuild_results = {}
+        self.prepub_results = {}
+        self.exit_results = {}
         self.plugins_timestamps = {}
         self.plugins_durations = {}
         self.plugins_errors = {}

--- a/atomic_reactor/plugin.py
+++ b/atomic_reactor/plugin.py
@@ -326,7 +326,7 @@ class PrePublishPluginsRunner(BuildPluginsRunner):
 
     def __init__(self, dt, workflow, plugins_conf, *args, **kwargs):
         logger.info("initializing runner of pre-publish plugins")
-        self.plugins_results = workflow.postbuild_results
+        self.plugins_results = workflow.prepub_results
         super(PrePublishPluginsRunner, self).__init__(dt, workflow, 'PrePublishPlugin', plugins_conf, *args, **kwargs)
 
 
@@ -359,6 +359,7 @@ class ExitPlugin(PostBuildPlugin):
 class ExitPluginsRunner(BuildPluginsRunner):
     def __init__(self, dt, workflow, plugins_conf, *args, **kwargs):
         logger.info("initializing runner of exit plugins")
+        self.plugins_results = workflow.exit_results
         super(ExitPluginsRunner, self).__init__(dt, workflow, 'ExitPlugin',
                                                 plugins_conf, *args, **kwargs)
 

--- a/atomic_reactor/plugins/exit_koji_promote.py
+++ b/atomic_reactor/plugins/exit_koji_promote.py
@@ -624,7 +624,14 @@ class KojiPromotePlugin(ExitPlugin):
                 if output.file:
                     output.file.close()
 
-        session.CGImport(koji_metadata, server_dir)
+        build_info = session.CGImport(koji_metadata, server_dir)
+        # Older versions of CGImport do not return a value.
+        build_id = build_info.get("id") if build_info else None
 
         self.log.debug("Submitted with metadata: %s",
                        json.dumps(koji_metadata, sort_keys=True, indent=4))
+        self.log.debug("Build information: %s",
+                       json.dumps(build_info, sort_keys=True, indent=4))
+
+        return build_id
+


### PR DESCRIPTION
[ Issue #439 ]
Modified KojiPromotePlugin to return the ID of the started Koji build.
Added to DockerBuildWorkflow exit_result attribute to store results from exit plugins.
Modified StoreMetadataInOSv3Plugin to set a label on the OS Build with the previously stored Koji build ID.

Also, fixed PrePublishPluginsRunner to use the correct results dict.