### PR TITLE
Fix logging of 'docker build' output

### DIFF
--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -169,7 +169,7 @@ class CommandResult(object):
             if l:
                 logger.debug(l)
 
-        self._logs.append(item)
+        self._logs.append(line)
         if parsed_item is not None:
             self._error = parsed_item.get("error", None)
             self._error_detail = parsed_item.get("errorDetail", None)

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -166,10 +166,10 @@ class CommandResult(object):
 
         for l in line.splitlines():
             l = l.strip()
+            self._logs.append(l)
             if l:
                 logger.debug(l)
 
-        self._logs.append(line)
         if parsed_item is not None:
             self._error = parsed_item.get("error", None)
             self._error_detail = parsed_item.get("errorDetail", None)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -92,9 +92,9 @@ def test_clone_git_repo(tmpdir):
 class TestCommandResult(object):
     @pytest.mark.parametrize(('item', 'expected'), [
         (b'{"stream":"Step 0 : FROM ebbc51b7dfa5bcd993a[...]\\n"}\n',
-         "Step 0 : FROM ebbc51b7dfa5bcd993a[...]\n"),
+         "Step 0 : FROM ebbc51b7dfa5bcd993a[...]"),
 
-        (b'this is not valid JSON',
+        (b'this is not valid JSON\n',
          'this is not valid JSON'),
     ])
     def test_parse_item(self, item, expected):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -19,10 +19,12 @@ except ImportError:
     # Python 2.6
     from ordereddict import OrderedDict
 import docker
-from atomic_reactor.util import ImageName, \
-    wait_for_command, clone_git_repo, LazyGit, figure_out_dockerfile, render_yum_repo, \
-    process_substitutions, get_checksums, print_version_of_tools, get_version_of_tools, \
-    get_preferred_label_key, human_size
+from atomic_reactor.util import (ImageName, wait_for_command, clone_git_repo,
+                                 LazyGit, figure_out_dockerfile,
+                                 render_yum_repo, process_substitutions,
+                                 get_checksums, print_version_of_tools,
+                                 get_version_of_tools, get_preferred_label_key,
+                                 human_size, CommandResult)
 from tests.constants import DOCKERFILE_GIT, INPUT_IMAGE, MOCK, DOCKERFILE_SHA1
 from tests.util import requires_internet
 
@@ -85,6 +87,20 @@ def test_clone_git_repo(tmpdir):
     assert commit_id is not None
     assert len(commit_id) == 40  # current git hashes are this long
     assert os.path.isdir(os.path.join(tmpdir_path, '.git'))
+
+
+class TestCommandResult(object):
+    @pytest.mark.parametrize(('item', 'expected'), [
+        (b'{"stream":"Step 0 : FROM ebbc51b7dfa5bcd993a[...]\\n"}\n',
+         "Step 0 : FROM ebbc51b7dfa5bcd993a[...]\n"),
+
+        (b'this is not valid JSON',
+         'this is not valid JSON'),
+    ])
+    def test_parse_item(self, item, expected):
+        cr = CommandResult()
+        cr.parse_item(item)
+        assert cr.logs == [expected]
 
 
 @requires_internet


### PR DESCRIPTION
Previously the JSON representation was being logged instead of the actual log text.