### PR TITLE
Avoid osbs.conf collision in import_image

### DIFF
--- a/atomic_reactor/plugins/post_import_image.py
+++ b/atomic_reactor/plugins/post_import_image.py
@@ -61,7 +61,8 @@ class ImportImagePlugin(PostBuildPlugin):
         kwargs = {}
 
         # FIXME: remove `openshift_uri` once osbs-client is released
-        osbs_conf = Configuration(openshift_uri=self.url,
+        osbs_conf = Configuration(conf_file=None,
+                                  openshift_uri=self.url,
                                   openshift_url=self.url,
                                   use_auth=self.use_auth,
                                   verify_ssl=self.verify_ssl,

--- a/tests/plugins/test_import_image.py
+++ b/tests/plugins/test_import_image.py
@@ -54,8 +54,10 @@ def prepare(insecure_registry=None, retry_delay=None, namespace=None):
 
     expectation = flexmock(osbs.conf).should_receive('Configuration').and_return(fake_conf)
     if namespace:
-        expectation.with_args(namespace=namespace, verify_ssl=False, openshift_url="",
-                              openshift_uri="", use_auth=False, build_json_dir="")
+        expectation.with_args(conf_file=None, namespace=namespace,
+                              verify_ssl=False, openshift_url="",
+                              openshift_uri="", use_auth=False,
+                              build_json_dir="")
 
     runner = PostBuildPluginsRunner(tasker, workflow, [{
         'name': ImportImagePlugin.key,


### PR DESCRIPTION
Setting `conf_file` to `None` avoids the local file `/etc/osbs.conf` to be used if present.
This file can cause problems as it may have some uneeded configuration such as auth details.

This is the same approach taken by any other usage of `Configuration` object in this project: see `koji_promote`, `store_metadata_in_osv3`, `check_and_set_rebuild`.