### PR TITLE
When specified 'required':False, plugins should not fail the build

### DIFF
--- a/atomic_reactor/plugin.py
+++ b/atomic_reactor/plugin.py
@@ -195,9 +195,8 @@ class PluginsRunner(object):
             try:
                 plugin_class = self.plugin_classes[plugin_name]
             except KeyError:
-                self.on_plugin_failed()
-
                 if plugin_request.get('required', True):
+                    self.on_plugin_failed()
                     msg = ("no such plugin: '%s', did you set "
                            "the correct plugin type?") %  plugin_name
                     logger.error(msg)


### PR DESCRIPTION
fixes #624 

koji_promote ends with INFO - Not promoting failed build to koji #624

this relates to the change, where dockerfile_content was removed

in plugin.py PluginsRunner

self.on_plugin_failed() is called and sets plugin_failed to True,
even when plugin
plugin 'dockerfile_content' requested but not available
even when in prod_inner.json the plugin has set required to False

so based on that even when inside container build is success, but this not required plugin sets plugin_failed
koji_promote won't promote anything


so what this does it that if plugin which doesn't exist, and isn't required, won't set plugins_failed in workflow, therefore koji_promote WILL continue to pushing things to koji