### PR TITLE
koji_promote: use floating tags in extra.docker.repositories

### DIFF
--- a/atomic_reactor/plugins/exit_koji_promote.py
+++ b/atomic_reactor/plugins/exit_koji_promote.py
@@ -471,6 +471,7 @@ class KojiPromotePlugin(ExitPlugin):
         digests = self.get_digests()
         repositories = self.get_repositories(digests)
         arch = os.uname()[4]
+        tags = set(image.tag for image in self.workflow.tag_conf.primary_images)
         metadata, output = self.get_image_output(arch)
         metadata.update({
             'arch': arch,
@@ -484,6 +485,7 @@ class KojiPromotePlugin(ExitPlugin):
                     'id': image_id,
                     'parent_id': parent_id,
                     'repositories': repositories,
+                    'tags': list(tags),
                 },
             },
         })

--- a/atomic_reactor/plugins/exit_koji_promote.py
+++ b/atomic_reactor/plugins/exit_koji_promote.py
@@ -432,16 +432,18 @@ class KojiPromotePlugin(ExitPlugin):
 
         output_images = []
         for registry in registries:
-            image = self.nvr_image.copy()
-            image.registry = registry.uri
-            pullspec = image.to_str()
+            for image in self.workflow.tag_conf.primary_images:
+                image.registry = registry.uri
+                pullspec = image.to_str()
 
-            output_images.append(pullspec)
+                output_images.append(pullspec)
 
-            digest = digests.get(image.to_str(registry=False))
-            if digest:
-                digest_pullspec = image.to_str(tag=False) + "@" + digest
-                output_images.append(digest_pullspec)
+                if image == self.nvr_image:
+                    digest = digests.get(image.to_str(registry=False))
+                    if digest:
+                        digest_pullspec = image.to_str(tag=False) + "@" + digest
+                        output_images.append(digest_pullspec)
+                        self.log.debug("using digest for tag %s", image.tag)
 
         return output_images
 
@@ -471,7 +473,6 @@ class KojiPromotePlugin(ExitPlugin):
         digests = self.get_digests()
         repositories = self.get_repositories(digests)
         arch = os.uname()[4]
-        tags = set(image.tag for image in self.workflow.tag_conf.primary_images)
         metadata, output = self.get_image_output(arch)
         metadata.update({
             'arch': arch,
@@ -485,7 +486,6 @@ class KojiPromotePlugin(ExitPlugin):
                     'id': image_id,
                     'parent_id': parent_id,
                     'repositories': repositories,
-                    'tags': list(tags),
                 },
             },
         })


### PR DESCRIPTION
This new extra field lists the primary tags that are set on the image.