### PR TITLE
Report buildstep failure reason

### DIFF
--- a/atomic_reactor/plugin.py
+++ b/atomic_reactor/plugin.py
@@ -241,9 +241,11 @@ class PluginsRunner(object):
                 if buildstep_phase:
                     assert isinstance(plugin_response, BuildResult)
                     if plugin_response.is_failed():
-                        msg = "Build step plugin %s failed" % plugin_class.key
-                        logger.error(msg)
-                        self.on_plugin_failed(plugin_class.key, "Buildstep plugin failed")
+                        logger.error("Build step plugin %s failed: %s",
+                                     plugin_class.key,
+                                     plugin_response.fail_reason)
+                        self.on_plugin_failed(plugin_class.key,
+                                              plugin_response.fail_reason)
                         plugin_successful = False
                         self.plugins_results[plugin_class.key] = plugin_response
                         break

--- a/tests/plugins/test_docker_api.py
+++ b/tests/plugins/test_docker_api.py
@@ -80,15 +80,18 @@ def test_build(is_failed):
 
     workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image')
     flexmock(CommandResult).should_receive('is_failed').and_return(is_failed)
+    error_detail = 'error detail'
     if is_failed:
-        flexmock(CommandResult, error_detail="built error")
-
-    if is_failed:
+        flexmock(CommandResult, error_detail=error_detail)
         with pytest.raises(PluginFailedException):
             workflow.build_docker_image()
     else:
         workflow.build_docker_image()
    
     assert isinstance(workflow.buildstep_result['docker_api'], BuildResult)
-    assert workflow.build_result
+    assert workflow.build_result == workflow.buildstep_result['docker_api']
     assert workflow.build_result.is_failed() == is_failed
+
+    if is_failed:
+        assert workflow.build_result.fail_reason == error_detail
+        assert error_detail in workflow.plugins_errors['docker_api']


### PR DESCRIPTION
When the buildstep plugin fails its BuildResult holds a fail_reason. Use this when marking the plugin as failed, as it will be used to describe why the build failed.

Signed-off-by: Tim Waugh <twaugh@redhat.com>