### PR TITLE
add_labels_in_df: several fixes

### DIFF
--- a/atomic_reactor/plugins/pre_add_labels_in_df.py
+++ b/atomic_reactor/plugins/pre_add_labels_in_df.py
@@ -236,9 +236,9 @@ class AddLabelsPlugin(PreBuildPlugin):
 
         # changing dockerfile.labels writes out modified Dockerfile - err on
         # the safe side and make a copy
-        self.add_aliases(base_image_labels.copy(), dockerfile.labels.copy())
+        self.add_aliases(base_image_labels, dockerfile.labels)
         if self.info_url_format:
-            self.add_info_url(base_image_labels.copy(), dockerfile.labels.copy())
+            self.add_info_url(base_image_labels, dockerfile.labels)
 
         # correct syntax is:
         #   LABEL "key"="value" "key2"="value2"

--- a/atomic_reactor/plugins/pre_add_labels_in_df.py
+++ b/atomic_reactor/plugins/pre_add_labels_in_df.py
@@ -154,13 +154,13 @@ class AddLabelsPlugin(PreBuildPlugin):
             else:
                 self.log.warning("requested automatic label %r is not available", lbl)
 
-    def add_aliases(self, base_labels, df_labels, plugin_labels):
+    def add_aliases(self, base_labels, df_labels):
         all_labels = base_labels.copy()
         all_labels.update(df_labels)
-        all_labels.update(plugin_labels)
+        all_labels.update(self.labels)
 
         new_labels = df_labels.copy()
-        new_labels.update(plugin_labels)
+        new_labels.update(self.labels)
 
         applied_alias = False
         not_applied = []
@@ -178,8 +178,7 @@ class AddLabelsPlugin(PreBuildPlugin):
                 continue
 
             is_old_inherited = old in base_labels and \
-                old not in df_labels and \
-                old not in plugin_labels
+                old not in new_labels
 
             if new in new_labels:
                 if all_labels[old] != all_labels[new]:
@@ -201,10 +200,10 @@ class AddLabelsPlugin(PreBuildPlugin):
             self.log.debug("applied only some aliases, following old labels were not found: %s",
                            ", ".join(not_applied))
 
-    def add_info_url(self, base_labels, df_labels, plugin_labels):
+    def add_info_url(self, base_labels, df_labels):
         all_labels = base_labels.copy()
         all_labels.update(df_labels)
-        all_labels.update(plugin_labels)
+        all_labels.update(self.labels)
 
         class MyFormatter(string.Formatter):
             """
@@ -237,9 +236,9 @@ class AddLabelsPlugin(PreBuildPlugin):
 
         # changing dockerfile.labels writes out modified Dockerfile - err on
         # the safe side and make a copy
-        self.add_aliases(base_image_labels.copy(), dockerfile.labels.copy(), self.labels.copy())
+        self.add_aliases(base_image_labels.copy(), dockerfile.labels.copy())
         if self.info_url_format:
-            self.add_info_url(base_image_labels.copy(), dockerfile.labels.copy(), self.labels.copy())
+            self.add_info_url(base_image_labels.copy(), dockerfile.labels.copy())
 
         # correct syntax is:
         #   LABEL "key"="value" "key2"="value2"

--- a/atomic_reactor/plugins/pre_add_labels_in_df.py
+++ b/atomic_reactor/plugins/pre_add_labels_in_df.py
@@ -155,22 +155,18 @@ class AddLabelsPlugin(PreBuildPlugin):
                 self.log.warning("requested automatic label %r is not available", lbl)
 
     def add_aliases(self, base_labels, df_labels):
-        all_labels = base_labels.copy()
-        all_labels.update(df_labels)
-        all_labels.update(self.labels)
-
         new_labels = df_labels.copy()
         new_labels.update(self.labels)
+
+        all_labels = base_labels.copy()
+        all_labels.update(new_labels)
 
         applied_alias = False
         not_applied = []
 
-        def add_as_an_alias(new, old, is_old_inherited):
-            self.log.warning("adding label %r as an alias for label %r", new, old)
-            if is_old_inherited and new in all_labels:
-                self.labels[old] = all_labels[new]
-            else:
-                self.labels[new] = all_labels[old]
+        def add_as_an_alias(src, dest):
+            self.log.warning("adding label %r as an alias for label %r", dest, src)
+            self.labels[dest] = all_labels[src]
 
         for old, new in self.aliases.items():
             if old not in all_labels:
@@ -180,18 +176,20 @@ class AddLabelsPlugin(PreBuildPlugin):
             is_old_inherited = old in base_labels and \
                 old not in new_labels
 
+            if is_old_inherited and new in all_labels:
+                add_as_an_alias(new, old)
+
             if new in new_labels:
                 if all_labels[old] != all_labels[new]:
-                    if is_old_inherited:
-                        add_as_an_alias(new, old, is_old_inherited)
-                        continue
                     self.log.warning("labels %r=%r and %r=%r should probably have same value",
                                      old, all_labels[old], new, all_labels[new])
 
                 self.log.debug("alias label %r for %r already exists, skipping", new, old)
                 continue
 
-            add_as_an_alias(new, old, is_old_inherited)
+            if not is_old_inherited or new not in base_labels:
+                add_as_an_alias(old, new)
+
             applied_alias = True
             self.log.info(self.labels)
 

--- a/atomic_reactor/plugins/pre_add_labels_in_df.py
+++ b/atomic_reactor/plugins/pre_add_labels_in_df.py
@@ -161,12 +161,13 @@ class AddLabelsPlugin(PreBuildPlugin):
         all_labels = base_labels.copy()
         all_labels.update(new_labels)
 
-        applied_alias = False
+        self.applied_alias = False
         not_applied = []
 
         def add_as_an_alias(src, dest):
             self.log.warning("adding label %r as an alias for label %r", dest, src)
             self.labels[dest] = all_labels[src]
+            self.applied_alias = True
 
         for old, new in self.aliases.items():
             if old not in all_labels:
@@ -180,7 +181,7 @@ class AddLabelsPlugin(PreBuildPlugin):
                 add_as_an_alias(new, old)
 
             if new in new_labels:
-                if all_labels[old] != all_labels[new]:
+                if not is_old_inherited and all_labels[old] != all_labels[new]:
                     self.log.warning("labels %r=%r and %r=%r should probably have same value",
                                      old, all_labels[old], new, all_labels[new])
 
@@ -190,11 +191,10 @@ class AddLabelsPlugin(PreBuildPlugin):
             if not is_old_inherited or new not in base_labels:
                 add_as_an_alias(old, new)
 
-            applied_alias = True
             self.log.info(self.labels)
 
         # warn if we applied only some aliases
-        if applied_alias and not_applied:
+        if self.applied_alias and not_applied:
             self.log.debug("applied only some aliases, following old labels were not found: %s",
                            ", ".join(not_applied))
 


### PR DESCRIPTION
* remove extra `copy()`
* don't pass plugin_labels -  these are available in `self.labels`
* fix `add_as_an_alias` to show which label was added as an alias (previously it was showing that new was added as an alias always, although sometimes it was in reverse)
* make sure `applied_alias` is set only when `add_as_an_alias` is called

Signed-off-by: Vadim Rutkovsky <vrutkovs@redhat.com>