### PR TITLE
squash: removal of old image should not be fatal

### DIFF
--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -258,6 +258,7 @@ class DockerBuildWorkflow(object):
         self.postbuild_results = {}
         self.prepub_results = {}
         self.exit_results = {}
+        self.plugin_workspace = {}
         self.plugins_timestamps = {}
         self.plugins_durations = {}
         self.plugins_errors = {}

--- a/atomic_reactor/plugins/exit_remove_built_image.py
+++ b/atomic_reactor/plugins/exit_remove_built_image.py
@@ -65,3 +65,6 @@ class GarbageCollectionPlugin(ExitPlugin):
                                  image, ex.response.status_code, ex.response.reason)
             else:
                 raise
+        except Exception as ex:
+            self.log.warning("exception while removing image %s: %r, ignoring",
+                             image, ex)

--- a/atomic_reactor/plugins/exit_remove_built_image.py
+++ b/atomic_reactor/plugins/exit_remove_built_image.py
@@ -9,7 +9,6 @@ of the BSD license. See the LICENSE file for details.
 Remove built image (this only makes sense if you store the image in some registry first)
 """
 from atomic_reactor.plugin import ExitPlugin
-from atomic_reactor.util import ImageName
 from atomic_reactor.plugins.post_tag_and_push import TagAndPushPlugin
 
 from docker.errors import APIError
@@ -51,7 +50,7 @@ class GarbageCollectionPlugin(ExitPlugin):
             # FIXME: we may need to add force here, let's try it like this for now
             # FIXME: when ID of pulled img matches an ID of an image already present, don't remove
             for base_image_tag in self.workflow.pulled_base_images:
-                self.remove_image(ImageName.parse(base_image_tag), force=False)
+                self.remove_image(base_image_tag, force=False)
 
         if TagAndPushPlugin.key in self.workflow.postbuild_results:
             for registry in self.workflow.push_conf.docker_registries:

--- a/atomic_reactor/plugins/exit_remove_built_image.py
+++ b/atomic_reactor/plugins/exit_remove_built_image.py
@@ -9,7 +9,6 @@ of the BSD license. See the LICENSE file for details.
 Remove built image (this only makes sense if you store the image in some registry first)
 """
 from atomic_reactor.plugin import ExitPlugin
-from atomic_reactor.plugins.post_tag_and_push import TagAndPushPlugin
 
 from docker.errors import APIError
 
@@ -51,14 +50,6 @@ class GarbageCollectionPlugin(ExitPlugin):
             # FIXME: when ID of pulled img matches an ID of an image already present, don't remove
             for base_image_tag in self.workflow.pulled_base_images:
                 self.remove_image(base_image_tag, force=False)
-
-        if TagAndPushPlugin.key in self.workflow.postbuild_results:
-            for registry in self.workflow.push_conf.docker_registries:
-                for image in self.workflow.tag_conf.images:
-                    registry_image = image.copy()
-                    registry_image.registry = registry.uri
-
-                    self.remove_image(registry_image, force=True)
 
         workspace = self.workflow.plugin_workspace.get(self.key, {})
         images_to_remove = workspace.get('images_to_remove', [])

--- a/atomic_reactor/plugins/post_tag_and_push.py
+++ b/atomic_reactor/plugins/post_tag_and_push.py
@@ -10,6 +10,7 @@ from copy import deepcopy
 import re
 
 from atomic_reactor.plugin import PostBuildPlugin
+from atomic_reactor.plugins.exit_remove_built_image import defer_removal
 
 
 __all__ = ('TagAndPushPlugin', )
@@ -60,6 +61,7 @@ class TagAndPushPlugin(PostBuildPlugin):
                                                       force=True)
 
                 pushed_images.append(registry_image)
+                defer_removal(self.workflow, registry_image)
 
                 digest = self.extract_digest(logs, image.tag or 'latest')
                 if digest:

--- a/atomic_reactor/plugins/pre_add_filesystem.py
+++ b/atomic_reactor/plugins/pre_add_filesystem.py
@@ -20,6 +20,7 @@ import os
 
 from atomic_reactor.constants import DEFAULT_DOWNLOAD_BLOCK_SIZE
 from atomic_reactor.plugin import PreBuildPlugin
+from atomic_reactor.plugins.exit_remove_built_image import defer_removal
 from atomic_reactor.koji_util import create_koji_session, TaskWatcher, stream_task_output
 
 
@@ -213,6 +214,7 @@ class AddFilesystemPlugin(PreBuildPlugin):
 
         new_base_image = self.import_base_image(filesystem)
         self.workflow.builder.set_base_image(new_base_image)
