### PR TITLE
Better error reporting for push failures

### DIFF
--- a/atomic_reactor/core.py
+++ b/atomic_reactor/core.py
@@ -494,7 +494,8 @@ class DockerTasker(LastLogger):
         command_result = wait_for_command(logs)
         self.last_logs = command_result.logs
         if command_result.is_failed():
-            raise RuntimeError("Failed to push image %s" % image)
+            detail = command_result.error_detail
+            raise RuntimeError("Failed to push image %s: %s" % (image, detail))
         return command_result.parsed_logs
 
     def tag_and_push_image(self, image, target_image, insecure=False, force=False, dockercfg=None):

--- a/tests/test_tasker.py
+++ b/tests/test_tasker.py
@@ -200,6 +200,7 @@ def test_push_image(temp_image_name, should_fail):
         with pytest.raises(RuntimeError) as exc:
             output = t.push_image(temp_image_name, insecure=True)
         assert "Failed to push image" in str(exc)
+        assert "connection refused" in str(exc)
     else:
         output = t.push_image(temp_image_name, insecure=True)
         assert output is not None


### PR DESCRIPTION
If the registry push fails for some reason it would be useful to see the error message reported during push. This exception message gets stored in the build annotations and is reported in Koji.

Signed-off-by: Tim Waugh <twaugh@redhat.com>