### PR TITLE
Make reactor_config default to reading config.yaml

### DIFF
--- a/atomic_reactor/plugins/pre_reactor_config.py
+++ b/atomic_reactor/plugins/pre_reactor_config.py
@@ -11,6 +11,7 @@ from atomic_reactor.plugin import PreBuildPlugin
 import codecs
 import json
 import jsonschema
+import os
 from pkg_resources import resource_stream
 import yaml
 
@@ -88,17 +89,19 @@ class ReactorConfigPlugin(PreBuildPlugin):
     # Exceptions from this plugin should fail the build
     is_allowed_to_fail = False
 
-    def __init__(self, tasker, workflow, config_path):
+    def __init__(self, tasker, workflow, config_path, basename='config.yaml'):
         """
         constructor
 
         :param tasker: DockerTasker instance
         :param workflow: DockerBuildWorkflow instance
-        :param config_path: str, configuration filename
+        :param config_path: str, configuration path (directory)
+        :param basename: str, filename within directory; default is config.yaml
         """
         # call parent constructor
         super(ReactorConfigPlugin, self).__init__(tasker, workflow)
         self.config_path = config_path
+        self.basename = basename
 
     def run(self):
         """
@@ -108,8 +111,9 @@ class ReactorConfigPlugin(PreBuildPlugin):
         Store in workflow workspace for later retrieval.
         """
 
-        self.log.info("reading config from %s", self.config_path)
-        with open(self.config_path) as fp:
+        config_filename = os.path.join(self.config_path, self.basename)
+        self.log.info("reading config from %s", config_filename)
+        with open(config_filename) as fp:
             conf = yaml.safe_load(fp)
 
         # Validate against JSON schema

--- a/tests/plugins/test_reactor_config.py
+++ b/tests/plugins/test_reactor_config.py
@@ -42,6 +42,24 @@ class TestReactorConfigPlugin(object):
         same_conf = get_config(workflow)
         assert conf is same_conf
 
+    @pytest.mark.parametrize('basename', ['reactor-config.yaml', None])
+    def test_filename(self, tmpdir, basename):
+        filename = os.path.join(str(tmpdir), basename or 'config.yaml')
+        with open(filename, 'w'):
+            pass
+
+        tasker, workflow = self.prepare()
+        plugin = ReactorConfigPlugin(tasker, workflow,
+                                     config_path=str(tmpdir),
+                                     basename=filename)
+        assert plugin.run() == None
+
+    def test_filename_not_found(self):
+        tasker, workflow = self.prepare()
+        plugin = ReactorConfigPlugin(tasker, workflow, config_path='/not-found')
+        with pytest.raises(Exception):
+            plugin.run()
+
     def test_no_schema_resource(self, tmpdir, caplog):
         class FakeProvider(object):
             def get_resource_stream(self, pkg, rsc):
@@ -53,12 +71,12 @@ class TestReactorConfigPlugin(object):
             .should_receive('get_provider')
             .and_return(FakeProvider()))
 
-        filename = os.path.join(str(tmpdir), 'reactor_config.yaml')
+        filename = os.path.join(str(tmpdir), 'config.yaml')
         with open(filename, 'w'):
             pass
 
         tasker, workflow = self.prepare()
-        plugin = ReactorConfigPlugin(tasker, workflow, config_path=filename)
+        plugin = ReactorConfigPlugin(tasker, workflow, config_path=str(tmpdir))
         with caplog.atLevel(logging.ERROR):
             with pytest.raises(Exception):
                 plugin.run()
@@ -84,12 +102,12 @@ class TestReactorConfigPlugin(object):
             .should_receive('get_provider')
             .and_return(FakeProvider()))
 
-        filename = os.path.join(str(tmpdir), 'reactor_config.yaml')
+        filename = os.path.join(str(tmpdir), 'config.yaml')
         with open(filename, 'w'):
             pass
 
         tasker, workflow = self.prepare()
-        plugin = ReactorConfigPlugin(tasker, workflow, config_path=filename)
+        plugin = ReactorConfigPlugin(tasker, workflow, config_path=str(tmpdir))
         with caplog.atLevel(logging.ERROR):
             with pytest.raises(Exception):
                 plugin.run()
@@ -184,11 +202,11 @@ class TestReactorConfigPlugin(object):
         ])
     ])
     def test_bad_cluster_config(self, tmpdir, caplog, config, errors):
-        filename = os.path.join(str(tmpdir), 'reactor_config.yaml')
+        filename = os.path.join(str(tmpdir), 'config.yaml')
         with open(filename, 'w') as fp:
             fp.write(dedent(config))
         tasker, workflow = self.prepare()
-        plugin = ReactorConfigPlugin(tasker, workflow, config_path=filename)
+        plugin = ReactorConfigPlugin(tasker, workflow, config_path=str(tmpdir))
 
         with caplog.atLevel(logging.ERROR):
             with pytest.raises(ValidationError):
@@ -204,11 +222,11 @@ class TestReactorConfigPlugin(object):
                 assert error in captured_errs
 
     def test_bad_version(self, tmpdir):
-        filename = os.path.join(str(tmpdir), 'reactor_config.yaml')
+        filename = os.path.join(str(tmpdir), 'config.yaml')
         with open(filename, 'w') as fp:
             fp.write("version: 2")
         tasker, workflow = self.prepare()
-        plugin = ReactorConfigPlugin(tasker, workflow, config_path=filename)
+        plugin = ReactorConfigPlugin(tasker, workflow, config_path=str(tmpdir))
 
         with pytest.raises(ValueError):
             plugin.run()
@@ -247,11 +265,11 @@ class TestReactorConfigPlugin(object):
         ]),
     ])
     def test_good_cluster_config(self, tmpdir, config, clusters):
-        filename = os.path.join(str(tmpdir), 'reactor_config.yaml')
+        filename = os.path.join(str(tmpdir), 'config.yaml')
         with open(filename, 'w') as fp:
             fp.write(dedent(config))
         tasker, workflow = self.prepare()
-        plugin = ReactorConfigPlugin(tasker, workflow, config_path=filename)
+        plugin = ReactorConfigPlugin(tasker, workflow, config_path=str(tmpdir))
         assert plugin.run() == None
 
         conf = get_config(workflow)


### PR DESCRIPTION
It is easy for osbs-client to pass the path at which the Kubernetes secret is mounted but harder for it to pass the filename within the secret representing the config.

Add a 'basename' parameter to reactor_config which defaults to 'config.yaml' to handle this.

Signed-off-by: Tim Waugh <twaugh@redhat.com>