### PR TITLE
Remove code paths for py 2.6

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ We try to write good code. This is what it means to us:
 
 * Maximum line length is 100 characters
 * Pull Request *must* pass following checks:
-  * [Travis CI test](https://travis-ci.org/projectatomic/atomic-reactor) - This means that no tests fail on Python 2.6, 2.7 and >= 3.4
+  * [Travis CI test](https://travis-ci.org/projectatomic/atomic-reactor) - This means that no tests fail on Python 2.7 and >= 3.4
     * You can run tests locally using `pytest`
   * [Landscape test](https://landscape.io/github/projectatomic/atomic-reactor) - This means that code follows pep8 and is otherwise sane. To check this, run these commands:
     * `pyflakes atomic_reactor`

--- a/atomic_reactor/cli/main.py
+++ b/atomic_reactor/cli/main.py
@@ -265,12 +265,7 @@ class CLI(object):
     def run(self):
         self.set_arguments()
         args = self.parser.parse_args()
-        try:
-            # Capture any warning.warn() calls and log them
-            logging.captureWarnings(True)
-        except AttributeError:
-            # Python 2.6 doesn't have captureWarnings()
-            pass
+        logging.captureWarnings(True)
 
         if args.verbose:
             set_logging(level=logging.DEBUG)

--- a/atomic_reactor/plugins/pre_inject_yum_repo.py
+++ b/atomic_reactor/plugins/pre_inject_yum_repo.py
@@ -129,9 +129,7 @@ class InjectYumRepoPlugin(PreBuildPlugin):
         """
         run the plugin
         """
-        # dict comprehension is syntax error on 2.6
-        yum_repos = dict((k, v) for (k, v) in self.workflow.files.items()
-                                           if k.startswith(YUM_REPOS_DIR))
+        yum_repos = {k: v for k, v in self.workflow.files.items() if k.startswith(YUM_REPOS_DIR)}
         if self.wrap_commands:
             wrap_yum_commands(yum_repos, self.workflow.builder.df_path)
         else:

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -24,10 +24,7 @@ from atomic_reactor.constants import DOCKERFILE_FILENAME, TOOLS_USED, INSPECT_CO
 
 from dockerfile_parse import DockerfileParser
 
-try:
-    from importlib import import_module
-except ImportError:
-    import_module = __import__  # I love python 2.6
+from importlib import import_module
 
 
 logger = logging.getLogger(__name__)
@@ -219,27 +216,6 @@ def wait_for_command(logs_generator):
     return cr
 
 
-def backported_check_output(*popenargs, **kwargs):
-    """
-    Run command with arguments and return its output as a byte string.
-
-    Backported from Python 2.7 as it's implemented as pure python on stdlib.
-
-    https://gist.github.com/edufelipe/1027906
-    """
-    process = subprocess.Popen(stdout=subprocess.PIPE, *popenargs, **kwargs)
-    output, _ = process.communicate()
-    retcode = process.poll()
-    if retcode:
-        cmd = kwargs.get("args")
-        if cmd is None:
-            cmd = popenargs[0]
-        error = subprocess.CalledProcessError(retcode, cmd)
-        error.output = output
-        raise error
-    return output
-
-
 def clone_git_repo(git_url, target_dir, commit=None):
     """
     clone provided git repo to target_dir, optionally checkout provided commit
@@ -277,10 +253,7 @@ def clone_git_repo(git_url, target_dir, commit=None):
             subprocess.check_call(cmd, cwd=target_dir)
     cmd = ["git", "rev-parse", "HEAD"]
     logger.debug("getting SHA-1 of provided ref '%s'", cmd)
-    try:
-        commit_id = subprocess.check_output(cmd, cwd=target_dir)  # py 2.7
-    except AttributeError:
-        commit_id = backported_check_output(cmd, cwd=target_dir)  # py 2.6
+    commit_id = subprocess.check_output(cmd, cwd=target_dir)
     commit_id = commit_id.strip()
     logger.info("commit ID = %s", commit_id)
     return commit_id

--- a/tests/plugins/test_add_filesystem.py
+++ b/tests/plugins/test_add_filesystem.py
@@ -314,9 +314,8 @@ def test_image_task_failure(tmpdir, build_cancel, error_during_cancel, raise_err
         }]
     )
 
-    with caplog.atLevel(logging.INFO):
-        with pytest.raises(PluginFailedException) as exc:
-            results = runner.run()
+    with caplog.atLevel(logging.INFO), pytest.raises(PluginFailedException) as exc:
+        results = runner.run()
 
     assert task_result in str(exc)
     # Also ensure getTaskResult exception message is wrapped properly

--- a/tests/plugins/test_add_labels.py
+++ b/tests/plugins/test_add_labels.py
@@ -8,11 +8,7 @@ of the BSD license. See the LICENSE file for details.
 
 from __future__ import print_function, unicode_literals
 
-try:
-    from collections import OrderedDict
-except ImportError:
-    # Python 2.6
-    from ordereddict import OrderedDict
+from collections import OrderedDict
 from atomic_reactor.inner import DockerBuildWorkflow
 from atomic_reactor.plugin import PreBuildPluginsRunner, PluginFailedException
 from atomic_reactor.plugins.pre_add_labels_in_df import AddLabelsPlugin

--- a/tests/plugins/test_reactor_config.py
+++ b/tests/plugins/test_reactor_config.py
@@ -77,9 +77,8 @@ class TestReactorConfigPlugin(object):
 
         tasker, workflow = self.prepare()
         plugin = ReactorConfigPlugin(tasker, workflow, config_path=str(tmpdir))
-        with caplog.atLevel(logging.ERROR):
-            with pytest.raises(Exception):
-                plugin.run()
+        with caplog.atLevel(logging.ERROR), pytest.raises(Exception):
+            plugin.run()
 
         captured_errs = [x.message for x in caplog.records()]
         assert "unable to extract JSON schema, cannot validate" in captured_errs
@@ -108,9 +107,8 @@ class TestReactorConfigPlugin(object):
 
         tasker, workflow = self.prepare()
         plugin = ReactorConfigPlugin(tasker, workflow, config_path=str(tmpdir))
-        with caplog.atLevel(logging.ERROR):
-            with pytest.raises(Exception):
-                plugin.run()
+        with caplog.atLevel(logging.ERROR), pytest.raises(Exception):
+            plugin.run()
 
         captured_errs = [x.message for x in caplog.records()]
         assert any("cannot validate" in x for x in captured_errs)
@@ -208,9 +206,8 @@ class TestReactorConfigPlugin(object):
         tasker, workflow = self.prepare()
         plugin = ReactorConfigPlugin(tasker, workflow, config_path=str(tmpdir))
 
-        with caplog.atLevel(logging.ERROR):
-            with pytest.raises(ValidationError):
-                plugin.run()
+        with caplog.atLevel(logging.ERROR), pytest.raises(ValidationError):
+            plugin.run()
 
         captured_errs = [x.message for x in caplog.records()]
         for error in errors:

--- a/tests/plugins/test_stop_autorebuild_if_disabled.py
+++ b/tests/plugins/test_stop_autorebuild_if_disabled.py
@@ -88,9 +88,8 @@ class TestStopAutorebuildIfDisabledPlugin(object):
         flexmock(configparser.SafeConfigParser).should_receive('read').and_return(None)
         # flexmock(configparser.SafeConfigParser).should_receive('getboolean').\
         #     with_args('autorebuild', 'enabled').and_return(False)
-        with mocked_configparser_getboolean(False):
-            with pytest.raises(AutoRebuildCanceledException):
-                self.runner.run()
+        with mocked_configparser_getboolean(False), pytest.raises(AutoRebuildCanceledException):
+            self.runner.run()
 
         self.assert_message_logged('autorebuild is disabled in .osbs-repo-config', caplog)
 

--- a/tests/plugins/test_yum_inject.py
+++ b/tests/plugins/test_yum_inject.py
@@ -13,11 +13,7 @@ import os
 from atomic_reactor.constants import (YUM_REPOS_DIR, DEFAULT_YUM_REPOFILE_NAME, RELATIVE_REPOS_PATH,
                                       INSPECT_CONFIG)
 
-try:
-    from collections import OrderedDict
-except ImportError:
-    # Python 2.6
-    from ordereddict import OrderedDict
+from collections import OrderedDict
 from atomic_reactor.core import DockerTasker
 from atomic_reactor.inner import DockerBuildWorkflow
 from atomic_reactor.plugin import PreBuildPluginsRunner

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -19,11 +19,7 @@ from tempfile import mkdtemp
 from textwrap import dedent
 from flexmock import flexmock
 
-try:
-    from collections import OrderedDict
-except ImportError:
-    # Python 2.6
-    from ordereddict import OrderedDict
+from collections import OrderedDict
 import docker
 from atomic_reactor.inner import DockerBuildWorkflow
 from atomic_reactor.util import (ImageName, wait_for_command, clone_git_repo,


### PR DESCRIPTION
I've also checked that no tested code paths are deprecated using 
PYTHONWARNINGS=default env var

Signed-off-by: Vadim Rutkovsky <vrutkovs@redhat.com>