### PR TITLE
Additional tags: check invalid tag names

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -58,3 +58,5 @@ TOOLS_USED = (
 )
 
 DEFAULT_DOWNLOAD_BLOCK_SIZE = 10 * 1024 * 1024 # 10Mb
+
+TAG_NAME_REGEX = r'^[\w][\w.-]{0,127}$'

--- a/atomic_reactor/plugins/post_tag_from_config.py
+++ b/atomic_reactor/plugins/post_tag_from_config.py
@@ -7,9 +7,10 @@ of the BSD license. See the LICENSE file for details.
 """
 
 import os
+import re
 
 from atomic_reactor.plugin import PostBuildPlugin
-from atomic_reactor.constants import INSPECT_CONFIG
+from atomic_reactor.constants import INSPECT_CONFIG, TAG_NAME_REGEX
 from atomic_reactor.util import get_preferred_label_key
 
 
@@ -56,11 +57,13 @@ class TagFromConfigPlugin(PostBuildPlugin):
         with open(tags_filename) as tags_file:
             for tag in tags_file:
                 tag = tag.strip()
-                if tag:
-                    if '-' in tag:
-                        self.log.warning("tag '%s' includes '-', ignoring", tag)
-                    else:
-                        tags.append(tag)
+                tag_name_is_valid = re.match(TAG_NAME_REGEX, tag) is not None
+
+                if tag_name_is_valid and '-' not in tag:
+                    tags.append(tag)
+                else:
+                    self.log.warning("tag '%s' does not match '%s'"
+                        "or includes dashes, ignoring", tag, TAG_NAME_REGEX)
 
         return tags
 

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -850,6 +850,3 @@ def df_parser(df_path, workflow=None, cache_content=False, env_replace=True, par
         )
 
     return dfparser
-
-
-

--- a/tests/plugins/test_tag_from_config.py
+++ b/tests/plugins/test_tag_from_config.py
@@ -70,6 +70,9 @@ def mock_workflow(tmpdir):
     (['spam', 'bacon'], 'foo', ['foo:spam', 'foo:bacon']),
     # ignore tags with hyphens
     (['foo-bar', 'baz'], 'name', ['name:baz']),
+    # make sure that tags are also valid
+    (['illegal@char', '.starts.with.dot'], 'bar', []),
+    (['has_under', 'ends.dot.'], 'bar', ['bar:has_under', 'bar:ends.dot.']),
     (None, 'fedora', []),
 ])
 def test_tag_from_config_plugin_generated(tmpdir, docker_tasker, tags, name,


### PR DESCRIPTION
As for now, additional tag names are checked not to contain '-',
if they do, they are ignored.

This causes invalid tag names to be used, and failing the build
during tag_and_push.

The change validates tag names and removes additional tags, which
are not valid or have '-'.