### PR TITLE
Make importing istags fail after number of retries

### DIFF
--- a/atomic_reactor/plugins/post_import_image.py
+++ b/atomic_reactor/plugins/post_import_image.py
@@ -14,7 +14,7 @@ from osbs.api import OSBS
 from osbs.conf import Configuration
 from osbs.exceptions import OsbsResponseException
 
-from atomic_reactor.plugin import PostBuildPlugin
+from atomic_reactor.plugin import PostBuildPlugin, PluginFailedException
 from atomic_reactor.util import get_build_json
 
 
@@ -29,7 +29,7 @@ class ImportImagePlugin(PostBuildPlugin):
 
     def __init__(self, tasker, workflow, imagestream, docker_image_repo,
                  url, build_json_dir, verify_ssl=True, use_auth=True,
-                 insecure_registry=None, retry_delay=30):
+                 insecure_registry=None, retry_delay=30, retry_attempts=3):
         """
         constructor
 
@@ -44,6 +44,8 @@ class ImportImagePlugin(PostBuildPlugin):
         :param insecure_registry: bool, whether the Docker registry uses
                plain HTTP
         :param retry_delay: int, number of seconds to delay before retrying
+        :param retry_attempts: int, number of times it will be retried to
+               import image
         """
         # call parent constructor
         super(ImportImagePlugin, self).__init__(tasker, workflow)
@@ -55,6 +57,7 @@ class ImportImagePlugin(PostBuildPlugin):
         self.use_auth = use_auth
         self.insecure_registry = insecure_registry
         self.retry_delay = retry_delay
+        self.retry_attempts = retry_attempts
 
     def run(self):
         metadata = get_build_json().get("metadata", {})
@@ -83,15 +86,17 @@ class ImportImagePlugin(PostBuildPlugin):
             osbs.create_image_stream(self.imagestream, self.docker_image_repo,
                                      **kwargs)
         else:
-            self.log.info("Importing tags for %s", self.imagestream)
-            retry_attempts = 3
-            while True:
-                result = osbs.import_image(self.imagestream, **kwargs)
-                if result:
+            self.log.info("Importing new tags for %s", self.imagestream)
+
+            for attempts in range(self.retry_attempts):
+                new_tags_imported = osbs.import_image(self.imagestream)
+                if new_tags_imported:
                     break
 
-                if retry_attempts > 0:
-                    retry_attempts -= 1
-                    self.log.info("no new tags, will retry after %d seconds",
-                                  self.retry_delay)
-                    sleep(self.retry_delay)
+                self.log.info("no new tags, will retry after %d seconds (%d/%d)",
+                              self.retry_delay, attempts + 1, self.retry_attempts)
+                sleep(self.retry_delay)
+
+            if not new_tags_imported:
+                msg = "Failed to import new tags for %s"
+                raise PluginFailedException(msg % self.imagestream)

--- a/tests/plugins/test_import_image.py
+++ b/tests/plugins/test_import_image.py
@@ -164,9 +164,9 @@ def test_import_image(namespace, monkeypatch):
 
 
 @pytest.mark.parametrize(('retry_delay', 'results'), [
-    (1, [False, True]),
-    (0, [False, False, False]),
-    (2, [True]),
+    (0, [False, True]),
+    (0.01, [False, False, False]),
+    (0.02, [True]),
 ])
 def test_import_image_retry(retry_delay, results, monkeypatch):
     """
@@ -197,6 +197,31 @@ def test_import_image_retry(retry_delay, results, monkeypatch):
             runner.run()
     else:
         runner.run()
+
+
+@pytest.mark.parametrize(('import_attempts'), [0, 1, 2])
+def test_import_image_attempts_config(import_attempts):
+    """
+    Test the validation of import_attempts
+    """
+    args = {
+        "tasker": None,
+        "workflow": None,
+        "imagestream": None,
+        "docker_image_repo": None,
+        "url": None,
+        "build_json_dir": None,
+        "import_attempts": import_attempts,
+    }
+
+    if import_attempts > 0:
+        plugin = ImportImagePlugin(**args)
+        assert plugin.import_attempts == import_attempts
+    else:
+        with pytest.raises(ValueError) as value_error:
+            ImportImagePlugin(**args)
+            assert value_error.value.message == (
+                "import_attempts is %d, should be at least 1" % import_attempts)
 
 
 def test_exception_during_create(monkeypatch):


### PR DESCRIPTION
When importing new ImageStreamTags in `post_import_image` plug-in,
the code hit an infinite loop, in case the import never
succeeded.

The above was solved by raising a `PluginFailedException` in case
the number of retries was reached.

Optional parameter `retry_attempts` was also added. Defaults to 3,
which was the previous hard-coded value for this function.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>