### PR TITLE
build_orchestrator: Add metadata fragments from koji_upload

### DIFF
--- a/atomic_reactor/plugins/build_orchestrate_build.py
+++ b/atomic_reactor/plugins/build_orchestrate_build.py
@@ -52,7 +52,7 @@ class WorkerBuildInfo(object):
 
     def get_annotations(self):
         build_annotations = self.build.get_annotations() or {}
-        return {
+        annotations = {
             'build': {
                 'cluster-url': self.osbs.os_conf.get_openshift_base_uri(),
                 'namespace': self.osbs.os_conf.get_namespace(),
@@ -63,6 +63,13 @@ class WorkerBuildInfo(object):
             'plugins-metadata': json.loads(
                 build_annotations.get('plugins-metadata', '{}')),
         }
+
+        if 'metadata_fragment' in build_annotations and \
+           'metadata_fragment_key' in build_annotations:
+            annotations['metadata_fragment'] = build_annotations['metadata_fragment']
+            annotations['metadata_fragment_key'] = build_annotations['metadata_fragment_key']
+
+        return annotations
 
     def get_fail_reason(self):
         if not self.build:


### PR DESCRIPTION
When the new plugin, koji_upload, is enabled, it will pass metadata
from the worker to the orchestrator through an osbs configmap object.

The pointer to this configmap object will be passed through an annotations
object.  Currently, orchestrator plugins can not access this metadata
info because it is not saved.

Save the info inside get_annotations() if available.  This will allow
future plugins like post_fetch_worker_metadata to grab and utilize
this data.