### PR TITLE
Change to use dnf/clean, and update to use existing images

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,14 +125,14 @@ $ docker build -t buildroot-hostdocker .
 As soon as our build image is built, we can start building stuff in it:
 
 ```bash
-$ atomic-reactor build git --method hostdocker --build-image buildroot --image test-image --uri "https://github.com/TomasTomecek/docker-hello-world.git"
+$ atomic-reactor build git --method hostdocker --build-image buildroot-hostdocker --image test-image --uri "https://github.com/TomasTomecek/docker-hello-world.git"
 ```
 
 Built image will be in the build container. Therefore this example doesn't make much sense. If you would like to access the built image, you should probably push it to your registry and build it like this:
 
 ```bash
 $ atomic-reactor build git --method hostdocker \
-             --build-image buildroot \
+             --build-image buildroot-hostdocker \
              --image test-image \
              --target-registries 172.17.42.1:5000 \
              --uri "https://github.com/TomasTomecek/docker-hello-world.git"

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Or you can build the image using docker and install Atomic Reactor directly from
 
 ```dockerfile
 FROM fedora:latest
-RUN yum -y install docker-io git python-docker-py python-setuptools koji atomic-reactor
+RUN dnf -y install docker-io git python-docker-py python-setuptools koji atomic-reactor; dnf clean all
 CMD ["atomic-reactor", "-v", "inside-build", "--input", "path"]
 ```
 


### PR DESCRIPTION
Uses `dnf` to install and clean: to remove the cached packages that have been installed.
Also changed the names of the images that are used in the build process (buildroot doesn't exist)