### PR TITLE
Remove preprocess_plugins from input_osv3

### DIFF
--- a/atomic_reactor/plugins/input_osv3.py
+++ b/atomic_reactor/plugins/input_osv3.py
@@ -12,8 +12,6 @@ import json
 import os
 
 from atomic_reactor.plugin import InputPlugin
-from atomic_reactor.plugins.pre_pull_base_image import PullBaseImagePlugin
-from atomic_reactor.plugins.post_tag_and_push import TagAndPushPlugin
 from atomic_reactor.util import get_build_json
 
 
@@ -51,8 +49,6 @@ class OSv3InputPlugin(InputPlugin):
 
         self.plugins_json = json.loads(self.plugins_json)
 
-        self.preprocess_plugins()
-
         input_json = {
             'source': {
                 'provider': 'git',
@@ -67,51 +63,6 @@ class OSv3InputPlugin(InputPlugin):
         self.log.debug("build json: %s", input_json)
 
         return input_json
-
-    def get_plugin(self, section, name):
-        try:
-            plugin = [p for p in self.plugins_json[section] if p.get('name') == name][0]
-        except IndexError:
-            return None
-        else:
-            return plugin
-
-    def preprocess_plugins(self):
-        for typ in ('prebuild', 'postbuild', 'prepublish', 'exit'):
-            self.plugins_json.setdefault('{0}_plugins'.format(typ), [])
-
-        # XXX: Remove the two if blocks after we stop using super old osbs:(
-        pull_plugin = self.get_plugin('prebuild_plugins', PullBaseImagePlugin.key)
-        if not pull_plugin:
-            self.log.warning("%s is missing in prebuild_plugins - please update your osbs-client!",
-                             PullBaseImagePlugin.key)
-            pull_plugin = { "name": PullBaseImagePlugin.key }
-            self.plugins_json['prebuild_plugins'].insert(0, pull_plugin)
-
-        change_plugin = self.get_plugin('prebuild_plugins', 'change_source_registry')
-        if change_plugin:
-            if 'registry_uri' in change_plugin.get('args', {}):
-                pull_plugin.setdefault('args', {})['parent_registry'] = \
-                    change_plugin['args']['registry_uri']
-            if 'insecure_registry' in change_plugin.get('args', {}):
-                pull_plugin.setdefault('args', {})['parent_registry_insecure'] = \
-                    change_plugin['args']['insecure_registry']
-            self.plugins_json['prebuild_plugins'].remove(change_plugin)
-
-        if 'parent_registry' not in pull_plugin.get('args', {}):
-            self.log.error("source registry is not configured")
-
-        push_plugin = self.get_plugin('postbuild_plugins', TagAndPushPlugin.key)
-        if not push_plugin and self.target_registry:
-            self.log.warning("%s is missing in postbuild_plugins - please update your osbs-client!",
-                             TagAndPushPlugin.key)
-            push_plugin = { "name": TagAndPushPlugin.key }
-            self.plugins_json['postbuild_plugins'].insert(0, push_plugin)
-
-        if push_plugin and self.target_registry:
-            push_plugin.setdefault('args', {}).setdefault('registries', {})
-            if not push_plugin['args']['registries']:
-                push_plugin['args']['registries'][self.target_registry] = {"insecure": True}
 
     @classmethod
     def is_autousable(cls):

--- a/tests/plugins/test_input_osv3.py
+++ b/tests/plugins/test_input_osv3.py
@@ -17,87 +17,6 @@ from flexmock import flexmock
 
 from tests.constants import LOCALHOST_REGISTRY
 
-@pytest.mark.parametrize('prebuild_json,expected_json', [
-    ([],
-     [{ 'name': 'pull_base_image' }]
-    ),
-    ([{ 'name': 'pull_base_image' }],
-     [{ 'name': 'pull_base_image' }]
-    ),
-    ([{ 'name': 'pull_base_image', 'args': { 'a': 'b' }}],
-     [{ 'name': 'pull_base_image', 'args': { 'a': 'b' }}]
-    ),
-    ([{ 'name': 'change_source_registry' }],
-     [{ 'name': 'pull_base_image' }]
-    ),
-    ([{ 'name': 'change_source_registry',
-        'args': { 'registry_uri': 'localhost:666', 'insecure_registry': True }}],
-     [{ 'name': 'pull_base_image',
-        'args': { 'parent_registry': 'localhost:666', 'parent_registry_insecure': True }}]
-    ),
-    ([{ 'name': 'change_source_registry' }, { 'name': 'pull_base_image', 'args': { 'a': 'b' }}],
-     [{ 'name': 'pull_base_image', 'args': { 'a': 'b' }}]
-    ),
-])
-def test_prebuild_plugins_rewrite(prebuild_json, expected_json):
-    plugins_json = {
-        'prebuild_plugins': prebuild_json,
-    }
-
-    mock_env = {
-        'BUILD': '{}',
-        'SOURCE_URI': 'https://github.com/foo/bar.git',
-        'SOURCE_REF': 'master',
-        'OUTPUT_IMAGE': 'asdf:fdsa',
-        'OUTPUT_REGISTRY': 'localhost:5000',
-        'ATOMIC_REACTOR_PLUGINS': json.dumps(plugins_json),
-    }
-    flexmock(os, environ=mock_env)
-
-    plugin = OSv3InputPlugin()
-    assert plugin.run()['prebuild_plugins'] == expected_json
-
-
-@pytest.mark.parametrize('output_registry,postbuild_json,expected_json', [
-    (LOCALHOST_REGISTRY,
-     [],
-     [{ 'name': 'tag_and_push', 'args': { 'registries': { LOCALHOST_REGISTRY: { 'insecure': True }}}}]
-    ),
-    (LOCALHOST_REGISTRY,
-     [{ 'name': 'tag_and_push' }],
-     [{ 'name': 'tag_and_push', 'args': { 'registries': { LOCALHOST_REGISTRY: { 'insecure': True }}}}]
-    ),
-    (LOCALHOST_REGISTRY,
-     [{ 'name': 'tag_and_push', 'args': { 'registries': { 'foo': { 'insecure': True }}}}],
-     [{ 'name': 'tag_and_push', 'args': { 'registries': { 'foo': { 'insecure': True }}}}]
-    ),
-    (None,
-     [{ 'name': 'tag_and_push', 'args': { 'registries': { 'foo': { 'insecure': True }}}}],
-     [{ 'name': 'tag_and_push', 'args': { 'registries': { 'foo': { 'insecure': True }}}}]
-    ),
-    (None,
-     [],
-     []
-    ),
-])
-def test_postbuild_plugins_rewrite(output_registry, postbuild_json, expected_json):
-    plugins_json = {
-        'postbuild_plugins': postbuild_json,
-    }
-
-    mock_env = {
-        'BUILD': '{}',
-        'SOURCE_URI': 'https://github.com/foo/bar.git',
-        'SOURCE_REF': 'master',
-        'OUTPUT_IMAGE': 'asdf:fdsa',
-        'OUTPUT_REGISTRY': output_registry,
-        'ATOMIC_REACTOR_PLUGINS': json.dumps(plugins_json),
-    }
-    flexmock(os, environ=mock_env)
-
-    plugin = OSv3InputPlugin()
-    assert plugin.run()['postbuild_plugins'] == expected_json
-
 
 def test_doesnt_fail_if_no_plugins():
     mock_env = {
@@ -111,7 +30,7 @@ def test_doesnt_fail_if_no_plugins():
     flexmock(os, environ=mock_env)
 
     plugin = OSv3InputPlugin()
-    assert plugin.run()['prebuild_plugins'] == [{'name': 'pull_base_image'}]
+    assert plugin.run()['openshift_build_selflink'] is None
 
 
 @pytest.mark.parametrize('build, expected', [


### PR DESCRIPTION
Manipulating pull_base_image and tag_and_push plugins is no longer
needed. Additionally, this causes errors when creating custom base
images with add_filesystem plugin.