### PR TITLE
(ignore for now) Record errors for exit plugins that must succeed

### DIFF
--- a/atomic_reactor/plugin.py
+++ b/atomic_reactor/plugin.py
@@ -232,13 +232,15 @@ class PluginsRunner(object):
             except Exception as ex:
                 msg = "plugin '%s' raised an exception: %r" % (plugin_class.key, ex)
                 logger.debug(traceback.format_exc())
+                if not plugin_is_allowed_to_fail:
+                    self.on_plugin_failed(plugin_class.key, ex)
+
                 if plugin_is_allowed_to_fail or keep_going:
                     logger.warning(msg)
                     logger.info("error is not fatal, continuing...")
                     if not plugin_is_allowed_to_fail:
                         failed_msgs.append(msg)
                 else:
-                    self.on_plugin_failed(plugin_class.key, ex)
                     logger.error(msg)
                     raise PluginFailedException(msg)
 


### PR DESCRIPTION
Previously plugins such as koji_promote, i.e. exit plugins which must succeed, do not have their failures recorded in the workflow's `plugins_errors` dict. This means build errors due to failures in such plugins have no meaningful error message stored in the build annotations.

This PR fixes that.