### PR TITLE
add dockpulp to the list of tools used

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -56,6 +56,7 @@ TOOLS_USED = (
     {"pkg_name": "docker_squash"},
     {"pkg_name": "atomic_reactor"},
     {"pkg_name": "osbs", "display_name": "osbs-client"},
+    {"pkg_name": "dockpulp"},
 )
 
 DEFAULT_DOWNLOAD_BLOCK_SIZE = 10 * 1024 * 1024 # 10Mb


### PR DESCRIPTION
This makes atomic-reactor log the version that's installed.