### PR TITLE
gitignore: Add .cache and lib directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 *.swp
 dist/
 *.egg-info/
+build/
+
+# Unit test / coverage reports
+.cache


### PR DESCRIPTION
These directories are transient from either running a local build or test
coverage.  Clean up git status by hiding them.

This mimics what osbs-client does.

Signed-off-by: Don Zickus <dzickus@redhat.com>