### PR TITLE
Some improvements related to the buildstep phase

### DIFF
--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -364,15 +364,14 @@ class DockerBuildWorkflow(object):
 
                 if self.build_result.is_failed():
                     raise PluginFailedException(self.build_result.fail_reason)
-                
-                self.builder.is_built = True
-                self.builder.image_id = self.build_result.image_id
-                self.built_image_inspect = self.builder.inspect_built_image()
-
             except PluginFailedException as ex:
                 self.builder.is_built = False
                 logger.error('buildstep plugin failed: %s', ex)
                 raise
+
+            self.builder.is_built = True
+            self.builder.image_id = self.build_result.image_id
+            self.built_image_inspect = self.builder.inspect_built_image()
 
             # run prepublish plugins
             prepublish_runner = PrePublishPluginsRunner(self.builder.tasker, self, self.prepublish_plugins_conf,
@@ -392,6 +391,9 @@ class DockerBuildWorkflow(object):
                 raise
 
             return self.build_result
+        except Exception as ex:
+            logger.debug("caught exception (%r) so running exit plugins", ex)
+            raise
         finally:
             # We need to make sure all exit plugins are executed
             signal.signal(signal.SIGTERM, lambda *args: None)

--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -363,9 +363,7 @@ class DockerBuildWorkflow(object):
                 self.build_result = buildstep_runner.run()
 
                 if self.build_result.is_failed():
-                    logger.error('buildstep plugin failed: %s',
-                                 self.build_result.fail_reason)
-                    raise PluginFailedException('buildstep plugin failed')
+                    raise PluginFailedException(self.build_result.fail_reason)
                 
                 self.builder.is_built = True
                 self.builder.image_id = self.build_result.image_id

--- a/atomic_reactor/plugin.py
+++ b/atomic_reactor/plugin.py
@@ -408,8 +408,8 @@ class BuildStepPluginsRunner(BuildPluginsRunner):
         logger.info("initializing runner of build-step plugin")
         self.plugins_results = workflow.buildstep_result
 
-        if not plugin_conf:
-            # if none buildstep plugins specified, fallback to docker api plugin
+        if plugin_conf is None:
+            # if there is no buildstep_plugins key, fallback to docker api plugin
             plugin_conf = [{'name': 'docker_api', 'is_allowed_to_fail': False}]
         else:
             # any non existing buildstep plugin must be skipped without error

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -261,7 +261,8 @@ def test_fallback_to_docker_build(docker_tasker):
     setattr(workflow, 'builder', X())
 
     runner = BuildStepPluginsRunner(docker_tasker, workflow, [])
-    assert runner.plugins_conf == [{'name': 'docker_api', 'is_allowed_to_fail': False}]
+    assert runner.plugins_conf == []
+
     runner = BuildStepPluginsRunner(docker_tasker, workflow, None)
     assert runner.plugins_conf == [{'name': 'docker_api', 'is_allowed_to_fail': False}]
 


### PR DESCRIPTION
- Only log buildstep failures once
- Improve error logging if inspecting the built image fails
- The docker_api fallback only applies when the buildstep_plugins key is not present at all
