### PR TITLE
koji_promote: store resulting image config

### DIFF
--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -174,6 +174,8 @@ class DockerRegistry(Registry):
         """
         super(DockerRegistry, self).__init__(uri, insecure=insecure)
         self.digests = {}  # maps tags (str) to their digest, if available
+        self.config = None  # stores image config from the registry, 
+        # media type of the config is application/vnd.docker.container.image.v1+json
 
 
 class PushConf(object):

--- a/tests/plugins/test_tag_and_push.py
+++ b/tests/plugins/test_tag_and_push.py
@@ -13,7 +13,7 @@ from atomic_reactor.core import DockerTasker
 from atomic_reactor.inner import DockerBuildWorkflow
 from atomic_reactor.plugin import PostBuildPluginsRunner
 from atomic_reactor.plugins.post_tag_and_push import TagAndPushPlugin
-from atomic_reactor.util import ImageName
+from atomic_reactor.util import ImageName, ManifestDigest
 from tests.constants import LOCALHOST_REGISTRY, TEST_IMAGE, INPUT_IMAGE, MOCK, DOCKER0_REGISTRY
 import atomic_reactor.util
 
@@ -121,7 +121,7 @@ def test_tag_and_push_plugin(tmpdir, monkeypatch, image_name, logs, should_raise
 
     (flexmock(atomic_reactor.util)
         .should_receive('get_manifest_digests')
-        .and_return({'v1': DIGEST_V1, 'v2': DIGEST_V2})
+        .and_return(ManifestDigest(v1=DIGEST_V1, v2=DIGEST_V2))
     )
 
     runner = PostBuildPluginsRunner(
@@ -152,5 +152,5 @@ def test_tag_and_push_plugin(tmpdir, monkeypatch, image_name, logs, should_raise
         if MOCK:
             # we only test this when mocking docker because we don't expect
             # running actual docker against v2 registry
-            assert workflow.push_conf.docker_registries[0].digests[image_name]['v1'] == DIGEST_V1
-            assert workflow.push_conf.docker_registries[0].digests[image_name]['v2'] == DIGEST_V2
+            assert workflow.push_conf.docker_registries[0].digests[image_name].v1 == DIGEST_V1
+            assert workflow.push_conf.docker_registries[0].digests[image_name].v2 == DIGEST_V2

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -321,7 +321,7 @@ def test_get_manifest_digests(tmpdir, image, registry, insecure, creds,
         }
         return (200, headers, '')
 
-    responses.add_callback(responses.HEAD, url, callback=request_callback)
+    responses.add_callback(responses.GET, url, callback=request_callback)
 
     expected_versions = versions
     if versions is None:
@@ -382,7 +382,7 @@ def test_get_manifest_digests_missing(tmpdir, v1_digest, v2_digest):
         }
         return (200, headers, '')
 
-    responses.add_callback(responses.HEAD, url, callback=request_callback)
+    responses.add_callback(responses.GET, url, callback=request_callback)
 
     actual_digests = get_manifest_digests(**kwargs)
 


### PR DESCRIPTION
This change will make sure brew/koji extra info has container info from the registry. After the image was pushed registry is queried for container config using v2 schema 2 digest