### PR TITLE
pulp_sync: provide basic auth required for registry

### DIFF
--- a/atomic_reactor/plugins/post_pulp_sync.py
+++ b/atomic_reactor/plugins/post_pulp_sync.py
@@ -6,22 +6,35 @@ of the BSD license. See the LICENSE file for details.
 
 Sync built image to pulp registry using Docker Registry HTTP API V2
 
-Authentication is via a key and certificate in a secret which the
-builder service account is allowed to mount:
+Pulp authentication is via a key and certificate. Docker V2 registry
+authentication is via a dockercfg file. Both of these sets of
+credentials are stored in secrets which the builder service account is
+allowed to mount:
 
-$ oc secrets new pulp ./pulp.key ./pulp.cer
-secrets/pulp
+$ oc secrets new pulp pulp.key=./pulp.key pulp.cer=./pulp.cer
+secret/pulp
 $ oc secrets add serviceaccount/builder secret/pulp --for=mount
+$ oc secrets new-dockercfg registry-dockercfg [...]
+secret/registry-dockercfg
+$ oc secrets add serviceaccount/builder secret/registry-dockercfg --for=mount
 
-In the BuildConfig for atomic-reactor, specify the secret in the
+In the BuildConfig for atomic-reactor, specify the secrets in the
 strategy's 'secrets' array, specifying a mount path:
 
