### PR TITLE
don't overwrite distribution-scope label in dockerfile

### DIFF
--- a/atomic_reactor/plugins/pre_add_labels_in_df.py
+++ b/atomic_reactor/plugins/pre_add_labels_in_df.py
@@ -67,7 +67,7 @@ class AddLabelsPlugin(PreBuildPlugin):
     }
 
     def __init__(self, tasker, workflow, labels,
-                 dont_overwrite=("Architecture", "architecture", ),
+                 dont_overwrite=("distribution-scope", ),
                  auto_labels=("build-date",
                               "architecture",
                               "vcs-type",

--- a/atomic_reactor/plugins/pre_add_labels_in_df.py
+++ b/atomic_reactor/plugins/pre_add_labels_in_df.py
@@ -82,13 +82,13 @@ class AddLabelsPlugin(PreBuildPlugin):
         :param workflow: DockerBuildWorkflow instance
         :param labels: dict, key value pairs to set as labels; or str, JSON-encoded dict
         :param dont_overwrite: iterable, list of label keys which should not be overwritten
-                               IF they are present in baseimage!
+                               if they are present in parent image
         :param auto_labels: iterable, list of labels to be determined automatically, if supported
         :param aliases: dict, maps old label names to new label names - for each old name found in
                         base image, dockerfile, or labels argument, a label with the new name is
                         added (with the same value)
         :param dont_overwrite_if_in_dockerfile : iterable, list of label keys which should not be
-                                                 overwritten IF they are present in dockerfile!
+                                                 overwritten if they are present in dockerfile
         """
         # call parent constructor
         super(AddLabelsPlugin, self).__init__(tasker, workflow)

--- a/atomic_reactor/plugins/pre_add_labels_in_df.py
+++ b/atomic_reactor/plugins/pre_add_labels_in_df.py
@@ -36,6 +36,15 @@ LABEL "label1"="value1" "label 2"="some value"
 CMD date
 ```
 
+
+By default there is parameter:
+    dont_overwrite=("Architecture", "architecture")
+which disallows to overwrite labels in the list if they are in parent image.
+
+After that is also another check via parameter :
+    dont_overwrite_if_in_dockerfile=("distribution-scope",)
+which disallows to overwrite labels in the list if they are in dockerfile
+
 Keys and values are quoted as necessary.
 """
 

--- a/atomic_reactor/plugins/pre_add_labels_in_df.py
+++ b/atomic_reactor/plugins/pre_add_labels_in_df.py
@@ -67,7 +67,7 @@ class AddLabelsPlugin(PreBuildPlugin):
     }
 
     def __init__(self, tasker, workflow, labels,
-                 dont_overwrite=("distribution-scope", ),
+                 dont_overwrite=dont_overwrite=("Architecture", "architecture"),
                  auto_labels=("build-date",
                               "architecture",
                               "vcs-type",
@@ -81,6 +81,7 @@ class AddLabelsPlugin(PreBuildPlugin):
         :param workflow: DockerBuildWorkflow instance
         :param labels: dict, key value pairs to set as labels; or str, JSON-encoded dict
         :param dont_overwrite: iterable, list of label keys which should not be overwritten
+                               IF they are present if baseimage!
         :param auto_labels: iterable, list of labels to be determined automatically, if supported
         :param aliases: dict, maps old label names to new label names - for each old name found in
                         base image, dockerfile, or labels argument, a label with the new name is

--- a/atomic_reactor/plugins/pre_add_labels_in_df.py
+++ b/atomic_reactor/plugins/pre_add_labels_in_df.py
@@ -82,13 +82,13 @@ class AddLabelsPlugin(PreBuildPlugin):
         :param workflow: DockerBuildWorkflow instance
         :param labels: dict, key value pairs to set as labels; or str, JSON-encoded dict
         :param dont_overwrite: iterable, list of label keys which should not be overwritten
-                               IF they are present if baseimage!
+                               IF they are present in baseimage!
         :param auto_labels: iterable, list of labels to be determined automatically, if supported
         :param aliases: dict, maps old label names to new label names - for each old name found in
                         base image, dockerfile, or labels argument, a label with the new name is
                         added (with the same value)
         :param dont_overwrite_if_in_dockerfile : iterable, list of label keys which should not be
-                                                 overwritten IF they are present if dockerfile!
+                                                 overwritten IF they are present in dockerfile!
         """
         # call parent constructor
         super(AddLabelsPlugin, self).__init__(tasker, workflow)

--- a/tests/plugins/test_add_labels.py
+++ b/tests/plugins/test_add_labels.py
@@ -299,7 +299,7 @@ def test_add_labels_aliases(tmpdir, docker_tasker, caplog,
 def test_dont_overwrite_distribution_scope(tmpdir, docker_tasker):
     df_content = "FROM fedora\n"
     df_content += 'LABEL distribution-scope="private"'
-    labels_conf_base = {INSPECT_CONFIG: {"Labels": {"distribution-scope": "public"}}}
+    labels_conf_base = {INSPECT_CONFIG: {"Labels": {"distribution-scope": "private"}}}
 
     df = df_parser(str(tmpdir))
     df.content = df_content
@@ -317,7 +317,7 @@ def test_dont_overwrite_distribution_scope(tmpdir, docker_tasker):
         workflow,
         [{
             'name': AddLabelsPlugin.key,
-            'args': {'labels': {"distribution-scope": "public"}, "dont_overwrite": ["distribution-scope"], "auto_labels": [],
+            'args': {'labels': {"distribution-scope": "restricted"}, "dont_overwrite": ["distribution-scope"], "auto_labels": [],
                      'aliases': {}}
         }]
     )

--- a/tests/plugins/test_add_labels.py
+++ b/tests/plugins/test_add_labels.py
@@ -317,7 +317,7 @@ def test_dont_overwrite_distribution_scope(tmpdir, docker_tasker):
         workflow,
         [{
             'name': AddLabelsPlugin.key,
-            'args': {'labels': {"distribution-scope": "restricted"}, "dont_overwrite": ["distribution-scope"], "auto_labels": [],
+            'args': {'labels': {"distribution-scope": "restricted"}, "dont_overwrite_if_in_dockerfile": ["distribution-scope"], "auto_labels": [],
                      'aliases': {}}
         }]
     )

--- a/tests/plugins/test_add_labels.py
+++ b/tests/plugins/test_add_labels.py
@@ -296,7 +296,13 @@ def test_add_labels_aliases(tmpdir, docker_tasker, caplog,
     if expected_log:
         assert expected_log in caplog.text()
 
-def test_dont_overwrite_distribution_scope(tmpdir, docker_tasker):
+@pytest.mark.parametrize('labels', [{"distribution-scope": "restricted",
+                                     "dont_overwrite_if_in_dockerfile": "distribution-scope",
+                                     "auto_labels": [], 'aliases': {}},
+                                    {"distribution-scope": "restricted",
+                                     "auto_labels": [], 'aliases': {}}
+])
+def test_dont_overwrite_distribution_scope(tmpdir, docker_tasker, labels):
     df_content = "FROM fedora\n"
     df_content += 'LABEL distribution-scope="private"'
     labels_conf_base = {INSPECT_CONFIG: {"Labels": {"distribution-scope": "private"}}}
@@ -317,8 +323,7 @@ def test_dont_overwrite_distribution_scope(tmpdir, docker_tasker):
         workflow,
         [{
             'name': AddLabelsPlugin.key,
-            'args': {'labels': {"distribution-scope": "restricted"}, "dont_overwrite_if_in_dockerfile": ["distribution-scope"], "auto_labels": [],
-                     'aliases': {}}
+            'args': {'labels': labels}
         }]
     )
 


### PR DESCRIPTION
allow users to define distribution-scope label in dockerfile, it will work unless you specify wider scope than in parent image