### PR TITLE
exit_sendmail: rework sendmail plugin to use information from koji

### DIFF
--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -281,6 +281,7 @@ class DockerBuildWorkflow(object):
         self.plugins_durations = {}
         self.plugins_errors = {}
         self.autorebuild_canceled = False
+        self.build_canceled = False
         self.plugin_failed = False
         self.plugin_files = plugin_files
 
@@ -330,6 +331,7 @@ class DockerBuildWorkflow(object):
         return self._base_image_inspect
 
     def throw_canceled_build_exception(self, *args, **kwargs):
+        self.build_canceled = True
         raise BuildCanceledException("Build was canceled")
 
     def build_docker_image(self):

--- a/tests/plugins/test_add_filesystem.py
+++ b/tests/plugins/test_add_filesystem.py
@@ -21,7 +21,7 @@ except ImportError:
     import inspect
     import sys
 
-    # Find out mocked koji module
+    # Find our mocked koji module
     import tests.koji as koji
     mock_koji_path = os.path.dirname(inspect.getfile(koji.ClientSession))
     if mock_koji_path not in sys.path:

--- a/tests/plugins/test_koji_promote.py
+++ b/tests/plugins/test_koji_promote.py
@@ -17,7 +17,7 @@ except ImportError:
     import inspect
     import sys
 
-    # Find out mocked koji module
+    # Find our mocked koji module
     import tests.koji as koji
     mock_koji_path = os.path.dirname(inspect.getfile(koji.ClientSession))
     if mock_koji_path not in sys.path:

--- a/tests/plugins/test_sendmail.py
+++ b/tests/plugins/test_sendmail.py
@@ -1,230 +1,449 @@
 import os
 import smtplib
 
-from dockerfile_parse import DockerfileParser
 from flexmock import flexmock
 import pytest
-import requests
 import six
+import json
+
+try:
+    import koji
+except ImportError:
+    import inspect
+    import sys
+
+    # Find our mocked koji module
+    import tests.koji as koji
+    mock_koji_path = os.path.dirname(inspect.getfile(koji.ClientSession))
+    if mock_koji_path not in sys.path:
+        sys.path.append(os.path.dirname(mock_koji_path))
+
+    # Now load it properly, the same way the plugin will
+    del koji
+    import koji
+
 
 from atomic_reactor.plugin import PluginFailedException
 from atomic_reactor.plugins.pre_check_and_set_rebuild import CheckAndSetRebuildPlugin
 from atomic_reactor.plugins.exit_sendmail import SendMailPlugin
-from atomic_reactor.source import GitSource
-from atomic_reactor.util import ImageName
-from atomic_reactor.build import BuildResult
+from atomic_reactor.plugins.exit_koji_promote import KojiPromotePlugin
+from atomic_reactor import util
+from smtplib import SMTPException
 
 MS, MF = SendMailPlugin.MANUAL_SUCCESS, SendMailPlugin.MANUAL_FAIL
 AS, AF = SendMailPlugin.AUTO_SUCCESS, SendMailPlugin.AUTO_FAIL