+        defer_removal(self.workflow, new_base_image)
 
         return {
             'base-image-id': new_base_image,

--- a/atomic_reactor/plugins/prepub_squash.py
+++ b/atomic_reactor/plugins/prepub_squash.py
@@ -13,6 +13,7 @@ import os
 
 from atomic_reactor.constants import EXPORTED_SQUASHED_IMAGE_NAME
 from atomic_reactor.plugin import PrePublishPlugin
+from atomic_reactor.plugins.exit_remove_built_image import defer_removal
 from atomic_reactor.util import get_exported_image_metadata
 from docker_squash.squash import Squash
 
@@ -98,6 +99,4 @@ class PrePublishSquashPlugin(PrePublishPlugin):
 
         metadata.update(get_exported_image_metadata(metadata["path"]))
         self.workflow.exported_image_sequence.append(metadata)
-
-        if self.remove_former_image:
-            self.tasker.remove_image(self.image)
+        defer_removal(self.workflow, self.image)

--- a/tests/plugins/test_remove_built_image.py
+++ b/tests/plugins/test_remove_built_image.py
@@ -8,31 +8,31 @@ of the BSD license. See the LICENSE file for details.
 
 from __future__ import print_function, unicode_literals
 
+import flexmock
+import pytest
+
 from atomic_reactor.core import DockerTasker
 from atomic_reactor.inner import DockerBuildWorkflow
 from atomic_reactor.plugin import PostBuildPluginsRunner
-from atomic_reactor.plugins.exit_remove_built_image import GarbageCollectionPlugin
+from atomic_reactor.plugins.exit_remove_built_image import (GarbageCollectionPlugin,
+                                                            defer_removal)
 from atomic_reactor.plugins.post_tag_and_push import TagAndPushPlugin
 from atomic_reactor.util import ImageName
-from tests.constants import LOCALHOST_REGISTRY, TEST_IMAGE, INPUT_IMAGE, MOCK
+from tests.constants import (LOCALHOST_REGISTRY,
+                             TEST_IMAGE,
+                             IMPORTED_IMAGE_ID,
+                             INPUT_IMAGE,
+                             MOCK)
 
 if MOCK:
     from tests.docker_mock import mock_docker
 
 
-class Y(object):
+class X(object):
     pass
 
 
-class X(object):
-    image_id = INPUT_IMAGE
-    source = Y()
-    source.dockerfile_path = None
-    source.path = None
-    base_image = ImageName(repo="qwe", tag="asd")
-
-
-def test_remove_built_image_plugin(tmpdir):
+def mock_environment(base_image=None):
     if MOCK:
         mock_docker()
 
@@ -42,13 +42,43 @@ def test_remove_built_image_plugin(tmpdir):
     workflow.postbuild_results[TagAndPushPlugin.key] = True
     workflow.tag_conf.add_primary_image(TEST_IMAGE)
     workflow.push_conf.add_docker_registry(LOCALHOST_REGISTRY, insecure=True)
-    setattr(workflow, 'builder', X)
+    setattr(workflow, 'builder', X())
+    setattr(workflow.builder, 'image_id', INPUT_IMAGE)
+    setattr(workflow.builder, 'source', X())
+    setattr(workflow.builder.source, 'dockerfile_path', None)
+    setattr(workflow.builder.source, 'path', None)
+    base_image = ImageName.parse(IMPORTED_IMAGE_ID)
+    setattr(workflow.builder, 'base_image', base_image)
+    workflow.pulled_base_images.add(IMPORTED_IMAGE_ID)
+    return tasker, workflow
 
-    runner = PostBuildPluginsRunner(
-        tasker,
-        workflow,
-        [{
-            'name': GarbageCollectionPlugin.key,
-        }]
-    )
-    output = runner.run()
+
+class TestGarbageCollectionPlugin(object):
+    @pytest.mark.parametrize(('remove_base', 'deferred', 'expected'), [
+        (False, [], set([INPUT_IMAGE])),
+        (False, ['defer'], set([INPUT_IMAGE, 'defer'])),
+        (True, [], set([IMPORTED_IMAGE_ID, INPUT_IMAGE])),
+        (True, ['defer'], set([IMPORTED_IMAGE_ID, INPUT_IMAGE, 'defer'])),
+    ])
+    def test_remove_built_image_plugin(self, remove_base, deferred, expected):
+        tasker, workflow = mock_environment()
+        runner = PostBuildPluginsRunner(
+            tasker,
+            workflow,
+            [{
+                'name': GarbageCollectionPlugin.key,
+                'args': {'remove_pulled_base_image': remove_base},
+            }]
+        )
+        removed_images = []
+        def spy_remove_image(image_id, force=None):
+            removed_images.append(image_id)
+
+        flexmock(tasker, remove_image=spy_remove_image)
+        for image in deferred:
+            defer_removal(workflow, image)
+
+        output = runner.run()
+        image_set = set(removed_images)
+        assert len(image_set) == len(removed_images)
+        assert image_set == expected


### PR DESCRIPTION
This pull request adds a new helper function to the remove_built_image plugin, defer_removal. This helper function can be called from other plugins in order to ask that an image be removed at the end of the build. This removal should not be fatal.

As part of this I added a plugin workspace to the workflow object, which is storage that can be used by helper functions. It is persistent for the duration of the build workflow.

There are probably other member variables in the workflow that were being used for this purpose (eg pull_base_images), and they could probably be moved into the workspace.