### PR TITLE
Use labels from Config section of docker inspect

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -32,6 +32,10 @@ DEFAULT_YUM_REPOFILE_NAME = 'atomic-reactor-injected.repo'
 
 SOURCE_DIRECTORY_NAME = "source"
 
+# key in dictionary returned by "docker inspect" that holds the image
+# configuration (such as labels)
+INSPECT_CONFIG = "Config"
+
 # docs constants
 
 DESCRIPTION = "Python library with command line interface for building docker images."

--- a/atomic_reactor/plugins/post_tag_by_labels.py
+++ b/atomic_reactor/plugins/post_tag_by_labels.py
@@ -7,6 +7,7 @@ of the BSD license. See the LICENSE file for details.
 """
 
 from atomic_reactor.plugin import PostBuildPlugin
+from atomic_reactor.constants import INSPECT_CONFIG
 
 
 __all__ = ('TagByLabelsPlugin', )
@@ -37,12 +38,12 @@ class TagByLabelsPlugin(PostBuildPlugin):
         if not self.workflow.built_image_inspect:
             raise RuntimeError("There are no inspect data of built image. "
                                "Have the build succeeded?")
-        if "Labels" not in self.workflow.built_image_inspect["ContainerConfig"]:
+        if "Labels" not in self.workflow.built_image_inspect[INSPECT_CONFIG]:
             raise RuntimeError("No labels specified.")
 
         def get_label(label_name):
             try:
-                return self.workflow.built_image_inspect["ContainerConfig"]["Labels"][label_name]
+                return self.workflow.built_image_inspect[INSPECT_CONFIG]["Labels"][label_name]
             except KeyError:
                 raise RuntimeError("Missing label '%s'." % label_name)
 

--- a/atomic_reactor/plugins/pre_add_labels_in_df.py
+++ b/atomic_reactor/plugins/pre_add_labels_in_df.py
@@ -43,6 +43,7 @@ from __future__ import unicode_literals
 
 from dockerfile_parse import DockerfileParser
 from atomic_reactor.plugin import PreBuildPlugin
+from atomic_reactor.constants import INSPECT_CONFIG
 import json
 import datetime
 
@@ -160,7 +161,7 @@ class AddLabelsPlugin(PreBuildPlugin):
         run the plugin
         """
         try:
-            config = self.workflow.base_image_inspect["Config"]
+            config = self.workflow.base_image_inspect[INSPECT_CONFIG]
         except (AttributeError, TypeError):
             message = "base image was not inspected"
             self.log.error(message)

--- a/atomic_reactor/plugins/pre_inject_yum_repo.py
+++ b/atomic_reactor/plugins/pre_inject_yum_repo.py
@@ -11,7 +11,7 @@ Pre build plugin which injects custom yum repository in dockerfile.
 import os
 import re
 from dockerfile_parse import DockerfileParser
-from atomic_reactor.constants import YUM_REPOS_DIR, RELATIVE_REPOS_PATH
+from atomic_reactor.constants import YUM_REPOS_DIR, RELATIVE_REPOS_PATH, INSPECT_CONFIG
 from atomic_reactor.plugin import PreBuildPlugin
 
 
@@ -155,7 +155,7 @@ class InjectYumRepoPlugin(PreBuildPlugin):
 
             # Find out the USER inherited from the base image
             inspect = self.workflow.builder.inspect_base_image()
-            inherited_user = inspect['Config'].get('User', '')
+            inherited_user = inspect[INSPECT_CONFIG].get('User', '')
             df = DockerfileParser(self.workflow.builder.df_path)
             df.lines = add_yum_repos_to_dockerfile(repos_host_cont_mapping,
                                                    df, inherited_user)

--- a/tests/plugins/test_add_dockerfile.py
+++ b/tests/plugins/test_add_dockerfile.py
@@ -16,6 +16,7 @@ from atomic_reactor.plugin import PreBuildPluginsRunner
 from atomic_reactor.plugins.pre_add_dockerfile import AddDockerfilePlugin
 from atomic_reactor.plugins.pre_add_labels_in_df import AddLabelsPlugin
 from atomic_reactor.util import ImageName
+from atomic_reactor.constants import INSPECT_CONFIG
 from tests.constants import MOCK_SOURCE, MOCK
 from tests.fixtures import docker_tasker
 if MOCK:
@@ -138,7 +139,7 @@ CMD blabla"""
         mock_docker()
 
     workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image')
-    flexmock(workflow, base_image_inspect={"Config": {"Labels": {}}})
+    flexmock(workflow, base_image_inspect={INSPECT_CONFIG: {"Labels": {}}})
     workflow.builder = X
     workflow.builder.df_path = df.dockerfile_path
     workflow.builder.df_dir = str(tmpdir)

--- a/tests/plugins/test_add_labels.py
+++ b/tests/plugins/test_add_labels.py
@@ -19,6 +19,7 @@ from atomic_reactor.plugin import PreBuildPluginsRunner
 from atomic_reactor.plugins.pre_add_labels_in_df import AddLabelsPlugin
 from atomic_reactor.util import ImageName
 from atomic_reactor.source import VcsInfo
+from atomic_reactor.constants import INSPECT_CONFIG
 import re
 import json
 import pytest
@@ -50,8 +51,8 @@ FROM fedora"""
 DF_CONTENT_LABEL = '''\
 FROM fedora
 LABEL "label2"="df value"'''
