### PR TITLE
push_to_pulp: make PulpUploader inherit dockpulp logging level set in PulpPushPlugin.__init__

### DIFF
--- a/atomic_reactor/plugins/post_push_to_pulp.py
+++ b/atomic_reactor/plugins/post_push_to_pulp.py
@@ -40,7 +40,6 @@ pulp_secret_path:
 
 from __future__ import print_function, unicode_literals
 from dockpulp import setup_logger
-from atomic_reactor import set_logging
 
 from atomic_reactor.plugins.post_pulp_sync import PulpSyncPlugin
 from atomic_reactor.plugin import PostBuildPlugin
@@ -83,8 +82,6 @@ class PulpUploader(object):
         self.username = username
         self.password = password
         self.publish = publish
-
-        set_logging("dockpulp")
 
     def _check_file(self):
         # Sanity-check image


### PR DESCRIPTION
This makes `push_to_pulp` plugin less chatty:
```
2017-01-17 12:45:04,077 - atomic_reactor.plugins.pulp_push - INFO - image names: ['rhel7/rsyslog:7.3.vrutkovs-3', 'rhel7/rsyslog:7.3.vrutkovs', 'rhel7/rsyslog:latest', 'rhel7/rsyslog:none-20170117134015']
2017-01-17 12:45:04,077 - atomic_reactor.plugins.pulp_push - INFO - checking image before upload
2017-01-17 12:45:04,122 - atomic_reactor.plugins.pulp_push - INFO - using configured path /var/run/secrets/atomic-reactor/pulpsecret for secrets
2017-01-17 12:45:04,122 - atomic_reactor.plugins.pulp_push - INFO - pulp_repos = {u'redhat-rhel7-rsyslog': PulpRepo(registry_id=u'rhel7/rsyslog', tags=[u'7.3.vrutkovs-3', u'7.3.vrutkovs', u'latest', u'none-20170117134015'])}
2017-01-17 12:45:05,533 - atomic_reactor.plugins.pulp_push - INFO - Missing repos: 
2017-01-17 12:45:07,728 - atomic_reactor.plugins.pulp_push - DEBUG - existing layers: ['e3a08181649e0a6ddf1f610d0977c99f61f1b8510e4bdc1d2829f5f0c795f94c', '3d13b3f1f8a15c2db4010250df461f9c21134dc6e0712664f59c83d795fe8b97']
2017-01-17 12:45:07,728 - atomic_reactor.plugins.pulp_push - DEBUG - using unpacker cat for extension .tar
2017-01-17 12:45:07,728 - atomic_reactor.plugins.pulp_push - DEBUG - running set -o pipefail; cat /tmp/tmp9InpRx/image.tar | tar --delete e3a08181649e0a6ddf1f610d0977c99f61f1b8510e4bdc1d2829f5f0c795f94c/layer.tar 3d13b3f1f8a15c2db4010250df461f9c21134dc6e0712664f59c83d795fe8b97/layer.tar | gzip - > /tmp/strip_tar_Vbpaqe.gz
2017-01-17 12:45:09,704 - atomic_reactor.plugins.pulp_push - DEBUG - uploading /tmp/strip_tar_Vbpaqe.gz
INFO      upload request: dec9c10b-d87e-4393-b25a-651c6f89ad33
INFO      uploading a 0M image
INFO      content uploaded
INFO      adding d2f39da07d5e8a33a13882e5a7b1c5255648e88e11592159c6871330c0c39baf to redhat-everything
INFO      Pulp spawned a subtask: f280506b-158a-4635-b9a9-443e596e14df
INFO      waiting up to 5000 seconds for task f280506b-158a-4635-b9a9-443e596e14df...
INFO      subtask completed
INFO      removed upload request dec9c10b-d87e-4393-b25a-651c6f89ad33
INFO      copying d2f39da07d5e8a33a13882e5a7b1c5255648e88e11592159c6871330c0c39baf from redhat-everything to redhat-rhel7-rsyslog
INFO      Pulp spawned a subtask: 468f64b1-fed1-4fc4-9939-20db6575e621
INFO      waiting up to 5000 seconds for task 468f64b1-fed1-4fc4-9939-20db6575e621...
INFO      subtask completed
INFO      copying e3a08181649e0a6ddf1f610d0977c99f61f1b8510e4bdc1d2829f5f0c795f94c from redhat-everything to redhat-rhel7-rsyslog
INFO      Pulp spawned a subtask: 6240fdb1-0f8d-4cc8-a095-6acba73d0921
INFO      waiting up to 5000 seconds for task 6240fdb1-0f8d-4cc8-a095-6acba73d0921...
INFO      subtask completed
INFO      copying 3d13b3f1f8a15c2db4010250df461f9c21134dc6e0712664f59c83d795fe8b97 from redhat-everything to redhat-rhel7-rsyslog
INFO      Pulp spawned a subtask: 8374654c-7d71-42dd-a2ea-c2414133fad5
INFO      waiting up to 5000 seconds for task 8374654c-7d71-42dd-a2ea-c2414133fad5...
INFO      subtask completed
INFO      updating repo redhat-rhel7-rsyslog
INFO      Pulp spawned a subtask: 0aeeb6e4-9458-4700-852c-e993704adb62
INFO      waiting up to 5000 seconds for task 0aeeb6e4-9458-4700-852c-e993704adb62...
INFO      subtask completed
2017-01-17 12:45:46,370 - atomic_reactor.plugins.pulp_push - INFO - publishing deferred until pulp_sync plugin runs
```