### PR TITLE
koji_util: don't import unicode_literals from __future__

### DIFF
--- a/atomic_reactor/koji_util.py
+++ b/atomic_reactor/koji_util.py
@@ -6,7 +6,7 @@ This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
 
-from __future__ import print_function, unicode_literals
+from __future__ import print_function
 
 
 import koji


### PR DESCRIPTION
Doing so causes koji to be unhappy since it requires strings for parameter values.

Couldn't figure out a way of adding a test case for this.

CC @lcarva