### PR TITLE
koji_promote: seems like build.extra.image is required

### DIFF
--- a/atomic_reactor/plugins/exit_koji_promote.py
+++ b/atomic_reactor/plugins/exit_koji_promote.py
@@ -513,7 +513,7 @@ class KojiPromotePlugin(ExitPlugin):
         if not isinstance(source, GitSource):
             raise RuntimeError('git source required')
 
-        extra = {}
+        extra = {'image': {}}
         koji_task_id = metadata.get('labels', {}).get('koji-task-id')
         if koji_task_id is not None:
             self.log.info("build configuration created by Koji Task ID %s",


### PR DESCRIPTION
It is not listed in the specification any more, but builds do not display correctly without this.