### PR TITLE
pulp_pull: new plugin

### DIFF
--- a/atomic_reactor/plugins/post_pulp_pull.py
+++ b/atomic_reactor/plugins/post_pulp_pull.py
@@ -47,16 +47,12 @@ class PulpPullPlugin(PostBuildPlugin):
         start = time()
 
         # Work out the name of the image to pull
-        image = None
-        for unique_image in self.workflow.tag_conf.unique_images:
-            image = unique_image
-            break
-
-        if not image:
-            raise RuntimeError('Unable to determine unique image name')
+        assert self.workflow.tag_conf.unique_images  # must be set
+        image = self.workflow.tag_conf.unique_images[0]
 
         assert self.workflow.push_conf.pulp_registries  # must be configured
         registry = self.workflow.push_conf.pulp_registries[0]
+
         pullspec = image.copy()
         pullspec.registry = registry.uri  # the image on Crane
 

--- a/atomic_reactor/plugins/post_pulp_pull.py
+++ b/atomic_reactor/plugins/post_pulp_pull.py
@@ -1,0 +1,88 @@
+"""Copyright (c) 2016 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+
+Pull built image from Crane to discover its image ID.
+
+After squashing our image, the squashed image 'docker save' form will
+have an image ID that is correct for its v2 schema 2
+representation. However since Pulp does not yet support v2 schema 2,
+we will need to remove that local image and re-pull it from Crane to
+discover the image ID Docker will give it.
+"""
+
+from __future__ import unicode_literals
+
+from atomic_reactor.plugin import PostBuildPlugin
+from atomic_reactor.plugins.exit_remove_built_image import defer_removal
+from docker.errors import NotFound
+from time import time, sleep
+
+class CraneTimeoutError(Exception):
+    """The expected image did not appear in the required time"""
+    pass
+
+
+class PulpPullPlugin(PostBuildPlugin):
+    key = 'pulp_pull'
+    is_allowed_to_fail = False
+
+    def __init__(self, tasker, workflow, timeout=600, retry_delay=30):
+        """
+        constructor
+
+        :param tasker: DockerTasker instance
+        :param workflow: DockerBuildWorkflow instance
+        :param timeout: int, maximum number of seconds to wait
+        :param retry_delay: int, seconds between pull attempts
+        """
+        # call parent constructor
+        super(PulpPullPlugin, self).__init__(tasker, workflow)
+        self.timeout = timeout
+        self.retry_delay = retry_delay
+
+    def run(self):
+        start = time()
+
+        # Work out the name of the image to pull
+        image = None
+        for unique_image in self.workflow.tag_conf.unique_images:
+            image = unique_image
+            break
+
+        if not image:
+            raise RuntimeError('Unable to determine unique image name')
+
+        assert self.workflow.push_conf.pulp_registries  # must be configured
+        registry = self.workflow.push_conf.pulp_registries[0]
+        pullspec = image.copy()
+        pullspec.registry = registry.uri  # the image on Crane
+
+        while True:
+            # Pull the image from Crane
+            name = self.tasker.pull_image(pullspec)
+
+            # Inspect it
+            try:
+                metadata = self.tasker.inspect_image(name)
+            except NotFound:
+                if time() - start > self.timeout:
+                    raise CraneTimeoutError("{}s exceeded".format(self.timeout))
+
+                self.log.info("will try again in %ss", self.retry_delay)
+                sleep(self.retry_delay)
+                continue
+
+            defer_removal(self.workflow, name)
+            break
+
+        # Adjust our idea of the image ID
+        image_id = metadata['Id']
+        self.log.debug("image ID changed from %s to %s",
+                       self.workflow.builder.image_id,
+                       image_id)
+        self.workflow.builder.image_id = image_id
+
+        return image_id

--- a/atomic_reactor/plugins/post_pulp_pull.py
+++ b/atomic_reactor/plugins/post_pulp_pull.py
@@ -20,6 +20,7 @@ from atomic_reactor.plugins.exit_remove_built_image import defer_removal
 from docker.errors import NotFound
 from time import time, sleep
 
+
 class CraneTimeoutError(Exception):
     """The expected image did not appear in the required time"""
     pass
@@ -65,7 +66,8 @@ class PulpPullPlugin(PostBuildPlugin):
                 metadata = self.tasker.inspect_image(name)
             except NotFound:
                 if time() - start > self.timeout:
-                    raise CraneTimeoutError("{}s exceeded".format(self.timeout))
+                    raise CraneTimeoutError("{} seconds exceeded"
+                                            .format(self.timeout))
 
                 self.log.info("will try again in %ss", self.retry_delay)
                 sleep(self.retry_delay)