-AC = SendMailPlugin.AUTO_CANCELED
+MC, AC = SendMailPlugin.MANUAL_CANCELED, SendMailPlugin.AUTO_CANCELED
+
+MOCK_EMAIL_DOMAIN = "domain.com"
+MOCK_KOJI_TASK_ID = 12345
+MOCK_KOJI_BUILD_ID = 98765
+MOCK_KOJI_PACKAGE_ID = 123
+MOCK_KOJI_TAG_ID = 456
+MOCK_KOJI_OWNER_ID = 789
+MOCK_KOJI_OWNER_NAME = "foo"
+MOCK_KOJI_OWNER_EMAIL = "foo@bar.com"
+MOCK_KOJI_OWNER_GENERATED = "@".join([MOCK_KOJI_OWNER_NAME, MOCK_EMAIL_DOMAIN])
+MOCK_KOJI_SUBMITTER_ID = 123456
+MOCK_KOJI_SUBMITTER_NAME = "baz"
+MOCK_KOJI_SUBMITTER_EMAIL = "baz@bar.com"
+MOCK_KOJI_SUBMITTER_GENERATED = "@".join([MOCK_KOJI_SUBMITTER_NAME, MOCK_EMAIL_DOMAIN])
+MOCK_ADDITIONAL_EMAIL = "spam@bar.com"
+
+
+class MockedClientSession(object):
+    def __init__(self, hub, opts=None, has_kerberos=True):
+        self.has_kerberos = has_kerberos
+
+    def krb_login(self, principal=None, keytab=None, proxyuser=None):
+        raise RuntimeError('No certificates provided')
+
+    def ssl_login(self, cert, ca, serverca, proxyuser=None):
+        return True
+
+    def getBuild(self, build_id):
+        assert build_id == MOCK_KOJI_BUILD_ID
+        return {'package_id': MOCK_KOJI_PACKAGE_ID}
+
+    def listTags(self, build_id):
+        assert build_id == MOCK_KOJI_BUILD_ID
+        return [{"id": MOCK_KOJI_TAG_ID}]
+
+    def getPackageConfig(self, tag_id, package_id):
+        assert tag_id == MOCK_KOJI_TAG_ID
+        assert package_id == MOCK_KOJI_PACKAGE_ID
+        return {"owner_id": MOCK_KOJI_OWNER_ID}
+
+    def getUser(self, user_id):
+        if user_id == MOCK_KOJI_OWNER_ID:
+            if self.has_kerberos:
+                return {"krb_principal": MOCK_KOJI_OWNER_EMAIL}
+            else:
+                return {"krb_principal": "",
+                        "name": MOCK_KOJI_OWNER_NAME}
+
+        elif user_id == MOCK_KOJI_SUBMITTER_ID:
+            if self.has_kerberos:
+                return {"krb_principal": MOCK_KOJI_SUBMITTER_EMAIL}
+            else:
+                return {"krb_principal": "",
+                        "name": MOCK_KOJI_SUBMITTER_NAME}
+
+        else:
+            assert False, "Don't know user with id %s" % user_id
+
+    def getTaskInfo(self, task_id):
+        assert task_id == MOCK_KOJI_TASK_ID
+        return {"owner": MOCK_KOJI_SUBMITTER_ID}
+
+    def listTaskOutput(self, task_id):
+        assert task_id == MOCK_KOJI_TASK_ID
+        return ["openshift-final.log", "build.log"]
+
+
+class MockedPathInfo(object):
+    def __init__(self, topdir=None):
+        self.topdir = topdir
+
+    def work(self):
+        return "https://koji/work/"
+
+    def taskrelpath(self, task_id):
+        assert task_id == MOCK_KOJI_TASK_ID
+        return "tasks/%s" % task_id
 
 
 class TestSendMailPlugin(object):
     def test_fails_with_unknown_states(self):
-        p = SendMailPlugin(None, None, send_on=['unknown_state', MS])
+        p = SendMailPlugin(None, None,
+                           smtp_host='smtp.bar.com', from_address='foo@bar.com',
+                           send_on=['unknown_state', MS])
         with pytest.raises(PluginFailedException) as e:
             p.run()
         assert str(e.value) == 'Unknown state(s) "unknown_state" for sendmail plugin'
 
