### PR TITLE
Remove base image inspect in bump_release

### DIFF
--- a/atomic_reactor/plugins/pre_bump_release.py
+++ b/atomic_reactor/plugins/pre_bump_release.py
@@ -43,7 +43,7 @@ class BumpReleasePlugin(PreBuildPlugin):
         run the plugin
         """
 
-        parser = df_parser(self.workflow.builder.df_path, workflow=self.workflow)
+        parser = df_parser(self.workflow.builder.df_path)
         release_labels = get_all_label_keys('release')
         dockerfile_labels = parser.labels
         if any(release_label in dockerfile_labels


### PR DESCRIPTION
This change removes the `bump_release` dependency of having the base image pulled locally. This is not needed as this plugin merely checks whether or not, one of, the `release` labels is set.

Also, this removes the need of orchestrator builds having to pull the base image locally.