### PR TITLE
sendmail: return earlier if koji build id or task id are not determined

### DIFF
--- a/atomic_reactor/plugins/exit_sendmail.py
+++ b/atomic_reactor/plugins/exit_sendmail.py
@@ -210,6 +210,9 @@ class SendMailPlugin(ExitPlugin):
             return '@'.join([obj['name'], self.email_domain])
 
     def _get_koji_submitter(self):
+        if not self.koji_task_id:
+            return ""
+
         koji_task_info = self.session.getTaskInfo(self.koji_task_id)
         koji_task_owner = self.session.getUser(koji_task_info['owner'])
         koji_task_owner_email = self._get_email_from_koji_obj(koji_task_owner)
@@ -218,6 +221,9 @@ class SendMailPlugin(ExitPlugin):
 
     def _get_koji_owners(self):
         result = []
+        if not self.koji_build_id:
+            return result
+
         koji_build_info = self.session.getBuild(self.koji_build_id)
 
         koji_tags = self.session.listTags(self.koji_build_id)
@@ -268,6 +274,9 @@ class SendMailPlugin(ExitPlugin):
 
         # Remove duplicates
         receivers_list = list(set(receivers_list))
+
+        # Remove empty and None items
+        receivers_list = [x for x in receivers_list if x]
 
         if not receivers_list:
             raise RuntimeError("No recepients found")

--- a/tests/plugins/test_sendmail.py
+++ b/tests/plugins/test_sendmail.py
@@ -379,11 +379,23 @@ class TestSendMailPlugin(object):
     @pytest.mark.parametrize('exception_location, expected_receivers', [
         ('koji_connection', []),
         ('submitter', [MOCK_KOJI_OWNER_EMAIL]),
+        ('empty_submitter', [MOCK_KOJI_OWNER_EMAIL]),
         ('owner', [MOCK_KOJI_SUBMITTER_EMAIL]),
+        ('empty_owner', [MOCK_KOJI_SUBMITTER_EMAIL]),
         ('empty_email_domain', [])])
     def test_koji_recepients_exception(self, monkeypatch, exception_location, expected_receivers):
         class TagConf(object):
             unique_images = []
+
+        if exception_location == 'empty_owner':
+            koji_build_id = None
+        else:
+            koji_build_id = MOCK_KOJI_BUILD_ID
+
+        if exception_location == 'empty_submitter':
+            koji_task_id = None
+        else:
+            koji_task_id = MOCK_KOJI_TASK_ID
 
         class WF(object):
             image = util.ImageName.parse('foo/bar:baz')
@@ -391,13 +403,13 @@ class TestSendMailPlugin(object):
             build_process_failed = False
             tag_conf = TagConf()
             exit_results = {
-                KojiPromotePlugin.key: MOCK_KOJI_BUILD_ID
+                KojiPromotePlugin.key: koji_build_id
             }
 
         monkeypatch.setenv("BUILD", json.dumps({
             'metadata': {
                 'labels': {
-                    'koji-task-id': MOCK_KOJI_TASK_ID,
+                    'koji-task-id': koji_task_id,
                 },
             }
         }))


### PR DESCRIPTION
This helps to avoid long tracebacks on downstream Brew instances

Signed-off-by: Vadim Rutkovsky <vrutkovs@redhat.com>