### PR TITLE
store_metadata_in_osv3: Convert KojiPromotePlugin.key to constant

### DIFF
--- a/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
+++ b/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
@@ -14,8 +14,8 @@ from osbs.api import OSBS
 from osbs.conf import Configuration
 from osbs.exceptions import OsbsResponseException
 
+from atomic_reactor.constants import PLUGIN_KOJI_PROMOTE_PLUGIN_KEY
 from atomic_reactor.plugin import ExitPlugin
-from atomic_reactor.plugins.exit_koji_promote import KojiPromotePlugin
 from atomic_reactor.util import get_build_json
 
 
@@ -120,7 +120,7 @@ class StoreMetadataInOSv3Plugin(ExitPlugin):
     def make_labels(self):
         labels = {}
 
-        koji_build_id = self.get_exit_result(KojiPromotePlugin.key)
+        koji_build_id = self.get_exit_result(PLUGIN_KOJI_PROMOTE_PLUGIN_KEY)
         if koji_build_id:
             labels["koji-build-id"] = str(koji_build_id)
 

--- a/tests/plugins/test_store_metadata.py
+++ b/tests/plugins/test_store_metadata.py
@@ -15,26 +15,11 @@ from datetime import datetime, timedelta
 from copy import deepcopy
 from textwrap import dedent
 
-try:
-    import koji as koji
-except ImportError:
-    import inspect
-    import os
-    import sys
-
-    # Find our mocked koji module
-    import tests.koji as koji
-    mock_koji_path = os.path.dirname(inspect.getfile(koji.ClientSession))
-    if mock_koji_path not in sys.path:
-        sys.path.append(os.path.dirname(mock_koji_path))
-finally:
-    del koji
-    from atomic_reactor.plugins.exit_koji_promote import KojiPromotePlugin
-
 from flexmock import flexmock
 from osbs.api import OSBS
 import osbs.conf
 from osbs.exceptions import OsbsResponseException
+from atomic_reactor.constants import PLUGIN_KOJI_PROMOTE_PLUGIN_KEY
 from atomic_reactor.build import BuildResult
 from atomic_reactor.inner import DockerBuildWorkflow
 from atomic_reactor.plugin import ExitPluginsRunner, PluginFailedException
@@ -308,7 +293,7 @@ CMD blabla"""
     workflow.builder.df_dir = str(tmpdir)
 
     workflow.exit_results = {
-        KojiPromotePlugin.key: koji_build_id,
+        PLUGIN_KOJI_PROMOTE_PLUGIN_KEY: koji_build_id,
     }
 
     runner = ExitPluginsRunner(
@@ -392,7 +377,7 @@ def test_store_metadata_fail_update_labels(tmpdir, caplog):
     workflow = prepare()
 
     workflow.exit_results = {
-        KojiPromotePlugin.key: 1234,
+        PLUGIN_KOJI_PROMOTE_PLUGIN_KEY: 1234,
     }
 
     runner = ExitPluginsRunner(


### PR DESCRIPTION
The plugin exit_store_metadata_in_osv3 was directly importing the
KojiPromotePlugin plugin even though it could be packaged separately.

Now that atomic_reactor/constants.py has been created to store the
key values, it is easier to use that file instead of a plugin that may
not be around.

Convert 'KojiPromotePlugin.key' -> PLUGIN_KOJI_PROMOTE_PLUGIN_KEY

and convert the imports:

'from atomic_reactor.plugins.exit_koji_promote import KojiPromotePlugin'
to
'from atomic_reactor.constants import PLUGIN_KOJI_PROMOTE_PLUGIN_KEY'

This is done for the store_metadata_in_osv3 plugin and its unit
test case, test_store_metadata.

For the test_store_metadata, I ripped out the tricky 'faulting import
and append a test path to plugin' logic.