### PR TITLE
Pass dockercfg path straight to docker-py's login

### DIFF
--- a/atomic_reactor/core.py
+++ b/atomic_reactor/core.py
@@ -451,9 +451,10 @@ class DockerTasker(LastLogger):
             raise RuntimeError(
                 "Failed to login to '%s': email = '%s', login = '%s', password = '%s'" %
                 (registry, email, login, password))
-        logger.debug(response)
         if u'Status' in response and response[u'Status'] == u'Login Succeeded':
             logger.info("login succeeded")
+        else:
+            logger.debug("response: %r", response)
 
     def push_image(self, image, insecure=False):
         """

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -603,9 +603,9 @@ class Dockercfg(object):
         :param secret_path: str, dirname of .dockercfg location
         """
 
-        json_secret_path = os.path.join(secret_path, '.dockercfg')
+        self.json_secret_path = os.path.join(secret_path, '.dockercfg')
         try:
-            with open(json_secret_path) as fp:
+            with open(self.json_secret_path) as fp:
                 self.json_secret = json.load(fp)
         except Exception:
             msg = "failed to read registry secret"

--- a/tests/plugins/test_tag_and_push.py
+++ b/tests/plugins/test_tag_and_push.py
@@ -97,7 +97,7 @@ def test_tag_and_push_plugin(tmpdir, image_name, logs, should_raise, use_secret)
     if MOCK:
         mock_docker()
         flexmock(docker.Client, push=lambda iid, **kwargs: iter(logs),
-                 login=lambda username, password, email, registry: {'Status': 'Login Succeeded'})
+                 login=lambda username, registry, dockercfg_path: {'Status': 'Login Succeeded'})
 
     tasker = DockerTasker()
     workflow = DockerBuildWorkflow({"provider": "git", "uri": "asd"}, TEST_IMAGE)


### PR DESCRIPTION
This doesn't expose the password in the logs, as docker daemon 
sends used creds as a response to login.