### PR TITLE
Make sure some labels - namely release and version - are always set

### DIFF
--- a/atomic_reactor/plugins/pre_add_labels_in_df.py
+++ b/atomic_reactor/plugins/pre_add_labels_in_df.py
@@ -64,6 +64,7 @@ import string
 class AddLabelsPlugin(PreBuildPlugin):
     key = "add_labels_in_dockerfile"
     is_allowed_to_fail = False
+    rewrite_whitelist = ['release', 'version']
 
     def __init__(self, tasker, workflow, labels,
                  dont_overwrite=("Architecture", "architecture"),
@@ -322,7 +323,9 @@ class AddLabelsPlugin(PreBuildPlugin):
             except KeyError:
                 self.log.info("label %r not present in base image", key)
             else:
-                if base_image_value == value:
+                # Some labels (self.rewrite_whitelist) should always be set in the dockerfile
+                # even if it was already set in base image and the values match
+                if base_image_value == value and key not in self.rewrite_whitelist:
                     self.log.info("label %r is already set to %r", key, value)
                     continue
                 else:

--- a/tests/plugins/test_add_labels.py
+++ b/tests/plugins/test_add_labels.py
@@ -75,10 +75,12 @@ LABELS_CONF_WITH_LABELS = {INSPECT_CONFIG: {"Labels": {
                                                 "com.redhat.build-host": "base value",
                                                 "Build_Host": "base value"}}}
 LABELS_CONF_BASE = {INSPECT_CONFIG: {"Labels": {"label1": "base value"}}}
+LABELS_CONF_BASE_EXPLICIT = {INSPECT_CONFIG: {"Labels": {"version": "x", "release": "1"}}}
 LABELS_CONF_BASE_NONE = {INSPECT_CONFIG: {"Labels": None}}
 LABELS_CONF = OrderedDict({'label1': 'value 1', 'label2': 'long value'})
 LABELS_CONF_ONE = {'label2': 'long value'}
 LABELS_CONF_WRONG = [('label1', 'value1'), ('label2', 'value2')]
+LABELS_CONF_EXPLICIT = {"version": "x", "release": "1"}
 LABELS_BLANK = {}
 # Can't be sure of the order of the labels, expect either
 EXPECTED_OUTPUT = ["""FROM fedora
@@ -118,8 +120,18 @@ LABEL "label2"="df value"
 """, r"""FROM fedora
 LABEL "label2"="df value"
 LABEL "label1"="df value"
-""",
-]
+"""]
+# Label order seems to be set randomly, so both possible options are added
+EXPECTED_OUTPUT9 = [r"""FROM fedora
+RUN yum install -y python-django
+CMD blabla
+LABEL "release"="1" "version"="x"
+""", r"""FROM fedora
+RUN yum install -y python-django
+CMD blabla
+LABEL "version"="x" "release"="1"
+"""]
+
 
 @pytest.mark.parametrize('df_content, labels_conf_base, labels_conf, dont_overwrite, aliases, expected_output', [
     (DF_CONTENT, LABELS_CONF_BASE, LABELS_CONF, [], {}, EXPECTED_OUTPUT),
@@ -135,6 +147,7 @@ LABEL "label1"="df value"
     (DF_CONTENT_LABEL, LABELS_CONF_BASE, LABELS_BLANK, [], {"label2": "labelnew", "x": "y"}, EXPECTED_OUTPUT7),
     (DF_CONTENT_LABEL, LABELS_CONF_BASE_NONE, LABELS_BLANK, [], {"label2": "labelnew"}, EXPECTED_OUTPUT7),
     (DF_CONTENT_LABEL, LABELS_CONF_BASE, LABELS_BLANK, [], {"label2": "label1"}, EXPECTED_OUTPUT8),
+    (DF_CONTENT, LABELS_CONF_BASE_EXPLICIT, LABELS_CONF_EXPLICIT, [], {}, EXPECTED_OUTPUT9),
 ])
 def test_add_labels_plugin(tmpdir, docker_tasker,
                            df_content, labels_conf_base, labels_conf, dont_overwrite, aliases,


### PR DESCRIPTION
Release and version labels would be written explicitly even if any of
them has the same value as in base image.

This fixes an issue I've sometimes seen in integration test runs - base image has release = 1, so if we build a new image on top of it atomic-reactor won't write this label in the file:
```
label u'release' is already set to u'1'
```

In the end the image would have a correct label set, but `koji_promote` would fail, as it fetches labels from Dockerfile, not knowing the label is set in the base image.

That also means release and version won't be written in Dockerfile, stored in the image - this is why this PR sets the labels explicitely, instead of updating `koji_promote` code