### PR TITLE
build_orchestrator: Save build_info in plugin's workspace

### DIFF
--- a/atomic_reactor/plugins/build_orchestrate_build.py
+++ b/atomic_reactor/plugins/build_orchestrate_build.py
@@ -26,6 +26,14 @@ from osbs.constants import BUILD_FINISHED_STATES
 ClusterInfo = namedtuple('ClusterInfo', ('cluster', 'platform', 'osbs', 'load'))
 
 
+def get_worker_build_info(workflow, platform):
+    """
+    Obtain worker build information for a given platform
+    """
+    workspace = workflow.plugin_workspace[OrchestrateBuildPlugin.key]
+    return workspace[platform]
+
+
 class WorkerBuildInfo(object):
 
     def __init__(self, build, cluster_info):
@@ -301,6 +309,10 @@ class OrchestrateBuildPlugin(BuildStepPlugin):
             for build_info in self.worker_builds
             if not build_info.build or not build_info.build.is_succeeded()
         }
+
+        workspace = {build_info.platform: build_info
+                     for build_info in self.worker_builds}
+        self.workflow.plugin_workspace[self.key] = workspace
 
         if fail_reasons:
             return BuildResult(fail_reason=json.dumps(fail_reasons),

--- a/tests/plugins/test_orchestrate_build.py
+++ b/tests/plugins/test_orchestrate_build.py
@@ -13,7 +13,8 @@ from atomic_reactor.inner import DockerBuildWorkflow
 from atomic_reactor.plugin import BuildCanceledException, PluginFailedException
 from atomic_reactor.plugin import BuildStepPluginsRunner
 from atomic_reactor.plugins import pre_reactor_config
-from atomic_reactor.plugins.build_orchestrate_build import OrchestrateBuildPlugin
+from atomic_reactor.plugins.build_orchestrate_build import (OrchestrateBuildPlugin,
+                                                            get_worker_build_info)
 from atomic_reactor.plugins.pre_reactor_config import ReactorConfig
 from atomic_reactor.util import ImageName, df_parser
 from dockerfile_parse import DockerfileParser
@@ -245,6 +246,9 @@ def test_orchestrate_build(tmpdir, config_kwargs, worker_build_image, logs_retur
 
     assert (build_result.labels == {})
 
+    build_info = get_worker_build_info(workflow, 'x86_64')
+    assert build_info.osbs
+
 
 def test_orchestrate_build_annotations_and_labels(tmpdir):
     workflow = mock_workflow(tmpdir)
@@ -335,6 +339,9 @@ def test_orchestrate_build_annotations_and_labels(tmpdir):
     })
 
     assert (build_result.labels == {'koji-build-id': 'koji-build-id'})
+
+    build_info = get_worker_build_info(workflow, 'x86_64')
+    assert build_info.osbs
 
 
 def test_orchestrate_build_cancelation(tmpdir):


### PR DESCRIPTION
The build orchestrator plugin goes through a lengthy setup to establish
cluster and osbs connection info.  Instead of replicating the setup in
later plugins, just save the build_info and pass it along to other
plugins that need it.

Currently this is intended to be used by the new post_fetch_metadata
plugin to connect to the established osbs setup to retrieve configmap
data.

The data is saved as a dict with platform as the key in
workflow.plugin_workspace and provides a wrapper call to retrieve it,
given platform and workflow parameters.

Signed-off-by: Don Zickus <dzickus@redhat.com>