### PR TITLE
pulp_sync: print 'image available at' in pulp_sync plugin

### DIFF
--- a/atomic_reactor/plugins/post_push_to_pulp.py
+++ b/atomic_reactor/plugins/post_push_to_pulp.py
@@ -345,7 +345,8 @@ class PulpPushPlugin(PostBuildPlugin):
                 image_file.flush()
                 crane_repos = self.push_tar(image_file.name, image_names)
 
-        for image_name in crane_repos:
-            self.log.info("image available at %s", str(image_name))
+        if self.publish:
+            for image_name in crane_repos:
+                self.log.info("image available at %s", str(image_name))
 
         return crane_repos

--- a/tests/plugins/test_pulp.py
+++ b/tests/plugins/test_pulp.py
@@ -17,7 +17,6 @@ from atomic_reactor.util import ImageName
 try:
     import dockpulp
     from atomic_reactor.plugins.post_push_to_pulp import PulpPushPlugin
-    from atomic_reactor.plugins.post_pulp_sync import PulpSyncPlugin
 except (ImportError, SyntaxError):
     dockpulp = None
 


### PR DESCRIPTION
This is essential for v2-only setups. 

The commit also uses correct repository_id (namespace/repo vs. repo) in order to sync from correct location.

TODO:
 * [x] Add a test case
 * [x] Show this message only if it was not shown during `pulp_push`
 * [x] ~~Add a testcase for missing namespace~~ the test already exists