### PR TITLE
koji_promote: use component in nvr, not Name label

### DIFF
--- a/atomic_reactor/plugins/exit_koji_promote.py
+++ b/atomic_reactor/plugins/exit_koji_promote.py
@@ -484,7 +484,8 @@ class KojiPromotePlugin(ExitPlugin):
 
         labels = DockerfileParser(self.workflow.builder.df_path).labels
         component = get_preferred_label(labels, 'com.redhat.component')
-        version, release = self.nvr_image.tag.split('-', 1)
+        version = get_preferred_label(labels, 'version')
+        release = get_preferred_label(labels, 'release')
 
         source = self.workflow.source
         if not isinstance(source, GitSource):
@@ -526,7 +527,7 @@ class KojiPromotePlugin(ExitPlugin):
                 self.nvr_image = image
                 break
         else:
-            raise RuntimeError('Unable to determine name-version-release')
+            raise RuntimeError('Unable to determine name:version-release')
 
         metadata_version = 0
 

--- a/tests/plugins/test_koji_promote.py
+++ b/tests/plugins/test_koji_promote.py
@@ -194,8 +194,10 @@ def mock_environment(tmpdir, session=None, name=None,
     setattr(workflow, 'tag_conf', TagConf())
     with open(os.path.join(str(tmpdir), 'Dockerfile'), 'wt') as df:
         df.write('FROM base\n'
-                 'LABEL BZComponent={} com.redhat.component={}\n'
-                 .format(component, component))
+                 'LABEL BZComponent={component} com.redhat.component={component}\n'
+                 'LABEL Version={version} version={version}\n'
+                 'LABEL Release={release} release={release}\n'
+                 .format(component=component, version=version, release=release))
         setattr(workflow.builder, 'df_path', df.name)
     if name and version:
         workflow.tag_conf.add_unique_image('user/test-image:{v}-timestamp'


### PR DESCRIPTION
We should be using component-version-release for the Koji Build, i.e.:
 * 'name' = com.redhat.component / BZComponent
 * 'version' = version / Version
 * 'release' = release / Release