-    @pytest.mark.parametrize('rebuild, success, canceled, send_on, expected', [
+    @pytest.mark.parametrize('rebuild, success, auto_canceled, manual_canceled, send_on, expected', [
         # make sure that right combinations only succeed for the specific state
-        (False, True, False, [MS], True),
-        (False, True, False, [MF, AS, AF, AC], False),
-        (False, False, False, [MF], True),
-        (False, False, False, [MS, AS, AF, AC], False),
-        (True, True, False, [AS], True),
-        (True, True, False, [MS, MF, AF, AC], False),
-        (True, False, False, [AF], True),
-        (True, False, False, [MS, MF, AS, AC], False),
-        (True, False, True, [AC], True),
+        (False, True, False, False, [MS], True),
+        (False, True, False, True, [MS], True),
+        (False, True, False, False, [MF, AS, AF, AC], False),
+        (False, True, False, True, [MF, AS, AF, AC], False),
+        (False, False, False, False, [MF], True),
+        (False, False, False, True, [MF], True),
+        (False, False, False, False, [MS, AS, AF, AC], False),
+        (False, False, False, True, [MS, AS, AF, AC], False),
+        (False, False, True, True, [MC], True),
+        (False, True, True, True, [MC], True),
+        (False, True, False, True, [MC], True),
+        (False, True, False, False, [MC], False),
+        (True, True, False, False, [AS], True),
+        (True, True, False, False, [MS, MF, AF, AC], False),
+        (True, False, False, False, [AF], True),
+        (True, False, False, False, [MS, MF, AS, AC], False),
+        (True, False, True, True, [AC], True),
         # auto_fail would also give us True in this case
-        (True, False, True, [MS, MF, AS], False),
+        (True, False, True, True, [MS, MF, AS], False),
         # also make sure that a random combination of more plugins works ok
-        (True, False, False, [AF, MS], True)
+        (True, False, False, False, [AF, MS], True)
     ])
-    def test_should_send(self, rebuild, success, canceled, send_on, expected):
-        p = SendMailPlugin(None, None, send_on=send_on)
-        assert p._should_send(rebuild, success, canceled) == expected
+    def test_should_send(self, rebuild, success, auto_canceled, manual_canceled, send_on, expected):
+        p = SendMailPlugin(None, None,
+                           smtp_host='smtp.bar.com', from_address='foo@bar.com',
+                           send_on=send_on)
+        assert p._should_send(rebuild, success, auto_canceled, manual_canceled) == expected
 
-    @pytest.mark.parametrize('autorebuild, submitter', [
-        (True, 'John Smith <jsmith@foobar.com>'),
-        (False, 'John Smith <jsmith@foobar.com>'),
-        (True, None),
-        (False, None),
+    @pytest.mark.parametrize(('autorebuild', 'auto_cancel', 'manual_cancel',
+                              'to_koji_submitter', 'has_koji_logs'), [
+        (True, False, False, True, True),
+        (True, True, False, True, True),
+        (True, False, True, True, True),
+        (True, False, False, True, False),
+        (True, True, False, True, False),
+        (True, False, True, True, False),
+        (False, False, False, True, True),
+        (False, True, False, True, True),
+        (False, False, True, True, True),
+        (False, False, False, True, False),
+        (False, True, False, True, False),
+        (False, False, True, True, False),
+        (True, False, False, False, True),
+        (True, True, False, False, True),
+        (True, False, True, False, True),
+        (True, False, False, False, False),
+        (True, True, False, False, False),
+        (True, False, True, False, False),
+        (False, False, False, False, True),
+        (False, True, False, False, True),
+        (False, False, True, False, True),
+        (False, False, False, False, False),
+        (False, True, False, False, False),
+        (False, False, True, False, False),
     ])
-    def test_render_mail(self, autorebuild, submitter):
+    def test_render_mail(self, monkeypatch, autorebuild, auto_cancel, manual_cancel,
+                         to_koji_submitter, has_koji_logs):
         # just test a random combination of the method inputs and hope it's ok for other
         #   combinations
-        class WF(object):
-            image = ImageName.parse('foo/bar:baz')
-            openshift_build_selflink = '/builds/blablabla'
-        kwargs = {'url': 'https://something.com'}
-        if submitter:
-            kwargs['submitter'] = submitter
-        p = SendMailPlugin(None, WF(), **kwargs)
-        subject, body = p._render_mail(autorebuild, False, False)
+        class TagConf(object):
+            unique_images = []
 
-        exp_subject = 'Image foo/bar:baz; Status failed; Submitted by '
+        class WF(object):
+            image = util.ImageName.parse('foo/bar:baz')
+            openshift_build_selflink = '/builds/blablabla'
+            build_process_failed = False
+            autorebuild_canceled = auto_cancel
+            build_canceled = manual_cancel
+            tag_conf = TagConf()
+            exit_results = {
+                KojiPromotePlugin.key: MOCK_KOJI_BUILD_ID
+            }
+
+        monkeypatch.setenv("BUILD", json.dumps({
+            'metadata': {
+                'labels': {
+                    'koji-task-id': MOCK_KOJI_TASK_ID,
+                },
+            }
+        }))
+
+        session = MockedClientSession('', has_kerberos=True)
+        pathinfo = MockedPathInfo()
+        flexmock(koji, ClientSession=lambda hub, opts: session, PathInfo=pathinfo)
+        kwargs = {
+            'url': 'https://something.com',
+            'smtp_host': 'smtp.bar.com',
+            'from_address': 'foo@bar.com',
+            'to_koji_submitter': to_koji_submitter,
+            'to_koji_pkgowner': False,
+            'koji_hub': '',
+            'koji_proxyuser': None,
+            'koji_ssl_certs_dir': '/certs',
+            'koji_krb_principal': None,
+            'koji_krb_keytab': None
+        }
+
+        if not has_koji_logs:
+            (flexmock(pathinfo)
+                .should_receive('work')
+                .and_raise(RuntimeError, "xyz"))
+
+        p = SendMailPlugin(None, WF(), **kwargs)
+        subject, body = p._render_mail(autorebuild, False, auto_cancel, manual_cancel)
+        # Submitter is updated in _get_receivers_list
+        try:
+            p._get_receivers_list()
+        except Exception:
+            pass
+
+        if to_koji_submitter:
+            subject, body = p._render_mail(autorebuild, False, auto_cancel, manual_cancel)
+
+        status = 'Canceled' if auto_cancel or manual_cancel else 'Failed'
+
+        exp_subject = '%s building image foo/bar:baz' % status
         exp_body = [
             'Image: foo/bar:baz',
-            'Status: failed',
+            'Status: ' + status,
             'Submitted by: ',
-            'Logs: https://something.com/builds/blablabla/log'
+            'Logs: '
         ]
         if autorebuild:
-            exp_subject += '<autorebuild>'
             exp_body[2] += '<autorebuild>'
-        elif submitter:
-            exp_subject += submitter
-            exp_body[2] += submitter
+        elif to_koji_submitter:
+            exp_body[2] += MOCK_KOJI_SUBMITTER_EMAIL
         else:
-            exp_subject += 'unknown'
-            exp_body[2] += 'unknown'
+            exp_body[2] += SendMailPlugin.DEFAULT_SUBMITTER
+
+        if has_koji_logs:
+            exp_body[3] += "https://koji/work/tasks/12345"
+        else:
+            exp_body[3] += "https://something.com/builds/blablabla/log"
 
         assert subject == exp_subject
         assert body == '\n'.join(exp_body)
 
-    def test_get_pdc_token(self, tmpdir):
-        tokenfile = os.path.join(str(tmpdir), SendMailPlugin.PDC_TOKEN_FILE)
-        p = SendMailPlugin(None, None, pdc_secret_path=str(tmpdir))
-        with open(tokenfile, 'w') as f:
-            f.write('thisistoken')
-        assert p._get_pdc_token() == 'thisistoken'
+    @pytest.mark.parametrize(
+        'has_koji_config, has_addit_address, to_koji_submitter, to_koji_pkgowner, expected_receivers', [
+            (True, True, True, True,
+                [MOCK_ADDITIONAL_EMAIL, MOCK_KOJI_OWNER_EMAIL, MOCK_KOJI_SUBMITTER_EMAIL]),
+            (True, False, True, True, [MOCK_KOJI_OWNER_EMAIL, MOCK_KOJI_SUBMITTER_EMAIL]),
+            (True, False, True, False, [MOCK_KOJI_SUBMITTER_EMAIL]),
+            (True, False, False, True, [MOCK_KOJI_OWNER_EMAIL]),
+            (True, True, False, False, [MOCK_ADDITIONAL_EMAIL]),
+            (True, False, False, False, []),
+            (False, False, False, False, []),
+            (False, True, False, True, [MOCK_ADDITIONAL_EMAIL]),
+            (False, True, True, False, [MOCK_ADDITIONAL_EMAIL]),
+        ])
+    def test_recepients_from_koji(self, monkeypatch,
+                                  has_addit_address,
+                                  has_koji_config, to_koji_submitter, to_koji_pkgowner,
+                                  expected_receivers):
+        class TagConf(object):
+            unique_images = []
 
-    @pytest.mark.parametrize('df_labels, pdc_component_df_label, expected', [
-        ({}, 'Foo', None),
-        ({'Foo': 'Bar'}, 'Foo', 'Bar'),
-    ])
-    def test_get_component_label(self, df_labels, pdc_component_df_label, expected):
         class WF(object):
-            class builder(object):
-                df_path = '/foo/bar'
-        p = SendMailPlugin(None, WF(), pdc_component_df_label=pdc_component_df_label)
-        flexmock(DockerfileParser, labels=df_labels)
-        if expected is None:
-            with pytest.raises(PluginFailedException):
-                p._get_component_label()
-        else:
-            assert p._get_component_label() == expected
+            image = util.ImageName.parse('foo/bar:baz')
+            openshift_build_selflink = '/builds/blablabla'
+            build_process_failed = False
+            tag_conf = TagConf()
+            exit_results = {
+                KojiPromotePlugin.key: MOCK_KOJI_BUILD_ID
+            }
 
-    def test_get_receivers_list_raises_unless_GitSource(self):
-        class WF(object):
-            source = None
-        p = SendMailPlugin(None, WF())
-        flexmock(p).should_receive('_get_component_label').and_return('foo')
+        monkeypatch.setenv("BUILD", json.dumps({
+            'metadata': {
+                'labels': {
+                    'koji-task-id': MOCK_KOJI_TASK_ID,
+                },
+            }
+        }))
 
-        with pytest.raises(PluginFailedException) as e:
-            p._get_receivers_list()
-        assert str(e.value) == 'Source is not of type "GitSource", panic!'
+        session = MockedClientSession('', has_kerberos=True)
+        flexmock(koji, ClientSession=lambda hub, opts: session, PathInfo=MockedPathInfo)
 
-    @pytest.mark.parametrize('value', [
-        True,
-        False
-    ])
-    def test_get_receivers_list_passes_verify_cert(self, value):
-        class WF(object):
-            source = GitSource('git', 'foo', provider_params={'git_commit': 'foo'})
-        p = SendMailPlugin(None, WF(), pdc_verify_cert=value)
-        flexmock(p).should_receive('_get_component_label').and_return('foo')
-        flexmock(p).should_receive('_get_pdc_token').and_return('foo')
-        flexmock(requests).should_receive('get').with_args(object, headers=object, params=object,
-                                                           verify=value).and_raise(RuntimeError)
+        kwargs = {
+            'url': 'https://something.com',
+            'smtp_host': 'smtp.bar.com',
+            'from_address': 'foo@bar.com',
+            'to_koji_submitter': to_koji_submitter,
+            'to_koji_pkgowner': to_koji_pkgowner,
+            'email_domain': MOCK_EMAIL_DOMAIN
+        }
+        if has_addit_address:
+            kwargs['additional_addresses'] = [MOCK_ADDITIONAL_EMAIL]
 
-        with pytest.raises(RuntimeError):
-            p._get_receivers_list()
+        if has_koji_config:
+            kwargs['koji_hub'] = ''
+            kwargs['koji_proxyuser'] = None
+            kwargs['koji_ssl_certs_dir'] = '/certs'
+            kwargs['koji_krb_principal'] = None
+            kwargs['koji_krb_keytab'] = None
 
-    def test_get_receivers_list_passes_pdc_token(self):
-        class WF(object):
-            source = GitSource('git', 'foo', provider_params={'git_commit': 'foo'})
-        p = SendMailPlugin(None, WF())
-        flexmock(p).should_receive('_get_component_label').and_return('foo')
-        flexmock(p).should_receive('_get_pdc_token').and_return('thisistoken')
-        headers = {'Authorization': 'Token thisistoken'}
-        flexmock(requests).should_receive('get').with_args(object, headers=headers, params=object,
-                                                           verify=True).and_raise(RuntimeError)
+        p = SendMailPlugin(None, WF(), **kwargs)
 
-        with pytest.raises(RuntimeError):
-            p._get_receivers_list()
-
-    def test_get_receivers_list_request_exception(self):
-        class WF(object):
-            source = GitSource('git', 'foo', provider_params={'git_commit': 'foo'})
-        p = SendMailPlugin(None, WF())
-        flexmock(p).should_receive('_get_component_label').and_return('foo')
-        flexmock(p).should_receive('_get_pdc_token').and_return('foo')
-        flexmock(requests).should_receive('get').and_raise(requests.RequestException('foo'))
-
-        with pytest.raises(RuntimeError) as e:
-            p._get_receivers_list()
-        assert str(e.value) == 'foo'
-
-    def test_get_receivers_list_wrong_status_code(self):
-        class WF(object):
-            source = GitSource('git', 'foo', provider_params={'git_commit': 'foo'})
-        p = SendMailPlugin(None, WF())
-        flexmock(p).should_receive('_get_component_label').and_return('foo')
-        flexmock(p).should_receive('_get_pdc_token').and_return('foo')
-
-        class R(object):
-            status_code = 404
-            text = 'bazinga!'
-        flexmock(requests).should_receive('get').and_return(R())
-
-        with pytest.raises(RuntimeError) as e:
-            p._get_receivers_list()
-        assert str(e.value) == 'PDC returned non-200 status code (404), see referenced build log'
-
-    def test_get_receivers_passes_proper_params(self):
-        class WF(object):
-            source = GitSource('git', 'foo', provider_params={'git_commit': 'branch'})
-        p = SendMailPlugin(None, WF(), pdc_contact_role='role')
-        flexmock(p).should_receive('_get_component_label').and_return('component')
-        flexmock(p).should_receive('_get_pdc_token').and_return('foo')
-
-        params = {'global_component': 'component', 'dist_git_branch': 'branch', 'role': 'role'}
-        flexmock(requests).should_receive('get').with_args(object, headers=object, params=params,
-                                                           verify=object).\
-            and_raise(requests.RequestException())
-
-        with pytest.raises(RuntimeError):
-            p._get_receivers_list()
-
-    @pytest.mark.parametrize('pdc_response, pdc_contact_role, expected', [
-        ({'count': 0, 'results': []},
-         SendMailPlugin.PDC_CONTACT_ROLE,
-         'no {0} role for the component'.format(SendMailPlugin.PDC_CONTACT_ROLE)),
-        ({'count': 1, 'results': [{'contact': {'email': 'foo@bar.com'}}]},
-         SendMailPlugin.PDC_CONTACT_ROLE,
-         ['foo@bar.com']),
-        ({'count': 2,
-          'results':
-            [{'contact': {'email': 'foo@bar.com'}}, {'contact': {'email': 'spam@spam.com'}}]},
-         SendMailPlugin.PDC_CONTACT_ROLE,
-         ['foo@bar.com', 'spam@spam.com']),
-    ])
-    def test_get_receivers_pdc_actually_responds(self, pdc_response, pdc_contact_role, expected):
-        class WF(object):
-            source = GitSource('git', 'foo', provider_params={'git_commit': 'foo'})
-        p = SendMailPlugin(None, WF(), pdc_contact_role=pdc_contact_role)
-        flexmock(p).should_receive('_get_component_label').and_return('foo')
-        flexmock(p).should_receive('_get_pdc_token').and_return('foo')
-
-        class R(object):
-            status_code = 200
-
-            def json(self):
-                return pdc_response
-        flexmock(requests).should_receive('get').and_return(R())
-
-        if isinstance(expected, str):
-            with pytest.raises(RuntimeError) as e:
+        if not expected_receivers:
+            with pytest.raises(RuntimeError):
                 p._get_receivers_list()
-            assert str(e.value) == expected
         else:
-            assert p._get_receivers_list() == expected
+            receivers = p._get_receivers_list()
+            assert sorted(receivers) == sorted(expected_receivers)
 
-    def test_send_mail(self):
-        p = SendMailPlugin(None, None, from_address='foo@bar.com', smtp_uri='smtp.spam.com')
+    @pytest.mark.parametrize('has_kerberos, expected_receivers', [
+        (True, [MOCK_KOJI_OWNER_EMAIL, MOCK_KOJI_SUBMITTER_EMAIL]),
+        (False, [MOCK_KOJI_OWNER_GENERATED, MOCK_KOJI_SUBMITTER_GENERATED])])
+    def test_generated_email(self, monkeypatch, has_kerberos, expected_receivers):
+        class TagConf(object):
+            unique_images = []
+
+        class WF(object):
+            image = util.ImageName.parse('foo/bar:baz')
+            openshift_build_selflink = '/builds/blablabla'
+            build_process_failed = False
+            tag_conf = TagConf()
+            exit_results = {
+                KojiPromotePlugin.key: MOCK_KOJI_BUILD_ID
+            }
+
+        monkeypatch.setenv("BUILD", json.dumps({
+            'metadata': {
+                'labels': {
+                    'koji-task-id': MOCK_KOJI_TASK_ID,
+                },
+            }
+        }))
+
+        session = MockedClientSession('', has_kerberos=has_kerberos)
+        flexmock(koji, ClientSession=lambda hub, opts: session, PathInfo=MockedPathInfo)
+
+        kwargs = {
+            'url': 'https://something.com',
+            'smtp_host': 'smtp.bar.com',
+            'from_address': 'foo@bar.com',
+            'to_koji_submitter': True,
+            'to_koji_pkgowner': True,
+            'email_domain': MOCK_EMAIL_DOMAIN,
+            'koji_hub': '',
+            'koji_proxyuser': None,
+            'koji_ssl_certs_dir': '/certs',
+            'koji_krb_principal': None,
+            'koji_krb_keytab': None
+        }
+        p = SendMailPlugin(None, WF(), **kwargs)
+        receivers = p._get_receivers_list()
+        assert sorted(receivers) == sorted(expected_receivers)
+
+        if has_kerberos:
+            assert p.submitter == MOCK_KOJI_SUBMITTER_EMAIL
+        else:
+            assert p.submitter == MOCK_KOJI_SUBMITTER_GENERATED
+
+    @pytest.mark.parametrize('exception_location, expected_receivers', [
+        ('koji_connection', []),
+        ('submitter', [MOCK_KOJI_OWNER_EMAIL]),
+        ('owner', [MOCK_KOJI_SUBMITTER_EMAIL]),
+        ('empty_email_domain', [])])
+    def test_koji_recepients_exception(self, monkeypatch, exception_location, expected_receivers):
+        class TagConf(object):
+            unique_images = []
+
+        class WF(object):
+            image = util.ImageName.parse('foo/bar:baz')
+            openshift_build_selflink = '/builds/blablabla'
+            build_process_failed = False
+            tag_conf = TagConf()
+            exit_results = {
+                KojiPromotePlugin.key: MOCK_KOJI_BUILD_ID
+            }
+
+        monkeypatch.setenv("BUILD", json.dumps({
+            'metadata': {
+                'labels': {
+                    'koji-task-id': MOCK_KOJI_TASK_ID,
+                },
+            }
+        }))
+
+        has_kerberos = exception_location != 'empty_email_domain'
+        session = MockedClientSession('', has_kerberos=has_kerberos)
+        if exception_location == 'koji_connection':
+            (flexmock(session)
+                .should_receive('ssl_login')
+                .and_raise(RuntimeError, "xyz"))
+        elif exception_location == 'submitter':
+            (flexmock(session)
+                .should_receive('getTaskInfo')
+                .and_raise(RuntimeError, "xyz"))
+        elif exception_location == 'owner':
+            (flexmock(session)
+                .should_receive('getPackageConfig')
+                .and_raise(RuntimeError, "xyz"))
+
+        flexmock(koji, ClientSession=lambda hub, opts: session, PathInfo=MockedPathInfo)
+
+        kwargs = {
+            'url': 'https://something.com',
+            'smtp_host': 'smtp.bar.com',
+            'from_address': 'foo@bar.com',
+            'to_koji_submitter': True,
+            'to_koji_pkgowner': True,
+            'koji_hub': '',
+            'koji_proxyuser': None,
+            'koji_ssl_certs_dir': '/certs',
+            'koji_krb_principal': None,
+            'koji_krb_keytab': None
+        }
+        if exception_location != 'empty_email_domain':
+            kwargs['email_domain'] = MOCK_EMAIL_DOMAIN
+        p = SendMailPlugin(None, WF(), **kwargs)
+        if not expected_receivers:
+            with pytest.raises(RuntimeError):
+                p._get_receivers_list()
+        else:
+            receivers = p._get_receivers_list()
+            assert sorted(receivers) == sorted(expected_receivers)
+
+    @pytest.mark.parametrize('throws_exception', [False, True])
+    def test_send_mail(self, throws_exception):
+        p = SendMailPlugin(None, None, from_address='foo@bar.com', smtp_host='smtp.spam.com')
 
         class SMTP(object):
             def sendmail(self, from_addr, to, msg):
@@ -235,36 +454,62 @@ class TestSendMailPlugin(object):
 
         smtp_inst = SMTP()
         flexmock(smtplib).should_receive('SMTP').and_return(smtp_inst)
-        flexmock(smtp_inst).should_receive('sendmail').\
-            with_args('foo@bar.com', ['spam@spam.com'], str)
+        sendmail_chain = (flexmock(smtp_inst).should_receive('sendmail').
+                          with_args('foo@bar.com', ['spam@spam.com'], str))
+        if throws_exception:
+            sendmail_chain.and_raise(smtplib.SMTPException, "foo")
         flexmock(smtp_inst).should_receive('quit')
-        p._send_mail(['spam@spam.com'], 'subject', 'body')
+
+        if throws_exception:
+            with pytest.raises(SMTPException) as e:
+                p._send_mail(['spam@spam.com'], 'subject', 'body')
+            assert str(e.value) == 'foo'
+        else:
+            p._send_mail(['spam@spam.com'], 'subject', 'body')
 
     def test_run_ok(self):
-        class WF(object):
-            build_result = BuildResult(fail_reason="not built")
-            autorebuild_canceled = False
-            prebuild_results = {CheckAndSetRebuildPlugin.key: True}
-            image = ImageName.parse('repo/name')
-        receivers = ['foo@bar.com', 'x@y.com']
-        p = SendMailPlugin(None, WF(), send_on=[AF])
+        class TagConf(object):
+            unique_images = []
 
-        flexmock(p).should_receive('_should_send').with_args(True, False, False).and_return(True)
+        class WF(object):
+            autorebuild_canceled = False
+            build_canceled = False
+            prebuild_results = {CheckAndSetRebuildPlugin.key: True}
+            image = util.ImageName.parse('repo/name')
+            build_process_failed = True
+            tag_conf = TagConf()
+
+        receivers = ['foo@bar.com', 'x@y.com']
+        p = SendMailPlugin(None, WF(),
+                           from_address='foo@bar.com', smtp_host='smtp.spam.com',
+                           send_on=[AF])
+
+        (flexmock(p).should_receive('_should_send')
+            .with_args(True, False, False, False).and_return(True))
         flexmock(p).should_receive('_get_receivers_list').and_return(receivers)
         flexmock(p).should_receive('_send_mail').with_args(receivers, six.text_type, six.text_type)
 
         p.run()
 
     def test_run_fails_to_obtain_receivers(self):
-        class WF(object):
-            build_result = BuildResult(fail_reason="not built")
-            autorebuild_canceled = False
-            prebuild_results = {CheckAndSetRebuildPlugin.key: True}
-            image = ImageName.parse('repo/name')
-        error_addresses = ['error@address.com']
-        p = SendMailPlugin(None, WF(), send_on=[AF], error_addresses=error_addresses)
+        class TagConf(object):
+            unique_images = []
 
-        flexmock(p).should_receive('_should_send').with_args(True, False, False).and_return(True)
+        class WF(object):
+            autorebuild_canceled = False
+            build_canceled = False
+            prebuild_results = {CheckAndSetRebuildPlugin.key: True}
+            image = util.ImageName.parse('repo/name')
+            build_process_failed = True
+            tag_conf = TagConf()
+
+        error_addresses = ['error@address.com']
+        p = SendMailPlugin(None, WF(),
+                           from_address='foo@bar.com', smtp_host='smtp.spam.com',
+                           send_on=[AF], error_addresses=error_addresses)
+
+        (flexmock(p).should_receive('_should_send')
+            .with_args(True, False, False, False).and_return(True))
         flexmock(p).should_receive('_get_receivers_list').and_raise(RuntimeError())
         flexmock(p).should_receive('_send_mail').with_args(error_addresses, six.text_type,
                                                            six.text_type)
@@ -273,13 +518,18 @@ class TestSendMailPlugin(object):
 
     def test_run_does_nothing_if_conditions_not_met(self):
         class WF(object):
-            build_result = BuildResult(fail_reason="not built")
             autorebuild_canceled = False
+            build_canceled = False
             prebuild_results = {CheckAndSetRebuildPlugin.key: True}
-            image = ImageName.parse('repo/name')
-        p = SendMailPlugin(None, WF(), send_on=[MS])
+            image = util.ImageName.parse('repo/name')
+            build_process_failed = True
 
-        flexmock(p).should_receive('_should_send').with_args(True, False, False).and_return(False)
+        p = SendMailPlugin(None, WF(),
+                           from_address='foo@bar.com', smtp_host='smtp.spam.com',
+                           send_on=[MS])
+
+        (flexmock(p).should_receive('_should_send')
+            .with_args(True, False, False, False).and_return(False))
         flexmock(p).should_receive('_get_receivers_list').times(0)
         flexmock(p).should_receive('_send_mail').times(0)
 

--- a/tests/test_inner.py
+++ b/tests/test_inner.py
@@ -781,6 +781,7 @@ def test_autorebuild_stop_prevents_build():
     assert not watch_post.was_called()
     assert watch_exit.was_called()
     assert workflow.autorebuild_canceled == True
+    assert not workflow.build_canceled
 
 
 @pytest.mark.parametrize('fail_at', ['pre_raises',
@@ -1161,14 +1162,18 @@ def test_cancel_build(request, fail_at):
     if fail_at == 'buildstep':
         with pytest.raises(PluginFailedException):
             workflow.build_docker_image()
+        assert workflow.build_canceled
         assert ("plugin '%s_watched' raised an exception:" % fail_at +
                 " BuildCanceledException('Build was canceled',)",) in fake_logger.errors
     else:
         workflow.build_docker_image()
 
         if fail_at != 'exit':
+            assert workflow.build_canceled
             assert ("plugin '%s_watched' raised an exception:" % fail_at +
                     " BuildCanceledException('Build was canceled',)",) in fake_logger.warnings
+        else:
+            assert not workflow.build_canceled
 
     assert watch_exit.was_called()
     assert watch_pre.was_called()


### PR DESCRIPTION
PDC part is removed, instead we'll use the following recepients:
 * If `always_notify` param is set it will be used an email address
 * If `to_koji_submitter` is set, the plugin will query Koji for kerberos 
 principal of the user, who initiated the task. The kerberos principal would be 
 used as an email address
 * If `to_koji_pkgowner` is set, the plugin will query Koji for build info 
 and include owners of the package-tags combinations in the notification
 
If no recepients are found, the plugin will send an error notification to people,
specified in `error_addresses`

TODO:
 * [x] Sort out `submitter` param - its best be renamed to `always_notify` or similar
 * [x] Add tests to cover exceptions when fetching koji submitter / package owner
 * [x] Introduce `email_domain` and construct email addresses if Koji instance doesn't use kerberos
Signed-off-by: Vadim Rutkovsky <vrutkovs@redhat.com>