### PR TITLE
Don't swallow docker build errors

### DIFF
--- a/atomic_reactor/build.py
+++ b/atomic_reactor/build.py
@@ -11,7 +11,6 @@ Logic above these classes has to set the workflow itself.
 """
 import json
 
-import sys
 import logging
 import traceback
 from dockerfile_parse import DockerfileParser


### PR DESCRIPTION
Apparently the log generator can throw exceptions which we currently ignore.

Before:
```
...
2016-08-10 07:06:39,662 - atomic_reactor.core - INFO - building image 'mmilata/test-image3:none-20160810130354' from path '/tmp/tmpX69ssE/source'
2016-08-10 07:06:39,698 - atomic_reactor.build - DEBUG - build is submitted, waiting for it to finish
2016-08-10 07:06:39,698 - atomic_reactor.util - INFO - wait_for_command
2016-08-10 07:06:39,698 - atomic_reactor.plugin - INFO - initializing runner of exit plugins
...
```

After:
```
...
2016-08-10 10:17:09,702 - atomic_reactor.core - INFO - building image 'mmilata/test-image3:none-20160810161641' from path '/tmp/tmp1wo8AV/source'
2016-08-10 10:17:09,734 - atomic_reactor.build - DEBUG - build is submitted, waiting for it to finish
2016-08-10 10:17:09,734 - atomic_reactor.util - INFO - wait_for_command
2016-08-10 10:17:09,735 - atomic_reactor.inner - ERROR - build failed
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/atomic_reactor-1.6.14-py2.7.egg/atomic_reactor/inner.py", line 338, in build_docker_image
    build_result = self.builder.build()
  File "/usr/lib/python2.7/site-packages/atomic_reactor-1.6.14-py2.7.egg/atomic_reactor/build.py", line 122, in build
    command_result = wait_for_command(logs_gen)  # wait for build to finish
  File "/usr/lib/python2.7/site-packages/atomic_reactor-1.6.14-py2.7.egg/atomic_reactor/util.py", line 210, in wait_for_command
    item = next(logs_generator)  # py2 & 3 compat
  File "/usr/lib/python2.7/site-packages/docker/client.py", line 230, in _stream_helper
    yield self._result(response)
  File "/usr/lib/python2.7/site-packages/docker/client.py", line 150, in _result
    self._raise_for_status(response)
  File "/usr/lib/python2.7/site-packages/docker/client.py", line 146, in _raise_for_status
    raise errors.APIError(e, response, explanation=explanation)
APIError: 500 Server Error: Internal Server Error ("ENV must have two arguments")
2016-08-10 10:17:09,736 - atomic_reactor.plugin - INFO - initializing runner of exit plugins
...
```