### PR TITLE
Initialise TaskWatcher state to avoid traceback

### DIFF
--- a/atomic_reactor/koji_util.py
+++ b/atomic_reactor/koji_util.py
@@ -85,6 +85,7 @@ class TaskWatcher(object):
         self.session = session
         self.task_id = task_id
         self.poll_interval = poll_interval
+        self.state = 'CANCELED'
 
     def wait(self):
         logger.debug("waiting for koji task %r to finish", self.task_id)


### PR DESCRIPTION
Previous behaviour of add_filesystem after cancelling task:
AttributeError: 'TaskWatcher' object has no attribute 'state'

Signed-off-by: Tim Waugh <twaugh@redhat.com>