### PR TITLE
pre_add_labels_in_df: don't add 'Z' suffix to a build date

### DIFF
--- a/atomic_reactor/plugins/pre_add_labels_in_df.py
+++ b/atomic_reactor/plugins/pre_add_labels_in_df.py
@@ -104,7 +104,7 @@ class AddLabelsPlugin(PreBuildPlugin):
 
         # build date
         dt = datetime.datetime.fromtimestamp(atomic_reactor_start_time)
-        generated['build-date'] = dt.isoformat() + 'Z'
+        generated['build-date'] = dt.isoformat()
 
         # architecture - assuming host and image architecture is the same
         generated['architecture'], _ = get_docker_architecture(self.tasker)

--- a/tests/plugins/test_add_labels.py
+++ b/tests/plugins/test_add_labels.py
@@ -150,7 +150,7 @@ def test_add_labels_plugin(tmpdir, docker_tasker,
         assert df.content in expected_output
 
 @pytest.mark.parametrize('auto_label, value_re_part', [
-    ('build-date', r'\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z'),
+    ('build-date', r'\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?'),
     ('architecture', 'x86_64'),
     ('vcs-type', 'git'),
     ('vcs-url', DOCKERFILE_GIT),


### PR DESCRIPTION
We can't be sure that build host has GMT time set

Fixes #454