### PR TITLE
Ignore 'dockerfile_content' plugin requests

### DIFF
--- a/atomic_reactor/plugins/input_osv3.py
+++ b/atomic_reactor/plugins/input_osv3.py
@@ -62,6 +62,16 @@ class OSv3InputPlugin(InputPlugin):
 
         self.log.debug("build json: %s", input_json)
 
+        # Compatibility code for dockerfile_content plugin
+        # If this (removed) plugin is requested, ignore it.
+        if 'prebuild_plugins' in self.plugins_json:
+            for index, plugin in enumerate(self.plugins_json['prebuild_plugins']):
+                if plugin['name'] == 'dockerfile_content':
+                    self.log.info("removing dockerfile_content plugin request; "
+                                  "please update your osbs-client!")
+                    del self.plugins_json['prebuild_plugins'][index]
+                    break
+
         return input_json
 
     @classmethod

--- a/tests/plugins/test_input_osv3.py
+++ b/tests/plugins/test_input_osv3.py
@@ -71,3 +71,38 @@ def test_plugins_variable(plugins_variable):
 
     plugin = OSv3InputPlugin()
     assert plugin.run()['postbuild_plugins'] is not None
+
+def test_remove_dockerfile_content():
+    plugins_json = {
+        'prebuild_plugins': [
+            {
+                'name': 'before',
+            },
+            {
+                'name': 'dockerfile_content',
+            },
+            {
+                'name': 'after',
+            },
+        ]
+    }
+
+    mock_env = {
+        'BUILD': '{}',
+        'SOURCE_URI': 'https://github.com/foo/bar.git',
+        'SOURCE_REF': 'master',
+        'OUTPUT_IMAGE': 'asdf:fdsa',
+        'OUTPUT_REGISTRY': 'localhost:5000',
+        'ATOMIC_REACTOR_PLUGINS': json.dumps(plugins_json),
+    }
+    flexmock(os, environ=mock_env)
+
+    plugin = OSv3InputPlugin()
+    assert plugin.run()['prebuild_plugins'] == [
+        {
+            'name': 'before',
+        },
+        {
+            'name': 'after',
+        },
+    ]


### PR DESCRIPTION
This change provides more compatibility when upgrading. If osbs-client is still requesting 'dockerfile_content' but it has been removed, we will ignore it.

Note that 'required' was broken prior to this release, hence the need for this compatibility work-around.