### PR TITLE
Revert "integrate py.test with 'python setup.py test'"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[aliases]
-test=pytest

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,5 @@ setup(
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     install_requires=_install_requirements(),
     data_files=data_files.items(),
-    setup_requires=['pytest-runner'],
-    tests_require=_get_requirements('tests/requirements.txt'),
 )
 


### PR DESCRIPTION
This reverts commit 016176a7df37c62389071b0175f393697fc1bf57.

pytest-runner is not available in RHEL, so instead of 'python setup.py test' a 
different command to run tests is required - see travis.yml or soon-to-be-merged contribution guide

Related: #593, #556