### PR TITLE
koji_promote: rename koji_task_id to container_koji_task_id

### DIFF
--- a/atomic_reactor/plugins/exit_koji_promote.py
+++ b/atomic_reactor/plugins/exit_koji_promote.py
@@ -519,7 +519,7 @@ class KojiPromotePlugin(ExitPlugin):
         if koji_task_id is not None:
             self.log.info("build configuration created by Koji Task ID %s",
                           koji_task_id)
-            extra['koji_task_id'] = koji_task_id
+            extra['container_koji_task_id'] = koji_task_id
 
         build = {
             'name': component,

--- a/tests/plugins/test_koji_promote.py
+++ b/tests/plugins/test_koji_promote.py
@@ -437,8 +437,8 @@ class TestKojiPromote(object):
         assert 'extra' in build
         extra = build['extra']
         assert isinstance(extra, dict)
-        assert 'koji_task_id' in extra
-        extra_koji_task_id = extra['koji_task_id']
+        assert 'container_koji_task_id' in extra
+        extra_koji_task_id = extra['container_koji_task_id']
         assert is_string_type(extra_koji_task_id)
         assert extra_koji_task_id == koji_task_id
 


### PR DESCRIPTION
This avoids ambiguity when we introduce filesystem_koji_task_id.