### PR TITLE
orchestration: don't set release for base image builds

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length=100

--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -13,6 +13,7 @@ import json
 import logging
 import tempfile
 import signal
+import docker
 
 from atomic_reactor.build import InsideBuilder
 from atomic_reactor.plugin import (
@@ -327,7 +328,13 @@ class DockerBuildWorkflow(object):
     @property
     def base_image_inspect(self):
         if self._base_image_inspect is None:
-            self._base_image_inspect = self.builder.tasker.inspect_image(self.builder.base_image)
+            try:
+                self._base_image_inspect = self.builder.tasker.inspect_image(
+                    self.builder.base_image)
+            except docker.errors.NotFound:
+                # If the base image cannot be found throw KeyError - as this property should behave
+                # like a dict
+                raise KeyError("Unprocessed base image Dockerfile cannot be inspected")
         return self._base_image_inspect
 
     def throw_canceled_build_exception(self, *args, **kwargs):

--- a/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
+++ b/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
@@ -9,7 +9,6 @@ from __future__ import unicode_literals
 
 import json
 import os
-import docker
 
 from osbs.api import OSBS
 from osbs.conf import Configuration
@@ -163,7 +162,7 @@ class StoreMetadataInOSv3Plugin(ExitPlugin):
 
         try:
             base_image_id = self.workflow.base_image_inspect['Id']
-        except docker.errors.NotFound:
+        except KeyError:
             base_image_id = ""
 
         annotations = {


### PR DESCRIPTION
Inspecting a dockerfile for base image before add_filesystem task has ran would 
crash with 'No such image: koji/image-build:latest'. This PR makes sure this 
method is not called and a bogus release is returned.

This is a temporary solution until `df_parser` is not fixed

Signed-off-by: Vadim Rutkovsky <vrutkovs@redhat.com>