### PR TITLE
provide hash algo for fetch maven artifacts by URL

### DIFF
--- a/atomic_reactor/schemas/fetch-artifacts-url.json
+++ b/atomic_reactor/schemas/fetch-artifacts-url.json
@@ -12,10 +12,20 @@
         "description": "The URL to be used to fetch artifact",
         "type": "string"
       },
-      "md5sum": {
-        "description": "The checksum of the artifact",
+      "md5": {
+        "description": "The md5 checksum of the artifact",
         "type": "string",
         "pattern": "^[a-f0-9]{32}$"
+      },
+      "sha1": {
+        "description": "The sha1 checksum of the artifact",
+        "type": "string",
+        "pattern": "^[a-f0-9]{40}$"
+      },
+      "sha256": {
+        "description": "The sha256 checksum of the artifact",
+        "type": "string",
+        "pattern": "^[a-f0-9]{64}$"
       },
       "target": {
         "description": "Name to be used when saving artifact to disk",
@@ -23,9 +33,17 @@
       }
     },
     "additionalProperties": false,
-    "required": [
-      "url",
-      "md5sum"
+    "required": ["url"],
+    "anyOf": [
+      {
+        "required": ["md5"]
+      },
+      {
+        "required": ["sha1"]
+      },
+      {
+        "required": ["sha256"]
+      }
     ]
   }
 }

--- a/tests/koji/__init__.py
+++ b/tests/koji/__init__.py
@@ -15,6 +15,16 @@ TASK_STATES = {
     'FAILED': 5,
 }
 
+CHECKSUM_TYPES = {
+    0: 'md5',
+    1: 'sha1',
+    2: 'sha256',
+
+    'md5': 0,
+    'sha1': 1,
+    'sha256': 2,
+}
+
 TASK_STATES.update({value: name for name, value in TASK_STATES.items()})
 
 class ClientSession(object):


### PR DESCRIPTION
Plugin fetch-maven-artifacts has been enhanced to allow
user to specify the hashing algorithm to be used when
validating an artifact downloaded via URL.
Possible options are md5, sha1 and sha256.

In addition, when fetching archives from Koji, plugin
no longer assumes the hashing algorithm is md5. Instead,
it leverages the checksum_type attribute from the artifact
information from Koji.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>