### PR TITLE
Fixed FROM version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM fedora:latest
+FROM fedora:24
 # e2fsprogs -- docker @ F20 wants it
-RUN yum -y install docker git python-docker-py python-setuptools e2fsprogs koji python-pip python-backports-lzma osbs gssproxy
+RUN dnf -y install docker git python-docker-py python-setuptools e2fsprogs koji python-pip python-backports-lzma osbs gssproxy
 RUN mkdir /tmp/atomic-reactor
 ADD . /tmp/atomic-reactor
 RUN cd /tmp/atomic-reactor && python setup.py install


### PR DESCRIPTION
This to prevent breaking automated builds when a new Fedora release
gets tagged with 'latest'. This means that subsequent releases need
this file to be modified to reflect the latest Fedora release, when
confirmed nothing breaks.