### PR TITLE
Improve docker_api fail_reason reporting

### DIFF
--- a/atomic_reactor/plugins/build_docker_api.py
+++ b/atomic_reactor/plugins/build_docker_api.py
@@ -45,7 +45,7 @@ class DockerApiPlugin(BuildStepPlugin):
 
         if command_result.is_failed():
             return BuildResult(logs=command_result.logs,
-                               fail_reason=command_result.error_detail)
+                               fail_reason=command_result.error)
         else:
             image_id = builder.get_built_image_info()['Id']
             return BuildResult(logs=command_result.logs, image_id=image_id)

--- a/tests/plugins/test_docker_api.py
+++ b/tests/plugins/test_docker_api.py
@@ -80,9 +80,10 @@ def test_build(is_failed):
 
     workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image')
     flexmock(CommandResult).should_receive('is_failed').and_return(is_failed)
-    error_detail = 'error detail'
+    error = "error message"
+    error_detail = "{u'message': u\"%s\"}" % error
     if is_failed:
-        flexmock(CommandResult, error_detail=error_detail)
+        flexmock(CommandResult, error=error, error_detail=error_detail)
         with pytest.raises(PluginFailedException):
             workflow.build_docker_image()
     else:
@@ -93,5 +94,6 @@ def test_build(is_failed):
     assert workflow.build_result.is_failed() == is_failed
 
     if is_failed:
-        assert workflow.build_result.fail_reason == error_detail
-        assert error_detail in workflow.plugins_errors['docker_api']
+        assert workflow.build_result.fail_reason == error
+        assert '\\' not in workflow.plugins_errors['docker_api']
+        assert error in workflow.plugins_errors['docker_api']


### PR DESCRIPTION
Before, Koji builds have results like:
```
Image build failed. Error in plugin docker_api: {u'message': u"The command '/bin/sh -c rm /etc/foo.cnf' returned a non-zero code: 1"}. OSBS build id: foobar-bazabcde-1
```

After, the results should look like:
```
Image build failed. Error in plugin docker_api: The command '/bin/sh -c rm /etc/foo.cnf' returned a non-zero code: 1. OSBS build id: foobar-bazabcde-1
```

Signed-off-by: Tim Waugh <twaugh@redhat.com>