### PR TITLE
Run exit plugins if the build has been cancelled

### DIFF
--- a/atomic_reactor/plugin.py
+++ b/atomic_reactor/plugin.py
@@ -38,6 +38,10 @@ class PluginFailedException(Exception):
     """ There was an error during plugin execution """
 
 
+class BuildCanceledException(Exception):
+    """Build was canceled"""
+
+
 class Plugin(object):
     """ abstract plugin class """
 


### PR DESCRIPTION
Docker sends SIGTERM to a container when its stopped (OSE build is cancelled).

This PR traps the signal and throws an  exception in the process if the build or pre-/post-build plugins are running. The signal handler will ignore the exception if exit plugins are running.

Default docker timeout is 30 secs, so exit plugins have plenty of time to finish.

TODO:
 - [x] Add tests