### PR TITLE
rpmqa: log exception info if remove fails

### DIFF
--- a/atomic_reactor/plugins/post_rpmqa.py
+++ b/atomic_reactor/plugins/post_rpmqa.py
@@ -61,7 +61,8 @@ class PostBuildRPMqaPlugin(PostBuildPlugin):
 
         try:
             self.tasker.remove_container(container_id)
-        except APIError as ex:
-            self.log.warning(repr(ex))
+        except APIError:
+            self.log.warning("error removing container (ignored):",
+                             exc_info=True)
 
         return plugin_output


### PR DESCRIPTION
For some exceptions repr() actually gives less information than str().

Since this exception is not a business-as-usual occurrence and may need investigation, guard against this by using the built-in exception display functionality of the logging module.