### PR TITLE
koji_promote: trap TypeError when checking help plugin config

### DIFF
--- a/atomic_reactor/plugins/exit_koji_promote.py
+++ b/atomic_reactor/plugins/exit_koji_promote.py
@@ -565,8 +565,10 @@ class KojiPromotePlugin(ExitPlugin):
         help_result = self.workflow.prebuild_results.get(AddHelpPlugin.key)
         if help_result is not None:
             try:
-                extra['image']['help'] = self.workflow.prebuild_plugins_conf[AddHelpPlugin.key]['help_file']
-            except KeyError:
+                add_help_config = [x for x in self.workflow.prebuild_plugins_conf
+                                   if x['name'] == AddHelpPlugin.key][0]
+                extra['image']['help'] = add_help_config['args']['help_file']
+            except (KeyError, TypeError, IndexError):
                 extra['image']['help'] = DEFAULT_HELP_FILENAME
 
         build = {

--- a/tests/plugins/test_koji_promote.py
+++ b/tests/plugins/test_koji_promote.py
@@ -1186,10 +1186,19 @@ class TestKojiPromote(object):
                                             version='1.0',
                                             release='1',
                                             session=session)
-        if expect_result in ['empty_result', 'pass']:
-            workflow.prebuild_plugins_conf[AddHelpPlugin.key] = {
-                'help_file': 'foo.md',
-            }
+
+        if expect_result == 'pass':
+            workflow.prebuild_plugins_conf = [{
+                "name": AddHelpPlugin.key,
+                "args": {
+                  "help_file": 'foo.md',
+                }
+            }]
+
+        if expect_result == 'empty_config':
+            workflow.prebuild_plugins_conf = [{
+                "name": AddHelpPlugin.key,
+            }]
 
         if expect_result != 'skip':
             workflow.prebuild_results[AddHelpPlugin.key] = "FROM rhel"


### PR DESCRIPTION
This also fixes `add_help` plugin's incorrect verification of `go-md2man` binary