-"secrets": [{
-  "secretSource": {
-    "name": "pulp"
+"secrets": [
+  {
+    "secretSource": {
+      "name": "pulp"
+    },
+    "mountPath": "/var/run/secrets/pulp"
   },
-  "mountPath": "/var/run/secrets/pulp"
-}]
+  {
+    "secretSource": {
+      "name": "registry-dockercfg"
+    },
+    "mountPath": "/var/run/secrets/registry-dockercfg"
+  }
+]
 
 In the configuration for this plugin, specify the same path for
 pulp_secret_path:
@@ -29,7 +42,8 @@ pulp_secret_path:
 "pulp_sync": {
   "pulp_registry_name": ...,
   ...
-  "pulp_secret_path": "/var/run/secrets/pulp"
+  "pulp_secret_path": "/var/run/secrets/pulp",
+  "registry_secret_path": "/var/run/secrets/registry-dockercfg"
 }
 
 """
@@ -38,50 +52,22 @@ from __future__ import print_function, unicode_literals
 
 from atomic_reactor.plugin import PostBuildPlugin
 from atomic_reactor.util import ImageName
-from contextlib import contextmanager
 import dockpulp
+import json
 import os
 import re
-from tempfile import NamedTemporaryFile
 
 
 # let's silence warnings from dockpulp: there is one warning for every
-# request which may result in tenths of messages: very annoying with
-# "module", it just prints one warning -- this should balance security
+# request which may result in tens of messages: very annoying.
+# with "module", it just prints one warning -- this should balance security
 # and UX
 from warnings import filterwarnings
 filterwarnings("module")
 
 
-@contextmanager
-def dockpulp_config(docker_registry, **kwargs):
-    """
-    Temporary dockpulp config pointing to the docker v2 registry
-
-    :yields: NamedTemporaryFile instance
-    """
-
-    env = 'sync'
-    template = """
-[registries]
-{sync}
-
-[filers]
-{sync}
-
-[pulps]
-{sync}
-"""
-    sync = '{env} = {url}'.format(env=env, url=docker_registry)
-    with NamedTemporaryFile('wt', **kwargs) as config:
-        config.write(template.format(sync=sync))
-        config.flush()
-        config.env = env
-        yield config
-
-
 class PulpSyncPlugin(PostBuildPlugin):
-    key = "pulp_sync"
+    key = 'pulp_sync'
     is_allowed_to_fail = False
 
     CER = 'pulp.cer'
@@ -92,7 +78,8 @@ class PulpSyncPlugin(PostBuildPlugin):
                  docker_registry,
                  delete_from_registry=False,
                  pulp_secret_path=None,
-                 username=None, password=None,
+                 registry_secret_path=None,
+                 insecure_registry=None,
                  dockpulp_loglevel=None):
         """
         constructor
@@ -102,21 +89,21 @@ class PulpSyncPlugin(PostBuildPlugin):
         :param pulp_registry_name: str, name of pulp registry to use,
                specified in /etc/dockpulp.conf
         :param docker_registry: str, URL of docker registry to sync from
+               including scheme e.g. https://registry.example.com
         :param delete_from_registry: bool, whether to delete the image
                from the docker v2 registry after sync
         :param pulp_secret_path: path to pulp.cer and pulp.key
-        :param username: pulp username, used in preference to
-               certificate and key
-        :param password: pulp password, used in preference to
-               certificate and key
+        :param registry_secret_path: path to .dockercfg for the V2 registry
+        :param insecure_registry: True if SSL validation should be skipped
+        :param dockpulp_loglevel: int, logging level for dockpulp
         """
         # call parent constructor
         super(PulpSyncPlugin, self).__init__(tasker, workflow)
         self.pulp_registry_name = pulp_registry_name
         self.docker_registry = docker_registry
         self.pulp_secret_path = pulp_secret_path
-        self.username = username
-        self.password = password
+        self.registry_secret_path = registry_secret_path
+        self.insecure_registry = insecure_registry
 
         if dockpulp_loglevel is not None:
             logger = dockpulp.setup_logger(dockpulp.log)
@@ -131,16 +118,9 @@ class PulpSyncPlugin(PostBuildPlugin):
                            "not implemented")
 
     def set_auth(self, pulp):
-        if self.username and self.password:
-            # Use username and password if provided
-            pulp.login(self.username, self.password)
-        elif self.pulp_secret_path or 'SOURCE_SECRET_PATH' in os.environ:
-            if self.pulp_secret_path is not None:
-                path = self.pulp_secret_path
-                self.log.info("using configured path %s for secrets", path)
-            else:
-                path = os.environ["SOURCE_SECRET_PATH"]
-                self.log.info("SOURCE_SECRET_PATH=%s from environment", path)
+        path = self.pulp_secret_path
+        if path is not None:
+            self.log.info("using configured path %s for secrets", path)
 
             # Work out the pathnames for the certificate/key pair
             cer = os.path.join(path, self.CER)
@@ -154,14 +134,44 @@ class PulpSyncPlugin(PostBuildPlugin):
             # Tell dockpulp
             pulp.set_certs(cer, key)
 
+    def get_dockercfg_credentials(self, docker_registry):
+        """
+        Read the .dockercfg file and return an empty dict, or else a dict
+        with keys 'basic_auth_username' and 'basic_auth_password'.
+        """
+        if not self.registry_secret_path:
+            return {}
+
+        json_secret_path = os.path.join(self.registry_secret_path,
+                                        '.dockercfg')
+        try:
+            with open(json_secret_path) as fp:
+                json_secret = json.load(fp)
+        except Exception:
+            msg = "failed to read registry secret"
+            self.log.error(msg, exc_info=True)
+            raise RuntimeError(msg)
+
+        try:
+            registry_creds = json_secret[docker_registry]
+        except KeyError:
+            self.log.warn('%s not found in .dockercfg',
+                          docker_registry)
+            return {}
+
+        return {
+            'basic_auth_username': registry_creds['username'],
+            'basic_auth_password': registry_creds['password'],
+        }
+
     def run(self):
         pulp = dockpulp.Pulp(env=self.pulp_registry_name)
         self.set_auth(pulp)
 
         # We only want the hostname[:port]
-        pulp_registry = re.sub(r'^https?://([^/]*)/?.*',
-                               lambda m: m.groups()[0],
-                               pulp.registry)
+        hostname_and_port = re.compile(r'^https?://([^/]*)/?.*')
+        pulp_registry = hostname_and_port.sub(lambda m: m.groups()[0],
+                                              pulp.registry)
 
         # Store the registry URI in the push configuration
         self.workflow.push_conf.add_pulp_registry(self.pulp_registry_name,
@@ -170,22 +180,28 @@ class PulpSyncPlugin(PostBuildPlugin):
         self.log.info("syncing from docker V2 registry %s",
                       self.docker_registry)
 
+        docker_registry = hostname_and_port.sub(lambda m: m.groups()[0],
+                                                self.docker_registry)
+
+        kwargs = self.get_dockercfg_credentials(docker_registry)
+        if self.insecure_registry is not None:
+            kwargs['ssl_validation'] = not self.insecure_registry
+
         images = []
         repos = {}  # pulp repo -> repo id
-        with dockpulp_config(docker_registry=self.docker_registry) as config:
-            for image in self.workflow.tag_conf.primary_images:
-                if image.pulp_repo not in repos:
-                    self.log.info("syncing %s", image.pulp_repo)
-                    repoinfo = pulp.syncRepo(config.env, image.pulp_repo,
-                                             config_file=config.name)
-                    repos[image.pulp_repo] = repoinfo[0]['id']
+        for image in self.workflow.tag_conf.primary_images:
+            if image.pulp_repo not in repos:
+                self.log.info("syncing %s", image.pulp_repo)
+                repoinfo = pulp.syncRepo(feed=self.docker_registry,
+                                         upstream_name=image.repo,
+                                         **kwargs)
+                repos[image.pulp_repo] = repoinfo[0]['id']
 
-
-                images.append(ImageName(registry=pulp_registry,
-                                        repo=image.repo))
+            images.append(ImageName(registry=pulp_registry,
+                                    repo=image.repo))
 
         self.log.info("publishing to crane")
         pulp.crane(list(repos.values()), wait=True)
 
-        # Return the set of qualitifed repo names for this image
+        # Return the set of qualified repo names for this image
         return images

--- a/atomic_reactor/plugins/post_pulp_sync.py
+++ b/atomic_reactor/plugins/post_pulp_sync.py
@@ -179,7 +179,8 @@ class PulpSyncPlugin(PostBuildPlugin):
         for image in self.workflow.tag_conf.primary_images:
             if image.pulp_repo not in repos:
                 self.log.info("syncing %s", image.pulp_repo)
-                repoinfo = pulp.syncRepo(feed=self.docker_registry,
+                repoinfo = pulp.syncRepo(repo=image.pulp_repo,
+                                         feed=self.docker_registry,
                                          upstream_name=image.repo,
                                          **kwargs)
                 repos[image.pulp_repo] = repoinfo[0]['id']

--- a/atomic_reactor/plugins/post_pulp_sync.py
+++ b/atomic_reactor/plugins/post_pulp_sync.py
@@ -201,7 +201,6 @@ class PulpSyncPlugin(PostBuildPlugin):
                 self.log.info("syncing %s", image.pulp_repo)
                 repoinfo = pulp.syncRepo(repo=image.pulp_repo,
                                          feed=self.docker_registry,
-                                         upstream_name=image.repo,
                                          **kwargs)
                 repos[image.pulp_repo] = repoinfo[0]['id']
 

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -592,3 +592,29 @@ def human_size(num, suffix='B'):
             return "%3.2f %s%s" % (num, unit, suffix)
         num /= 1024.0
     return "%.2f %s%s" % (num, 'Yi', suffix)
+
+
+class Dockercfg(object):
+    def __init__(self, secret_path):
+        """
+        Create a new Dockercfg object from a .dockercfg file whose
+        containing directory is secret_path.
+
+        :param secret_path: str, dirname of .dockercfg location
+        """
+
+        json_secret_path = os.path.join(secret_path, '.dockercfg')
+        try:
+            with open(json_secret_path) as fp:
+                self.json_secret = json.load(fp)
+        except Exception:
+            msg = "failed to read registry secret"
+            logger.error(msg, exc_info=True)
+            raise RuntimeError(msg)
+
+    def get_credentials(self, docker_registry):
+        try:
+            return self.json_secret[docker_registry]
+        except KeyError:
+            logger.warn('%s not found in .dockercfg', docker_registry)
+            return {}

--- a/tests/dockpulp/__init__.py
+++ b/tests/dockpulp/__init__.py
@@ -1,0 +1,36 @@
+"""
+Copyright (c) 2016 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+log = None
+
+
+def setup_logger(logger):
+    raise RuntimeError
+
+
+class Pulp(object):
+    """
+    dockpulp.Pulp stub
+    """
+
+    def __init__(self, env=None, config_file=None, config_override=None):
+        pass
+
+    def login(self, username, password):
+        pass
+
+    def set_certs(self, cer, key):
+        pass
+
+    def syncRepo(self, feed=None, upstream_name=None, repo=None,
+                 basic_auth_username=None, basic_auth_password=None,
+                 ssl_validation=None):
+        pass
+
+    def crane(self, repos, wait=True):
+        pass

--- a/tests/dockpulp/__init__.py
+++ b/tests/dockpulp/__init__.py
@@ -27,7 +27,7 @@ class Pulp(object):
     def set_certs(self, cer, key):
         pass
 
-    def syncRepo(self, feed=None, upstream_name=None, repo=None,
+    def syncRepo(self, feed=None, repo=None,
                  basic_auth_username=None, basic_auth_password=None,
                  ssl_validation=None):
         pass

--- a/tests/plugins/test_pulp_sync.py
+++ b/tests/plugins/test_pulp_sync.py
@@ -76,7 +76,7 @@ class TestPostPulpSync(object):
     def test_auth_none(self):
         docker_registry = 'http://registry.example.com'
         docker_repository = 'prod/myrepository'
-        pulp_repoid = 'prefix-prod-myrepository'
+        pulp_repoid = 'prod-myrepository'
         env = 'pulp'
         plugin = PulpSyncPlugin(tasker=None,
                                 workflow=self.workflow([docker_repository]),
@@ -93,6 +93,7 @@ class TestPostPulpSync(object):
         (flexmock(mockpulp)
             .should_receive('syncRepo')
             .with_args(object,
+                       repo=pulp_repoid,
                        feed=docker_registry,
                        upstream_name=docker_repository)
             .and_return([{'id': pulp_repoid}])
@@ -124,7 +125,7 @@ class TestPostPulpSync(object):
 
         docker_registry = 'http://registry.example.com'
         docker_repository = 'prod/myrepository'
-        pulp_repoid = 'prefix-prod-myrepository'
+        pulp_repoid = 'prod-myrepository'
         env = 'pulp'
         plugin = PulpSyncPlugin(tasker=None,
                                 workflow=self.workflow([docker_repository]),
@@ -145,6 +146,7 @@ class TestPostPulpSync(object):
             (flexmock(mockpulp)
                 .should_receive('syncRepo')
                 .with_args(object,
+                           repo=pulp_repoid,
                            feed=docker_registry,
                            upstream_name=docker_repository)
                 .and_return([{'id': pulp_repoid}])
@@ -207,7 +209,7 @@ class TestPostPulpSync(object):
     def test_dockercfg_registry_not_present(self, tmpdir):
         docker_registry = 'http://registry.example.com'
         docker_repository = 'prod/myrepository'
-        pulp_repoid = 'prefix-prod-myrepository'
+        pulp_repoid = 'prod-myrepository'
         env = 'pulp'
 
         registry_secret = os.path.join(str(tmpdir), '.dockercfg')
@@ -232,6 +234,7 @@ class TestPostPulpSync(object):
         (flexmock(mockpulp)
             .should_receive('syncRepo')
             .with_args(object,
+                       repo=pulp_repoid,
                        feed=docker_registry,
                        upstream_name=docker_repository)
             .and_return([{'id': pulp_repoid}])
@@ -248,7 +251,7 @@ class TestPostPulpSync(object):
     def test_dockercfg(self, tmpdir, scheme):
         docker_registry = '{}://registry.example.com'.format(scheme)
         docker_repository = 'prod/myrepository'
-        pulp_repoid = 'prefix-prod-myrepository'
+        pulp_repoid = 'prod-myrepository'
         user = 'user'
         pw = 'pass'
         env = 'pulp'
@@ -275,6 +278,7 @@ class TestPostPulpSync(object):
         (flexmock(mockpulp)
             .should_receive('syncRepo')
             .with_args(object,
+                       repo=pulp_repoid,
                        feed=docker_registry,
                        upstream_name=docker_repository,
                        basic_auth_username=user,
@@ -297,7 +301,7 @@ class TestPostPulpSync(object):
     def test_insecure_registry(self, insecure_registry, ssl_validation):
         docker_registry = 'http://registry.example.com'
         docker_repository = 'prod/myrepository'
-        pulp_repoid = 'prefix-prod-myrepository'
+        pulp_repoid = 'prod-myrepository'
         env = 'pulp'
         plugin = PulpSyncPlugin(tasker=None,
                                 workflow=self.workflow([docker_repository]),
@@ -309,10 +313,12 @@ class TestPostPulpSync(object):
         sync_exp = flexmock(mockpulp).should_receive('syncRepo')
         if ssl_validation is None:
             sync_exp = sync_exp.with_args(object,
+                                          repo=pulp_repoid,
                                           feed=docker_registry,
                                           upstream_name=docker_repository)
         else:
             sync_exp = sync_exp.with_args(object,
+                                          repo=pulp_repoid,
                                           feed=docker_registry,
                                           upstream_name=docker_repository,
                                           ssl_validation=ssl_validation)
@@ -370,7 +376,7 @@ class TestPostPulpSync(object):
     def test_store_registry(self, already_exists):
         docker_registry = 'http://registry.example.com'
         docker_repository = 'prod/myrepository'
-        pulp_repoid = 'prefix-prod-myrepository'
+        pulp_repoid = 'prod-myrepository'
         env = 'pulp'
         workflow = self.workflow([docker_repository])
 
@@ -384,6 +390,7 @@ class TestPostPulpSync(object):
         (flexmock(mockpulp)
             .should_receive('syncRepo')
             .with_args(object,
+                       repo=pulp_repoid,
                        feed=docker_registry,
                        upstream_name=docker_repository)
             .and_return([{'id': pulp_repoid}])

--- a/tests/plugins/test_pulp_sync.py
+++ b/tests/plugins/test_pulp_sync.py
@@ -51,7 +51,7 @@ class MockPulp(object):
     def set_certs(self, cer, key):
         pass
 
-    def syncRepo(self, feed=None, upstream_name=None, repo=None,
+    def syncRepo(self, feed=None, repo=None,
                  basic_auth_username=None, basic_auth_password=None,
                  ssl_validation=None):
         pass
@@ -109,8 +109,7 @@ class TestPostPulpSync(object):
             .should_receive('syncRepo')
             .with_args(object,
                        repo=pulp_repoid,
-                       feed=docker_registry,
-                       upstream_name=docker_repository)
+                       feed=docker_registry)
             .and_return([{'id': pulp_repoid}])
             .once()
             .ordered())
@@ -169,8 +168,7 @@ class TestPostPulpSync(object):
                 .should_receive('syncRepo')
                 .with_args(object,
                            repo=pulp_repoid,
-                           feed=docker_registry,
-                           upstream_name=docker_repository)
+                           feed=docker_registry)
                 .and_return([{'id': pulp_repoid}])
                 .once()
                 .ordered())
@@ -264,8 +262,7 @@ class TestPostPulpSync(object):
             .should_receive('syncRepo')
             .with_args(object,
                        repo=pulp_repoid,
-                       feed=docker_registry,
-                       upstream_name=docker_repository)
+                       feed=docker_registry)
             .and_return([{'id': pulp_repoid}])
             .once()
             .ordered())
@@ -316,7 +313,6 @@ class TestPostPulpSync(object):
             .with_args(object,
                        repo=pulp_repoid,
                        feed=docker_registry,
-                       upstream_name=docker_repository,
                        basic_auth_username=user,
                        basic_auth_password=pw)
             .and_return([{'id': pulp_repoid}])
@@ -357,13 +353,11 @@ class TestPostPulpSync(object):
         if ssl_validation is None:
             sync_exp = sync_exp.with_args(object,
                                           repo=pulp_repoid,
-                                          feed=docker_registry,
-                                          upstream_name=docker_repository)
+                                          feed=docker_registry)
         else:
             sync_exp = sync_exp.with_args(object,
                                           repo=pulp_repoid,
                                           feed=docker_registry,
-                                          upstream_name=docker_repository,
                                           ssl_validation=ssl_validation)
 
         (sync_exp
@@ -447,8 +441,7 @@ class TestPostPulpSync(object):
             .should_receive('syncRepo')
             .with_args(object,
                        repo=pulp_repoid,
-                       feed=docker_registry,
-                       upstream_name=docker_repository)
+                       feed=docker_registry)
             .and_return([{'id': pulp_repoid}])
             .once()
             .ordered())
@@ -534,8 +527,7 @@ class TestPostPulpSync(object):
             .should_receive('syncRepo')
             .with_args(object,
                        repo=pulp_repoid,
-                       feed=docker_registry,
-                       upstream_name=docker_repository)
+                       feed=docker_registry)
             .and_return([{'id': pulp_repoid}])
             .once()
             .ordered())

--- a/tests/plugins/test_pulp_sync.py
+++ b/tests/plugins/test_pulp_sync.py
@@ -56,6 +56,14 @@ class MockPulp(object):
                  ssl_validation=None):
         pass
 
+    def getRepos(self, rids, fields=None):
+        pass
+
+    def createRepo(self, repo_id, url, registry_id=None, desc=None,
+                   title=None, protected=False, distributors=True,
+                   prefix_with='redhat-', productline=None):
+        pass
+
     def crane(self, repos, wait=True):
         pass
 
@@ -77,6 +85,7 @@ class TestPostPulpSync(object):
         docker_registry = 'http://registry.example.com'
         docker_repository = 'prod/myrepository'
         pulp_repoid = 'prod-myrepository'
+        prefixed_pulp_repoid = 'redhat-prod-myrepository'
         env = 'pulp'
         plugin = PulpSyncPlugin(tasker=None,
                                 workflow=self.workflow([docker_repository]),
@@ -90,6 +99,12 @@ class TestPostPulpSync(object):
         (flexmock(mockpulp)
             .should_receive('set_certs')
             .never())
+        (flexmock(mockpulp)
+            .should_receive('getRepos')
+            .with_args([prefixed_pulp_repoid], fields=['id'])
+            .and_return([{'id': prefixed_pulp_repoid}])
+            .once()
+            .ordered())
         (flexmock(mockpulp)
             .should_receive('syncRepo')
             .with_args(object,
@@ -126,6 +141,7 @@ class TestPostPulpSync(object):
         docker_registry = 'http://registry.example.com'
         docker_repository = 'prod/myrepository'
         pulp_repoid = 'prod-myrepository'
+        prefixed_pulp_repoid = 'redhat-prod-myrepository'
         env = 'pulp'
         plugin = PulpSyncPlugin(tasker=None,
                                 workflow=self.workflow([docker_repository]),
@@ -141,6 +157,12 @@ class TestPostPulpSync(object):
             (flexmock(mockpulp)
                 .should_receive('set_certs')
                 .with_args(cer, key)
+                .once()
+                .ordered())
+            (flexmock(mockpulp)
+                .should_receive('getRepos')
+                .with_args([prefixed_pulp_repoid], fields=['id'])
+                .and_return([{'id': prefixed_pulp_repoid}])
                 .once()
                 .ordered())
             (flexmock(mockpulp)
@@ -210,6 +232,7 @@ class TestPostPulpSync(object):
         docker_registry = 'http://registry.example.com'
         docker_repository = 'prod/myrepository'
         pulp_repoid = 'prod-myrepository'
+        prefixed_pulp_repoid = 'redhat-prod-myrepository'
         env = 'pulp'
 
         registry_secret = os.path.join(str(tmpdir), '.dockercfg')
@@ -232,6 +255,12 @@ class TestPostPulpSync(object):
 
         mockpulp = MockPulp()
         (flexmock(mockpulp)
+            .should_receive('getRepos')
+            .with_args([prefixed_pulp_repoid], fields=['id'])
+            .and_return([{'id': prefixed_pulp_repoid}])
+            .once()
+            .ordered())
+        (flexmock(mockpulp)
             .should_receive('syncRepo')
             .with_args(object,
                        repo=pulp_repoid,
@@ -252,6 +281,7 @@ class TestPostPulpSync(object):
         docker_registry = '{}://registry.example.com'.format(scheme)
         docker_repository = 'prod/myrepository'
         pulp_repoid = 'prod-myrepository'
+        prefixed_pulp_repoid = 'redhat-prod-myrepository'
         user = 'user'
         pw = 'pass'
         env = 'pulp'
@@ -275,6 +305,12 @@ class TestPostPulpSync(object):
                                 registry_secret_path=str(tmpdir))
 
         mockpulp = MockPulp()
+        (flexmock(mockpulp)
+            .should_receive('getRepos')
+            .with_args([prefixed_pulp_repoid], fields=['id'])
+            .and_return([{'id': prefixed_pulp_repoid}])
+            .once()
+            .ordered())
         (flexmock(mockpulp)
             .should_receive('syncRepo')
             .with_args(object,
@@ -302,6 +338,7 @@ class TestPostPulpSync(object):
         docker_registry = 'http://registry.example.com'
         docker_repository = 'prod/myrepository'
         pulp_repoid = 'prod-myrepository'
+        prefixed_pulp_repoid = 'redhat-prod-myrepository'
         env = 'pulp'
         plugin = PulpSyncPlugin(tasker=None,
                                 workflow=self.workflow([docker_repository]),
@@ -310,6 +347,12 @@ class TestPostPulpSync(object):
                                 insecure_registry=insecure_registry)
 
         mockpulp = MockPulp()
+        (flexmock(mockpulp)
+            .should_receive('getRepos')
+            .with_args([prefixed_pulp_repoid], fields=['id'])
+            .and_return([{'id': prefixed_pulp_repoid}])
+            .once()
+            .ordered())
         sync_exp = flexmock(mockpulp).should_receive('syncRepo')
         if ssl_validation is None:
             sync_exp = sync_exp.with_args(object,
@@ -339,6 +382,12 @@ class TestPostPulpSync(object):
         loglevel = 3
 
         mockpulp = MockPulp()
+        (flexmock(mockpulp)
+            .should_receive('getRepos')
+            .with_args(['redhat-prod-myrepository'], fields=['id'])
+            .and_return([{'id': 'redhat-prod-myrepository'}])
+            .once()
+            .ordered())
         (flexmock(mockpulp)
             .should_receive('syncRepo')
             .and_return([{'id':''}]))
@@ -377,6 +426,7 @@ class TestPostPulpSync(object):
         docker_registry = 'http://registry.example.com'
         docker_repository = 'prod/myrepository'
         pulp_repoid = 'prod-myrepository'
+        prefixed_pulp_repoid = 'redhat-prod-myrepository'
         env = 'pulp'
         workflow = self.workflow([docker_repository])
 
@@ -387,6 +437,12 @@ class TestPostPulpSync(object):
         (flexmock(mockpulp)
             .should_receive('set_certs')
             .never())
+        (flexmock(mockpulp)
+            .should_receive('getRepos')
+            .with_args([prefixed_pulp_repoid], fields=['id'])
+            .and_return([{'id': prefixed_pulp_repoid}])
+            .once()
+            .ordered())
         (flexmock(mockpulp)
             .should_receive('syncRepo')
             .with_args(object,
@@ -426,6 +482,12 @@ class TestPostPulpSync(object):
         """
         mockpulp = MockPulp()
         (flexmock(mockpulp)
+            .should_receive('getRepos')
+            .with_args(['redhat-prod-myrepository'], fields=['id'])
+            .and_return([{'id': 'redhat-prod-myrepository'}])
+            .once()
+            .ordered())
+        (flexmock(mockpulp)
             .should_receive('syncRepo')
             .and_return([{'id':''}]))
         flexmock(dockpulp).should_receive('Pulp').and_return(mockpulp)
@@ -442,3 +504,49 @@ class TestPostPulpSync(object):
 
         assert [message for message in errors
                 if 'not implemented' in message]
+
+    def test_create_missing_repo(self):
+        docker_registry = 'http://registry.example.com'
+        docker_repository = 'prod/myrepository'
+        pulp_repoid = 'prod-myrepository'
+        prefixed_pulp_repoid = 'redhat-prod-myrepository'
+        env = 'pulp'
+        plugin = PulpSyncPlugin(tasker=None,
+                                workflow=self.workflow([docker_repository]),
+                                pulp_registry_name=env,
+                                docker_registry=docker_registry)
+
+        mockpulp = MockPulp()
+        (flexmock(mockpulp)
+            .should_receive('getRepos')
+            .with_args([prefixed_pulp_repoid], fields=['id'])
+            .and_return([])
+            .once()
+            .ordered())
+        (flexmock(mockpulp)
+            .should_receive('createRepo')
+            .with_args(prefixed_pulp_repoid, None,
+                       registry_id=docker_repository,
+                       prefix_with='redhat-')
+            .once()
+            .ordered())
+        (flexmock(mockpulp)
+            .should_receive('syncRepo')
+            .with_args(object,
+                       repo=pulp_repoid,
+                       feed=docker_registry,
+                       upstream_name=docker_repository)
+            .and_return([{'id': pulp_repoid}])
+            .once()
+            .ordered())
+        (flexmock(mockpulp)
+            .should_receive('crane')
+            .with_args([pulp_repoid], wait=True)
+            .once()
+            .ordered())
+        (flexmock(dockpulp)
+            .should_receive('Pulp')
+            .with_args(env=env)
+            .and_return(mockpulp))
+
+        plugin.run()


### PR DESCRIPTION
This pull request adds the ability for pulp_sync to provide basic auth credentials for the V2 registry to pulp.

It also adds the ability to create Pulp repositories if they are missing.