### PR TITLE
some docs fixes

### DIFF
--- a/atomic_reactor/api.py
+++ b/atomic_reactor/api.py
@@ -6,7 +6,7 @@ This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 
 
-Python API for atomic_reactor. This is the official way of interacting with atomic_reactor.
+Python API for atomic-reactor. This is the official way of interacting with atomic-reactor.
 """
 from atomic_reactor.inner import DockerBuildWorkflow
 from atomic_reactor.outer import PrivilegedBuildManager, DockerhostBuildManager

--- a/atomic_reactor/plugins/pre_bump_release.py
+++ b/atomic_reactor/plugins/pre_bump_release.py
@@ -31,7 +31,6 @@ class BumpReleasePlugin(PreBuildPlugin):
         :param workflow: DockerBuildWorkflow instance
         :param target: string, koji target to use as a source
         :param hub: string, koji hub (xmlrpc)
-        :param proxy: string, proxy user
         """
         # call parent constructor
         super(BumpReleasePlugin, self).__init__(tasker, workflow)

--- a/docs/apidocs/top.md
+++ b/docs/apidocs/top.md
@@ -1,6 +1,6 @@
 # API
 
-Atomic Reactor has proper python API. You can use it in your scripts or services without invoking shell:
+atomic-reactor has proper python API. You can use it in your scripts or services without invoking shell:
 
 ```python
 from atomic_reactor.api import build_image_in_privileged_container
@@ -9,7 +9,7 @@ response = build_image_in_privileged_container(
     source={
         'provider': 'git',
         'uri': 'https://github.com/TomasTomecek/docker-hello-world.git',
-    }
+    },
     image="atomic-reactor-test-image",
 )
 ```


### PR DESCRIPTION
docs/api.md is intended to be generated from docs/apidocs/ but was not entirely in sync for the boilerplate part (top.md).

The bump_release plugin documented a parameter that does not exist.