### PR TITLE
tag_from_config: ignore tags containing hyphens

### DIFF
--- a/atomic_reactor/plugins/post_tag_from_config.py
+++ b/atomic_reactor/plugins/post_tag_from_config.py
@@ -17,9 +17,10 @@ class TagFromConfigPlugin(PostBuildPlugin):
     Tags image with additional tags found in configuration file
 
     Configuration file must be named "additional-tags" and it must
-    reside in repository as a sibling of Dockerfile. Each line in
-    file is considered as a different tag to be applied. Empty lines
-    are ignored. Tags will be prefixed by the value of Name label.
+    reside in repository as a sibling of Dockerfile. Each line in file
+    is considered as a different tag to be applied. Empty lines and
+    tag names containing hyphens are ignored. Tags will be prefixed by
+    the value of Name label.
 
     For example, using the following configuration file:
 
@@ -33,6 +34,7 @@ class TagFromConfigPlugin(PostBuildPlugin):
         fedora:v1.0.1
 
     If configuration file is not found, this plugin takes no action.
+
     """
     key = 'tag_from_config'
     is_allowed_to_fail = False
@@ -54,7 +56,10 @@ class TagFromConfigPlugin(PostBuildPlugin):
             for tag in tags_file:
                 tag = tag.strip()
                 if tag:
-                    tags.append(tag)
+                    if '-' in tag:
+                        self.log.warning("tag '%s' includes '-', ignoring", tag)
+                    else:
+                        tags.append(tag)
 
         return tags
 

--- a/tests/plugins/test_tag_from_config.py
+++ b/tests/plugins/test_tag_from_config.py
@@ -69,6 +69,8 @@ def mock_workflow(tmpdir):
     ([], 'fedora', []),
     (['spam'], 'fedora', ['fedora:spam']),
     (['spam', 'bacon'], 'foo', ['foo:spam', 'foo:bacon']),
+    # ignore tags with hyphens
+    (['foo-bar', 'baz'], 'name', ['name:baz']),
     (None, 'fedora', []),
 ])
 def test_tag_from_config_plugin_generated(tmpdir, docker_tasker, tags, name,


### PR DESCRIPTION
If the additional-tags file is allowed to specify a tag containing a hyphen, there is a possibility of overwriting an n-v-r tag from a previous build.

The rationale for allowing additional tags in the first place is to allow a floating tag that refers to a version 'path', e.g. '3.2' which would float across versions 3.2.1, 3.2.2, and so on. Disallowing hyphens does not prevent this use-case.