### PR TITLE
Make bump_release and koji plugins use koji auth and ssl_dir

### DIFF
--- a/atomic_reactor/plugins/pre_bump_release.py
+++ b/atomic_reactor/plugins/pre_bump_release.py
@@ -25,7 +25,7 @@ class BumpReleasePlugin(PreBuildPlugin):
     # The target parameter is no longer used by this plugin. It's
     # left as an optional parameter to allow a graceful transition
     # in osbs-client.
-    def __init__(self, tasker, workflow, hub, target=None):
+    def __init__(self, tasker, workflow, hub, target=None, koji_ssl_certs_dir=None):
         """
         constructor
 
@@ -33,10 +33,18 @@ class BumpReleasePlugin(PreBuildPlugin):
         :param workflow: DockerBuildWorkflow instance
         :param hub: string, koji hub (xmlrpc)
         :param target: unused - backwards compatibility
+        :param koji_ssl_certs_dir: str, path to "cert", "ca", and "serverca"
+            Note that this plugin requires koji_ssl_certs_dir set if Koji
+            certificate is not trusted by CA bundle.
         """
         # call parent constructor
         super(BumpReleasePlugin, self).__init__(tasker, workflow)
-        self.xmlrpc = create_koji_session(hub)
+        koji_auth_info = None
+        if koji_ssl_certs_dir:
+            koji_auth_info = {
+                'ssl_certs_dir': koji_ssl_certs_dir,
+            }
+        self.xmlrpc = create_koji_session(hub, koji_auth_info)
 
     def run(self):
         """


### PR DESCRIPTION
Buildroot is assumed to have Koji certificate trusted already, which might not
be true for any given koji server.

Signed-off-by: Vadim Rutkovsky <vrutkovs@redhat.com>