### PR TITLE
Mark plugin as failed if plugin crashed on init

### DIFF
--- a/atomic_reactor/plugin.py
+++ b/atomic_reactor/plugin.py
@@ -204,11 +204,10 @@ class PluginsRunner(object):
 
             logger.debug("running plugin '%s'", plugin_name)
 
-            plugin_instance = self.create_instance_from_plugin(plugin_class, plugin_conf)
-            start_time = datetime.datetime.now()
-            self.save_plugin_timestamp(plugin_instance.key, start_time)
-
             try:
+                plugin_instance = self.create_instance_from_plugin(plugin_class, plugin_conf)
+                start_time = datetime.datetime.now()
+                self.save_plugin_timestamp(plugin_class.key, start_time)
                 plugin_response = plugin_instance.run()
             except AutoRebuildCanceledException as ex:
                 # if auto rebuild is canceled, then just reraise
@@ -218,7 +217,7 @@ class PluginsRunner(object):
                 #   AutoRebuildCanceledException was raised here)
                 raise
             except Exception as ex:
-                msg = "plugin '%s' raised an exception: %r" % (plugin_instance.key, ex)
+                msg = "plugin '%s' raised an exception: %r" % (plugin_class.key, ex)
                 logger.debug(traceback.format_exc())
                 if plugin_is_allowed_to_fail or keep_going:
                     logger.warning(msg)
@@ -226,7 +225,7 @@ class PluginsRunner(object):
                     if not plugin_is_allowed_to_fail:
                         failed_msgs.append(msg)
                 else:
-                    self.on_plugin_failed(plugin_instance.key, ex)
+                    self.on_plugin_failed(plugin_class.key, ex)
                     logger.error(msg)
                     raise PluginFailedException(msg)
 
@@ -237,11 +236,11 @@ class PluginsRunner(object):
                 duration = finish_time - start_time
                 seconds = duration.total_seconds()
                 logger.debug("plugin '%s' finished in %ds", plugin_name, seconds)
-                self.save_plugin_duration(plugin_instance.key, seconds)
+                self.save_plugin_duration(plugin_class.key, seconds)
             except Exception:
-                logger.exception("failed to save plugin duration")
+                logger.error("failed to save plugin duration")
 
-            self.plugins_results[plugin_instance.key] = plugin_response
+            self.plugins_results[plugin_class.key] = plugin_response
         if len(failed_msgs) == 1:
             raise PluginFailedException(failed_msgs[0])
         elif len(failed_msgs) > 1:

--- a/atomic_reactor/plugin.py
+++ b/atomic_reactor/plugin.py
@@ -232,13 +232,14 @@ class PluginsRunner(object):
                 plugin_response = ex
 
             try:
-                finish_time = datetime.datetime.now()
-                duration = finish_time - start_time
-                seconds = duration.total_seconds()
-                logger.debug("plugin '%s' finished in %ds", plugin_name, seconds)
-                self.save_plugin_duration(plugin_class.key, seconds)
+                if start_time:
+                    finish_time = datetime.datetime.now()
+                    duration = finish_time - start_time
+                    seconds = duration.total_seconds()
+                    logger.debug("plugin '%s' finished in %ds", plugin_name, seconds)
+                    self.save_plugin_duration(plugin_class.key, seconds)
             except Exception:
-                logger.error("failed to save plugin duration")
+                logger.exception("failed to save plugin duration")
 
             self.plugins_results[plugin_class.key] = plugin_response
         if len(failed_msgs) == 1:

--- a/tests/plugins/test_add_dockerfile.py
+++ b/tests/plugins/test_add_dockerfile.py
@@ -164,7 +164,7 @@ CMD blabla"""
     assert "ADD Dockerfile-jboss-eap-6-docker-6.4-77 /root/buildinfo/Dockerfile-jboss-eap-6-docker-6.4-77" in df.content
 
 
-def test_adddockerfile_fails(tmpdir, docker_tasker):
+def test_adddockerfile_fails(tmpdir, docker_tasker, caplog):
     df_content = """
 FROM fedora
 RUN yum install -y python-django
@@ -184,8 +184,8 @@ CMD blabla"""
             'name': AddDockerfilePlugin.key
         }]
     )
-    with pytest.raises(ValueError):
-        runner.run()
+    runner.run()
+    assert "plugin 'add_dockerfile' raised an exception: ValueError" in caplog.text()
 
 
 def test_adddockerfile_final(tmpdir, docker_tasker):
@@ -218,4 +218,3 @@ RUN yum install -y python-django
 ADD Dockerfile /root/buildinfo/Dockerfile-rhel-server-docker-7.1-20
 CMD blabla"""
     assert df.content == expected_output
-

--- a/tests/plugins/test_add_labels.py
+++ b/tests/plugins/test_add_labels.py
@@ -114,7 +114,8 @@ LABEL "label1"="df value"
     (DF_CONTENT_LABEL, LABELS_CONF_BASE, LABELS_BLANK, [], {"label2": "label1"}, EXPECTED_OUTPUT8),
 ])
 def test_add_labels_plugin(tmpdir, docker_tasker,
-                           df_content, labels_conf_base, labels_conf, dont_overwrite, aliases, expected_output):
+                           df_content, labels_conf_base, labels_conf, dont_overwrite, aliases,
+                           expected_output, caplog):
     df = DockerfileParser(str(tmpdir))
     df.content = df_content
 
@@ -140,11 +141,11 @@ def test_add_labels_plugin(tmpdir, docker_tasker,
         }]
     )
 
+    runner.run()
     if isinstance(expected_output, RuntimeError):
-        with pytest.raises(RuntimeError):
-            runner.run()
+        assert "plugin 'add_labels_in_dockerfile' raised an exception: RuntimeError" in caplog.text()
+
     else:
-        runner.run()
         assert AddLabelsPlugin.key is not None
         assert df.content in expected_output
 

--- a/tests/plugins/test_koji_promote.py
+++ b/tests/plugins/test_koji_promote.py
@@ -365,8 +365,9 @@ class TestKojiPromote(object):
         # No BUILD environment variable
         monkeypatch.delenv("BUILD", raising=False)
 
-        with pytest.raises(KeyError):
+        with pytest.raises(PluginFailedException) as exc:
             runner.run()
+        assert "plugin 'koji_promote' raised an exception: KeyError" in str(exc)
 
     def test_koji_promote_no_build_metadata(self, tmpdir, monkeypatch, os_env):
         tasker, workflow = mock_environment(tmpdir,
@@ -388,8 +389,9 @@ class TestKojiPromote(object):
                                             release='1',
                                             source=source)
         runner = create_runner(tasker, workflow)
-        with pytest.raises(PluginFailedException):
+        with pytest.raises(PluginFailedException) as exc:
             runner.run()
+        assert "plugin 'koji_promote' raised an exception: RuntimeError" in str(exc)
 
     def test_koji_promote_log_task_id(self, tmpdir, monkeypatch, os_env,
                                       caplog):


### PR DESCRIPTION
Put plugin init in try..catch block so that an exception in plugin init fails the plugin, not the build.

Reproduced this in ```bump_release``` plugin with local Koji, which dissallows connections without a certificate.

Fixes #518