### PR TITLE
Make sure build container is removed if build was unsuccessful

### DIFF
--- a/atomic_reactor/core.py
+++ b/atomic_reactor/core.py
@@ -244,11 +244,11 @@ class DockerTasker(LastLogger):
         logger.info("building image '%s' from path '%s'", image, path)
         try:
             response = self.d.build(path=path, tag=image.to_str(), stream=stream, nocache=not use_cache,
-                                    rm=remove_im, pull=False)  # returns generator
+                                    rm=remove_im, forcerm=True, pull=False)  # returns generator
         except TypeError:
             # because changing api is fun
             response = self.d.build(path=path, tag=image.to_str(), stream=stream, nocache=not use_cache,
-                                    rm=remove_im)  # returns generator
+                                    rm=remove_im, forcerm=True,)  # returns generator
         return response
 
     def build_image_from_git(self, url, image, git_path=None, git_commit=None, copy_dockerfile_to=None,


### PR DESCRIPTION
Fixes #575 

Docker-py's `forcerm` option makes sure that all intermediate containers are removed ii the build is unsuccessful