### PR TITLE
koji_promote: don't encode docker logs and final openshift logs if logs are bytestream

### DIFF
--- a/atomic_reactor/plugins/exit_koji_promote.py
+++ b/atomic_reactor/plugins/exit_koji_promote.py
@@ -345,7 +345,11 @@ class KojiPromotePlugin(ExitPlugin):
             logfile = NamedTemporaryFile(prefix=self.build_id,
                                          suffix=".log",
                                          mode='wb')
-            logfile.write(logs.encode('UTF-8'))
+            try:
+                logfile.write(logs)
+            except (TypeError, UnicodeEncodeError):
+                # Older osbs-client versions returned Unicode objects
+                logfile.write(logs.encode('utf-8'))
             logfile.flush()
             metadata = self.get_output_metadata(logfile.name,
                                                 "openshift-final.log")
@@ -354,7 +358,7 @@ class KojiPromotePlugin(ExitPlugin):
         docker_logs = NamedTemporaryFile(prefix="docker-%s" % self.build_id,
                                          suffix=".log",
                                          mode='wb')
-        docker_logs.write("\n".join(self.workflow.build_result.logs).encode('UTF-8'))
+        docker_logs.write("\n".join(self.workflow.build_result.logs).encode('utf-8'))
         docker_logs.flush()
         output.append(Output(file=docker_logs,
                              metadata=self.get_output_metadata(docker_logs.name,


### PR DESCRIPTION
Signed-off-by: Vadim Rutkovsky <vrutkovs@redhat.com>