### PR TITLE
distribution_scope: handle imported images

### DIFF
--- a/atomic_reactor/plugins/pre_distribution_scope.py
+++ b/atomic_reactor/plugins/pre_distribution_scope.py
@@ -70,7 +70,7 @@ class DistributionScopePlugin(PreBuildPlugin):
 
         try:
             scope_choice = labels[self.SCOPE_LABEL]
-        except KeyError:
+        except (KeyError, TypeError):
             self.log.debug("no distribution scope set for %s image", which)
             raise NothingToCheck
 


### PR DESCRIPTION
These have {'Labels': None} in their inspection data. They occur during creation of base images (pre_add_filesystem).