### PR TITLE
Handle unique_tag_only flag

### DIFF
--- a/atomic_reactor/plugins/exit_koji_promote.py
+++ b/atomic_reactor/plugins/exit_koji_promote.py
@@ -128,7 +128,7 @@ class KojiPromotePlugin(ExitPlugin):
                                   namespace=self.namespace)
         self.osbs = OSBS(osbs_conf, osbs_conf)
         self.build_id = None
-        self.nvr_image = None
+        self.pullspec_image = None
 
     @staticmethod
     def parse_rpm_output(output, tags, separator=';'):
@@ -438,7 +438,7 @@ class KojiPromotePlugin(ExitPlugin):
 
         output_images = []
         for registry in registries:
-            image = self.nvr_image.copy()
+            image = self.pullspec_image.copy()
             image.registry = registry.uri
             pullspec = image.to_str()
 
@@ -566,13 +566,18 @@ class KojiPromotePlugin(ExitPlugin):
             self.log.error("No build metadata")
             raise
 
+        for image in self.workflow.tag_conf.unique_images:
+            self.pullspec_image = image
+            break
+
         for image in self.workflow.tag_conf.primary_images:
             # dash at first/last postition does not count
             if '-' in image.tag[1:-1]:
-                self.nvr_image = image
+                self.pullspec_image = image
                 break
-        else:
-            raise RuntimeError('Unable to determine name:version-release')
+
+        if not self.pullspec_image:
+            raise RuntimeError('Unable to determine pullspec_image')
 
         metadata_version = 0
 

--- a/atomic_reactor/plugins/post_pulp_sync.py
+++ b/atomic_reactor/plugins/post_pulp_sync.py
@@ -204,7 +204,7 @@ class PulpSyncPlugin(PostBuildPlugin):
 
         images = []
         repos = {}  # pulp repo -> repo id
-        for image in self.workflow.tag_conf.primary_images:
+        for image in self.workflow.tag_conf.images:
             if image.pulp_repo not in repos:
                 repo_id = self.create_repo_if_missing(pulp,
                                                       image.pulp_repo,

--- a/tests/plugins/test_pulp_sync.py
+++ b/tests/plugins/test_pulp_sync.py
@@ -74,12 +74,12 @@ class MockPulp(object):
 class TestPostPulpSync(object):
     @staticmethod
     def workflow(docker_repos):
-        primary_images = []
-        for tag in ['1.0-1', '1.0', 'latest']:
-            primary_images.extend([ImageName(repo=repo, tag=tag)
+        images = []
+        for tag in ['1.0-1', '1.0', 'latest', 'unique-timestamp']:
+            images.extend([ImageName(repo=repo, tag=tag)
                                    for repo in docker_repos])
 
-        tag_conf = flexmock(primary_images=primary_images)
+        tag_conf = flexmock(images=images)
         push_conf = PushConf()
         return flexmock(tag_conf=tag_conf,
                         push_conf=push_conf)


### PR DESCRIPTION
When unique_tag_only parameter is used in osbs-client, atomic-reactor's tag_by_labels will not tag image with transient tags: N:V, N:V-R, latest. Instead only the unique timestamp tag is used.

Due to this, other plugins also had to be modified to allow the unique timestamp tag to be used in lieu of any primary tags.