### PR TITLE
Handle parent config env containing multiple '='

### DIFF
--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -825,7 +825,7 @@ def df_parser(df_path, workflow=None, cache_content=False, env_replace=True, par
                 elif isinstance(tmp_env, list):
                     try:
                         for key_val in tmp_env:
-                            key, val = key_val.split("=")
+                            key, val = key_val.split("=", 1)
                             p_env[key] = val
 
                     except ValueError:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -476,6 +476,8 @@ def test_df_parser_parent_env_arg(tmpdir):
 @pytest.mark.parametrize('env_arg', [
     {"test_env": "first"},
     ['test_env=first'],
+    ['test_env='],
+    ['test_env=--option=first --option=second'],
     ['test_env_first'],
 ])
 def test_df_parser_parent_env_wf(tmpdir, caplog, env_arg):
@@ -493,6 +495,8 @@ def test_df_parser_parent_env_wf(tmpdir, caplog, env_arg):
     if isinstance(env_arg, list) and ('=' not in env_arg[0]):
         expected_log_message = "Unable to parse all of Parent Config ENV"
         assert expected_log_message in [l.getMessage() for l in caplog.records()]
+    elif isinstance(env_arg, dict):
+        assert df.labels.get('label') == ('foobar ' + env_arg['test_env'])
     else:
-        assert df.labels.get('label') == 'foobar first'
+        assert df.labels.get('label') == 'foobar ' + env_arg[0].split('=', 1)[1]
 


### PR DESCRIPTION
When ENVs were obtained by inspecting the worklow of the parent_env,
and 'Env' was a list of values, conversion to dict failed on the split,
when any of the values was similar to:
```
    'test_env=--option=first --option=second'
```

To avoid this only a single split is done, on the first '='.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>