-LABELS_CONF_BASE = {"Config": {"Labels": {"label1": "base value"}}}
-LABELS_CONF_BASE_NONE = {"Config": {"Labels": None}}
+LABELS_CONF_BASE = {INSPECT_CONFIG: {"Labels": {"label1": "base value"}}}
+LABELS_CONF_BASE_NONE = {INSPECT_CONFIG: {"Labels": None}}
 LABELS_CONF = OrderedDict({'label1': 'value 1', 'label2': 'long value'})
 LABELS_CONF_ONE = {'label2': 'long value'}
 LABELS_CONF_WRONG = [('label1', 'value1'), ('label2', 'value2')]
@@ -257,11 +258,11 @@ def test_add_labels_aliases(tmpdir, docker_tasker, caplog,
         else:
             df_content += 'LABEL label_new="{0}"\n'.format(df_new)
 
-    base_labels = {"Config": {"Labels": {}}}
+    base_labels = {INSPECT_CONFIG: {"Labels": {}}}
     if base_old:
-        base_labels["Config"]["Labels"]["label_old"] = base_old
+        base_labels[INSPECT_CONFIG]["Labels"]["label_old"] = base_old
     if base_new:
-        base_labels["Config"]["Labels"]["label_new"] = base_new
+        base_labels[INSPECT_CONFIG]["Labels"]["label_new"] = base_new
 
     df = DockerfileParser(str(tmpdir))
     df.content = df_content
@@ -287,8 +288,8 @@ def test_add_labels_aliases(tmpdir, docker_tasker, caplog,
 
     runner.run()
     assert AddLabelsPlugin.key is not None
-    result_old = df.labels.get("label_old") or base_labels["Config"]["Labels"].get("label_old")
-    result_new = df.labels.get("label_new") or base_labels["Config"]["Labels"].get("label_new")
+    result_old = df.labels.get("label_old") or base_labels[INSPECT_CONFIG]["Labels"].get("label_old")
+    result_new = df.labels.get("label_new") or base_labels[INSPECT_CONFIG]["Labels"].get("label_new")
     assert result_old == expected_old
     assert result_new == expected_new
 

--- a/tests/plugins/test_tag_by_labels.py
+++ b/tests/plugins/test_tag_by_labels.py
@@ -14,6 +14,7 @@ from atomic_reactor.plugin import PostBuildPluginsRunner
 from atomic_reactor.plugins.post_tag_and_push import TagAndPushPlugin
 from atomic_reactor.plugins.post_tag_by_labels import TagByLabelsPlugin
 from atomic_reactor.util import ImageName
+from atomic_reactor.constants import INSPECT_CONFIG
 from tests.constants import LOCALHOST_REGISTRY, TEST_IMAGE, INPUT_IMAGE, MOCK
 
 if MOCK:
@@ -42,7 +43,7 @@ def test_tag_by_labels_plugin(tmpdir):
     version = "1.0"
     release = "1"
     workflow.built_image_inspect = {
-        "ContainerConfig": {
+        INSPECT_CONFIG: {
             "Labels": {
                 "Name": TEST_IMAGE,
                 "Version": version,

--- a/tests/plugins/test_yum_inject.py
+++ b/tests/plugins/test_yum_inject.py
@@ -10,7 +10,8 @@ of the BSD license. See the LICENSE file for details.
 from __future__ import print_function, unicode_literals
 
 import os
-from atomic_reactor.constants import YUM_REPOS_DIR, DEFAULT_YUM_REPOFILE_NAME, RELATIVE_REPOS_PATH
+from atomic_reactor.constants import (YUM_REPOS_DIR, DEFAULT_YUM_REPOFILE_NAME, RELATIVE_REPOS_PATH,
+                                      INSPECT_CONFIG)
 
 try:
     from collections import OrderedDict
@@ -54,7 +55,7 @@ def prepare(df_path, inherited_user=''):
     setattr(workflow.builder.source, 'dockerfile_path', None)
     setattr(workflow.builder.source, 'path', '')
 
-    inspection_data = {'Config': {'User': inherited_user}}
+    inspection_data = {INSPECT_CONFIG: {'User': inherited_user}}
     workflow.builder.inspect_base_image = lambda: inspection_data
     (flexmock(requests.Response, content=repocontent)
      .should_receive('raise_for_status')


### PR DESCRIPTION
I'm unable to find a definition of the docker inspect output, however I think that Labels should be read from the Config dictionary and not ContainerConfig.

Functionally this commit doesn't change anything because pre_ plugins have been using Config already and the only use of ContainerConfig was in post_ plugins where it doesn't really matter because after "docker build" the two dictionaries are identical. The intent is to make code less ambiguous.

Fixes #434.