### PR TITLE
koji_promote: fixes for build start time reporting

### DIFF
--- a/atomic_reactor/__init__.py
+++ b/atomic_reactor/__init__.py
@@ -10,9 +10,11 @@ constants
 """
 
 import logging
+import time
 
 
 __version__ = "1.6.9"
+start_time = time.time()
 
 
 def set_logging(name="atomic_reactor", level=logging.DEBUG, handler=None):

--- a/atomic_reactor/plugins/exit_koji_promote.py
+++ b/atomic_reactor/plugins/exit_koji_promote.py
@@ -18,6 +18,7 @@ from tempfile import NamedTemporaryFile
 import time
 
 from atomic_reactor import __version__ as atomic_reactor_version
+from atomic_reactor import start_time as atomic_reactor_start_time
 from atomic_reactor.plugin import ExitPlugin
 from atomic_reactor.source import GitSource
 from atomic_reactor.plugins.post_rpmqa import PostBuildRPMqaPlugin
@@ -494,17 +495,7 @@ class KojiPromotePlugin(ExitPlugin):
         return output_files
 
     def get_build(self, metadata):
-        build_start_time = metadata["creationTimestamp"]
-        try:
-            # Decode UTC RFC3339 date with no fractional seconds
-            # (the format we expect)
-            start_time_struct = time.strptime(build_start_time,
-                                              '%Y-%m-%dT%H:%M:%SZ')
-            start_time = int(time.mktime(start_time_struct))
-        except ValueError:
-            self.log.error("Invalid time format (%s)", build_start_time)
-            raise
-
+        start_time = int(atomic_reactor_start_time)
         labels = DockerfileParser(self.workflow.builder.df_path).labels
         component = get_preferred_label(labels, 'com.redhat.component')
         version = get_preferred_label(labels, 'version')

--- a/atomic_reactor/plugins/pre_add_labels_in_df.py
+++ b/atomic_reactor/plugins/pre_add_labels_in_df.py
@@ -42,6 +42,7 @@ Keys and values are quoted as necessary.
 from __future__ import unicode_literals
 
 from dockerfile_parse import DockerfileParser
+from atomic_reactor import start_time as atomic_reactor_start_time
 from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.constants import INSPECT_CONFIG
 import json
@@ -86,9 +87,8 @@ class AddLabelsPlugin(PreBuildPlugin):
         generated = {}
 
         # build date
-        rfc3339_ts = datetime.datetime.utcnow().isoformat()
-        rfc3339_ts += 'Z'
-        generated['build-date'] = rfc3339_ts
+        dt = datetime.datetime.fromtimestamp(atomic_reactor_start_time)
+        generated['build-date'] = dt.isoformat() + 'Z'
 
         # architecture - assuming host and image architecture is the same
         # TODO: this code is also in plugins/exit_koji_promote.py, factor it out

--- a/tests/plugins/test_koji_promote.py
+++ b/tests/plugins/test_koji_promote.py
@@ -380,22 +380,6 @@ class TestKojiPromote(object):
         with pytest.raises(PluginFailedException):
             runner.run()
 
-    def test_koji_promote_invalid_creation_timestamp(self, tmpdir, monkeypatch, os_env):
-        tasker, workflow = mock_environment(tmpdir,
-                                            name='ns/name',
-                                            version='1.0',
-                                            release='1')
-        runner = create_runner(tasker, workflow)
-
-        # Invalid timestamp format
-        monkeypatch.setenv("BUILD", json.dumps({
-            "metadata": {
-                "creationTimestamp": "2015-07-27 09:24 UTC"
-            }
-        }))
-        with pytest.raises(PluginFailedException):
-            runner.run()
-
     def test_koji_promote_wrong_source_type(self, tmpdir, os_env):
         source = PathSource('path', 'file:///dev/null')
         tasker, workflow = mock_environment(tmpdir,


### PR DESCRIPTION
Use the real start time (not creation time), and don't mis-parse the timezone.