### PR TITLE
add_labels_in_df: base image inspect not required

### DIFF
--- a/atomic_reactor/plugins/pre_add_labels_in_df.py
+++ b/atomic_reactor/plugins/pre_add_labels_in_df.py
@@ -271,18 +271,21 @@ class AddLabelsPlugin(PreBuildPlugin):
         info_url = MyFormatter().vformat(self.info_url_format, [], all_labels)
         self.labels['url'] = info_url
 
+    def _get_base_image_labels(self):
+        labels = {}
+
+        try:
+            labels = self.workflow.base_image_inspect[INSPECT_CONFIG]['Labels'] or {}
+        except (KeyError):
+            self.log.debug("base image was not inspected")
+
+        return labels
+
     def run(self):
         """
         run the plugin
         """
-        try:
-            config = self.workflow.base_image_inspect[INSPECT_CONFIG]
-        except (AttributeError, TypeError):
-            message = "base image was not inspected"
-            self.log.error(message)
-            raise RuntimeError(message)
-        else:
-            base_image_labels = config["Labels"] or {}
+        base_image_labels = self._get_base_image_labels()
 
         dockerfile = df_parser(self.workflow.builder.df_path, workflow=self.workflow)
 

--- a/tests/plugins/test_add_labels.py
+++ b/tests/plugins/test_add_labels.py
@@ -122,6 +122,7 @@ LABEL "label1"="df value"
 
 @pytest.mark.parametrize('df_content, labels_conf_base, labels_conf, dont_overwrite, aliases, expected_output', [
     (DF_CONTENT, LABELS_CONF_BASE, LABELS_CONF, [], {}, EXPECTED_OUTPUT),
+    (DF_CONTENT, LABELS_BLANK, LABELS_CONF, [], {}, EXPECTED_OUTPUT),
     (DF_CONTENT, LABELS_CONF_BASE, json.dumps(LABELS_CONF), [], {}, EXPECTED_OUTPUT),
     (DF_CONTENT, LABELS_CONF_BASE, LABELS_CONF_WRONG, [], {}, RuntimeError()),
     (DF_CONTENT, LABELS_CONF_BASE, LABELS_CONF, ["label1", ], {}, EXPECTED_OUTPUT2),


### PR DESCRIPTION
With the split of `add_filesystem` plugin to run on both orchestrator and worker builds, the tarball filesystem is not actually streamed into the docker engine for orchestrator build.
This causes the parent image to not be inspected when we're building base images. (The parent image in this case is just the loaded tarball filesystem).

This change is to allow the plugin to continue execution if the parent image has not been inspected.