### PR TITLE
koji_promote: store originating koji task ID in build metadata

### DIFF
--- a/atomic_reactor/plugins/exit_koji_promote.py
+++ b/atomic_reactor/plugins/exit_koji_promote.py
@@ -492,11 +492,11 @@ class KojiPromotePlugin(ExitPlugin):
             raise RuntimeError('git source required')
 
         extra = {}
-        kojitask = metadata.get('labels', {}).get('kojitask')
-        if kojitask is not None:
+        koji_task_id = metadata.get('labels', {}).get('koji-task-id')
+        if koji_task_id is not None:
             self.log.info("build configuration created by Koji Task ID %s",
-                          kojitask)
-            extra['koji_task_id'] = kojitask
+                          koji_task_id)
+            extra['koji_task_id'] = koji_task_id
 
         build = {
             'name': component,

--- a/atomic_reactor/plugins/exit_koji_promote.py
+++ b/atomic_reactor/plugins/exit_koji_promote.py
@@ -491,6 +491,13 @@ class KojiPromotePlugin(ExitPlugin):
         if not isinstance(source, GitSource):
             raise RuntimeError('git source required')
 
+        extra = {}
+        kojitask = metadata.get('labels', {}).get('kojitask')
+        if kojitask is not None:
+            self.log.info("build configuration created by Koji Task ID %s",
+                          kojitask)
+            extra['originating_koji_task_id'] = kojitask
+
         build = {
             'name': component,
             'version': version,
@@ -498,9 +505,7 @@ class KojiPromotePlugin(ExitPlugin):
             'source': "{0}#{1}".format(source.uri, source.commit_id),
             'start_time': start_time,
             'end_time': int(time.time()),
-            'extra': {
-                'image': {},
-            },
+            'extra': extra,
         }
 
         if self.metadata_only:

--- a/atomic_reactor/plugins/exit_koji_promote.py
+++ b/atomic_reactor/plugins/exit_koji_promote.py
@@ -496,7 +496,7 @@ class KojiPromotePlugin(ExitPlugin):
         if kojitask is not None:
             self.log.info("build configuration created by Koji Task ID %s",
                           kojitask)
-            extra['originating_koji_task_id'] = kojitask
+            extra['koji_task_id'] = kojitask
 
         build = {
             'name': component,

--- a/tests/plugins/test_koji_promote.py
+++ b/tests/plugins/test_koji_promote.py
@@ -380,20 +380,20 @@ class TestKojiPromote(object):
                                             release='1')
         runner = create_runner(tasker, workflow)
 
-        kojitask = '12345'
+        koji_task_id = '12345'
         monkeypatch.setenv("BUILD", json.dumps({
             'metadata': {
                 'creationTimestamp': '2015-07-27T09:24:00Z',
                 'namespace': NAMESPACE,
                 'name': BUILD_ID,
                 'labels': {
-                    'kojitask': kojitask,
+                    'koji-task-id': koji_task_id,
                 },
             }
         }))
         runner.run()
 
-        assert "Koji Task ID {}".format(kojitask) in caplog.text()
+        assert "Koji Task ID {}".format(koji_task_id) in caplog.text()
 
         metadata = session.metadata
         assert 'build' in metadata
@@ -403,9 +403,9 @@ class TestKojiPromote(object):
         extra = build['extra']
         assert isinstance(extra, dict)
         assert 'koji_task_id' in extra
-        koji_task_id = extra['koji_task_id']
-        assert is_string_type(koji_task_id)
-        assert koji_task_id == kojitask
+        extra_koji_task_id = extra['koji_task_id']
+        assert is_string_type(extra_koji_task_id)
+        assert extra_koji_task_id == koji_task_id
 
     @pytest.mark.parametrize('params', [
         {

--- a/tests/plugins/test_koji_promote.py
+++ b/tests/plugins/test_koji_promote.py
@@ -402,8 +402,8 @@ class TestKojiPromote(object):
         assert 'extra' in build
         extra = build['extra']
         assert isinstance(extra, dict)
-        assert 'originating_koji_task_id' in extra
-        koji_task_id = extra['originating_koji_task_id']
+        assert 'koji_task_id' in extra
+        koji_task_id = extra['koji_task_id']
         assert is_string_type(koji_task_id)
         assert koji_task_id == kojitask
 

--- a/tests/plugins/test_koji_promote.py
+++ b/tests/plugins/test_koji_promote.py
@@ -370,6 +370,43 @@ class TestKojiPromote(object):
         with pytest.raises(PluginFailedException):
             runner.run()
 
+    def test_koji_promote_log_task_id(self, tmpdir, monkeypatch, os_env,
+                                      caplog):
+        session = MockedClientSession('')
+        tasker, workflow = mock_environment(tmpdir,
+                                            session=session,
+                                            name='ns/name',
+                                            version='1.0',
+                                            release='1')
+        runner = create_runner(tasker, workflow)
+
+        kojitask = '12345'
+        monkeypatch.setenv("BUILD", json.dumps({
+            'metadata': {
+                'creationTimestamp': '2015-07-27T09:24:00Z',
+                'namespace': NAMESPACE,
+                'name': BUILD_ID,
+                'labels': {
+                    'kojitask': kojitask,
+                },
+            }
+        }))
+        runner.run()
+
+        assert "Koji Task ID {}".format(kojitask) in caplog.text()
+
+        metadata = session.metadata
+        assert 'build' in metadata
+        build = metadata['build']
+        assert isinstance(build, dict)
+        assert 'extra' in build
+        extra = build['extra']
+        assert isinstance(extra, dict)
+        assert 'originating_koji_task_id' in extra
+        koji_task_id = extra['originating_koji_task_id']
+        assert is_string_type(koji_task_id)
+        assert koji_task_id == kojitask
+
     @pytest.mark.parametrize('params', [
         {
             'should_raise': False,
@@ -775,7 +812,7 @@ class TestKojiPromote(object):
             'source',
             'start_time',
             'end_time',
-            'extra',
+            'extra',          # optional but always supplied
             'metadata_only',  # only when True
         ]) - mdonly
 


### PR DESCRIPTION
This is the ID of the Koji Task responsible for creating the build configuration.

Note: the 'extra' field in the 'build' map is optional, and is no longer required to have an 'image' member.