--- a/tests/plugins/test_pulp_pull.py
+++ b/tests/plugins/test_pulp_pull.py
@@ -1,0 +1,136 @@
+"""
+Copyright (c) 2016 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+from atomic_reactor.plugins.post_pulp_pull import (PulpPullPlugin,
+                                                   CraneTimeoutError)
+from atomic_reactor.inner import TagConf, PushConf
+from docker.errors import NotFound
+import time
+
+from flexmock import flexmock
+import pytest
+
+
+class MockerTasker(object):
+    def __init__(self):
+        self.pulled_images = []
+
+    def pull_image(self, image):
+        self.pulled_images.append(image)
+        return image.to_str()
+
+    def inspect_image(self, image):
+        pass
+
+
+class TestPostPulpPull(object):
+    TEST_UNIQUE_IMAGE = 'foo:unique-tag'
+    CRANE_URI = 'crane.example.com'
+
+    def workflow(self):
+        tag_conf = TagConf()
+        tag_conf.add_unique_image(self.TEST_UNIQUE_IMAGE)
+        push_conf = PushConf()
+        push_conf.add_pulp_registry('pulp', crane_uri=self.CRANE_URI)
+        builder = flexmock()
+        setattr(builder, 'image_id', 'sha256:(old)')
+        return flexmock(tag_conf=tag_conf,
+                        push_conf=push_conf,
+                        builder=builder,
+                        plugin_workspace={})
+
+    def test_no_unique_image(self):
+        tag_conf = TagConf()
+        workflow = flexmock(tag_conf=tag_conf)
+        plugin = PulpPullPlugin(None, workflow)
+        with pytest.raises(RuntimeError):
+            plugin.run()
+
+    def test_pull_first_time(self):
+        workflow = self.workflow()
+        tasker = MockerTasker()
+        expected_pullspec = '%s/%s' % (self.CRANE_URI, self.TEST_UNIQUE_IMAGE)
+        test_id = 'sha256:(new)'
+
+        (flexmock(tasker)
+            .should_call('pull_image')
+            .and_return(expected_pullspec)
+            .once()
+            .ordered())
+
+        (flexmock(tasker)
+            .should_receive('inspect_image')
+            .with_args(expected_pullspec)
+            .and_return({'Id': test_id})
+            .once())
+
+        plugin = PulpPullPlugin(tasker, workflow)
+
+        # Plugin return value is the new ID
+        assert plugin.run() == test_id
+
+        assert len(tasker.pulled_images) == 1
+        pulled = tasker.pulled_images[0].to_str()
+        assert pulled == expected_pullspec
+
+        # Image ID is updated in workflow
+        assert workflow.builder.image_id == test_id
+
+    def test_pull_timeout(self):
+        workflow = self.workflow()
+        tasker = MockerTasker()
+        expected_pullspec = '%s/%s' % (self.CRANE_URI, self.TEST_UNIQUE_IMAGE)
+
+        (flexmock(tasker)
+            .should_call('pull_image')
+            .and_return(expected_pullspec)
+            .times(3))
+
+        (flexmock(tasker)
+            .should_receive('inspect_image')
+            .with_args(expected_pullspec)
+            .and_raise(NotFound('message', flexmock(content=None)))
+            .times(3))
+
+        plugin = PulpPullPlugin(tasker, workflow, timeout=1, retry_delay=0.6)
+
+        # Should raise a timeout exception
+        with pytest.raises(CraneTimeoutError):
+            plugin.run()
+
+    def test_pull_retry(self):
+        workflow = self.workflow()
+        tasker = MockerTasker()
+        expected_pullspec = '%s/%s' % (self.CRANE_URI, self.TEST_UNIQUE_IMAGE)
+        test_id = 'sha256:(new)'
+
+        (flexmock(tasker)
+            .should_call('pull_image')
+            .and_return(expected_pullspec)
+            .times(3))
+
+        (flexmock(tasker)
+            .should_receive('inspect_image')
+            .with_args(expected_pullspec)
+            .and_raise(NotFound('message', flexmock(content=None)))
+            .and_raise(NotFound('message', flexmock(content=None)))
+            .and_return({'Id': test_id})
+            .times(3))
+
+        plugin = PulpPullPlugin(tasker, workflow, timeout=1, retry_delay=0.6)
+
+        # Plugin return value is the new ID
+        assert plugin.run() == test_id
+
+        assert len(tasker.pulled_images) == 3
+        for image in tasker.pulled_images:
+            pulled = image.to_str()
+            assert pulled == expected_pullspec
+
+        # Image ID is updated in workflow
+        assert workflow.builder.image_id == test_id

--- a/tests/plugins/test_pulp_pull.py
+++ b/tests/plugins/test_pulp_pull.py
@@ -44,13 +44,6 @@ class TestPostPulpPull(object):
                         builder=builder,
                         plugin_workspace={})
 
-    def test_no_unique_image(self):
-        tag_conf = TagConf()
-        workflow = flexmock(tag_conf=tag_conf)
-        plugin = PulpPullPlugin(None, workflow)
-        with pytest.raises(RuntimeError):
-            plugin.run()
-
     def test_pull_first_time(self):
         workflow = self.workflow()
         tasker = MockerTasker()


### PR DESCRIPTION
When adding content to Pulp, the conversion to v2 schema 1 causes the pulled image ID to be different than the one we re-imported from the squash plugin.

This plugin pulls the image from Pulp's Crane instance in order to discover the image ID.