### PR TITLE
new 'required' build JSON plugin keyword

### DIFF
--- a/atomic_reactor/plugin.py
+++ b/atomic_reactor/plugin.py
@@ -192,12 +192,21 @@ class PluginsRunner(object):
                 plugin_class = self.plugin_classes[plugin_name]
             except KeyError:
                 self.on_plugin_failed()
-                msg = "no such plugin: '%s', did you set the correct plugin type?" %plugin_name
-                logger.error(msg)
-                if keep_going:
-                    continue
 
-                raise PluginFailedException(msg)
+                if plugin_request.get('required', True):
+                    msg = ("no such plugin: '%s', did you set "
+                           "the correct plugin type?") %  plugin_name
+                    logger.error(msg)
+
+                    if keep_going:
+                        continue
+
+                    raise PluginFailedException(msg)
+                else:
+                    # This plugin is marked as not being required
+                    logger.warning("plugin '%s' requested but not available",
+                                   plugin_name)
+                    continue
             try:
                 plugin_is_allowed_to_fail = plugin_request['is_allowed_to_fail']
             except (TypeError, KeyError):

--- a/tests/test_inner.py
+++ b/tests/test_inner.py
@@ -330,6 +330,14 @@ class Post(PostBuildPlugin):
     key = 'post'
 
 
+class PrePub(PrePublishPlugin):
+    """
+    This plugin does nothing. It's only used for configuration testing.
+    """
+
+    key = 'prepub'
+
+
 class Exit(ExitPlugin):
     """
     This plugin does nothing. It's only used for configuration testing.
@@ -365,6 +373,19 @@ class Exit(ExitPlugin):
      True,  # logs error
     ),
 
+    # No 'name' key, prepub
+    ({
+        'prepublish_plugins': [{'args': {}},
+                               {'name': 'prepub_watched',
+                                'args': {
+                                    'watcher': Watcher(),
+                                },
+                               }]},
+     True,  # is fatal
+     True,  # logs error
+    ),
+     
+
     # No 'name' key, exit
     ({
         'exit_plugins': [{'args': {}},
@@ -372,7 +393,7 @@ class Exit(ExitPlugin):
                           'args': {
                               'watcher': Watcher(),
                           }
-                         }],
+                         }]
       },
      False,  # not fatal
      True,   # logs error
@@ -395,6 +416,17 @@ class Exit(ExitPlugin):
                              'args': {
                                  'watcher': Watcher(),
                              }
+                            }]},
+     False,  # not fatal,
+     False,  # no error logged
+    ),
+
+    # No 'args' key, prepub
+    ({'prepublish_plugins': [{'name': 'prepub'},
+                             {'name': 'prepub_watched',
+                              'args': {
+                                  'watcher': Watcher(),
+                              }
                             }]},
      False,  # not fatal,
      False,  # no error logged
@@ -435,6 +467,18 @@ class Exit(ExitPlugin):
      True,  # logs error
     ),
 
+    # No such plugin, prepub
+    ({'prepublish_plugins': [{'name': 'no plugin',
+                              'args': {}},
+                             {'name': 'prepub_watched',
+                              'args': {
+                                  'watcher': Watcher(),
+                              }
+                             }]},
+     True,  # is fatal
+     True,  # logs error
+    ),
+
     # No such plugin, exit
     ({'exit_plugins': [{'name': 'no plugin',
                         'args': {}},
@@ -445,6 +489,58 @@ class Exit(ExitPlugin):
                        }]},
      False,  # not fatal
      True,   # logs error
+    ),
+
+    # No such plugin, prebuild, not required
+    ({'prebuild_plugins': [{'name': 'no plugin',
+                            'args': {},
+                            'required': False},
+                           {'name': 'pre_watched',
+                            'args': {
+                                'watcher': Watcher(),
+                            }
+                           }]},
+     False,  # not fatal
+     False,  # does not log error
+    ),
+
+    # No such plugin, postbuild, not required
+    ({'postbuild_plugins': [{'name': 'no plugin',
+                             'args': {},
+                             'required': False},
+                            {'name': 'post_watched',
+                             'args': {
+                                 'watcher': Watcher(),
+                             }
+                            }]},
+     False,  # not fatal
+     False,  # does not log error
+    ),
+
+    # No such plugin, prepub, not required
+    ({'prepublish_plugins': [{'name': 'no plugin',
+                              'args': {},
+                              'required': False},
+                             {'name': 'prepub_watched',
+                              'args': {
+                                  'watcher': Watcher(),
+                              }
+                             }]},
+     False,  # not fatal
+     False,  # does not log error
+    ),
+
+    # No such plugin, exit, not required
+    ({'exit_plugins': [{'name': 'no plugin',
+                        'args': {},
+                        'required': False},
+                       {'name': 'exit_watched',
+                        'args': {
+                            'watcher': Watcher(),
+                        }
+                       }]},
+     False,  # not fatal
+     False,  # does not log error
     ),
 ])
 def test_plugin_errors(request, plugins, should_fail, should_log):


### PR DESCRIPTION
If required is set to false, absence of the plugin will not cause the build to fail.

Rationale: in order to be able to run builds using older atomic-reactor builder images we want to be able to run plugins only when they are present. An example is the new distribution_scope plugin. In order to add support for it to osbs-client, compatibility with older atomic-reactor builder images must be broken.

With the addition of the 'required' keyword, compatibility could be maintained for such plugins by including `"required": false` in their build JSON description in osbs-client.

See also https://github.com/projectatomic/osbs-client/pull/468.