### PR TITLE
koji_upload requires koji_upload_dir parameter

### DIFF
--- a/tests/plugins/test_fetch_worker.py
+++ b/tests/plugins/test_fetch_worker.py
@@ -131,8 +131,11 @@ def test_fetch_worker_plugin(tmpdir, fragment_key):
     worker_ppc64le = WorkerBuildInfo(build, cluster_info)
 
     workspace = {
-        'x86_64': worker_x86_64,
-        'ppc64le': worker_ppc64le,
+        'build_info': {
+            'x86_64': worker_x86_64,
+            'ppc64le': worker_ppc64le,
+        },
+        'koji_upload_dir': 'foo',
     }
 
     workflow.build_result = BuildResult(annotations=annotations, image_id="id1234")

--- a/tests/plugins/test_koji_upload.py
+++ b/tests/plugins/test_koji_upload.py
@@ -48,6 +48,7 @@ from six import string_types
 
 NAMESPACE = 'mynamespace'
 BUILD_ID = 'build-1'
+KOJI_UPLOAD_DIR = 'upload'
 
 
 def noop(*args, **kwargs): return None
@@ -131,6 +132,7 @@ class MockedClientSession(object):
                       blocksize=1048576, overwrite=True):
         self.uploaded_files.append(path)
         self.blocksize = blocksize
+        assert path.split(os.path.sep, 1)[0] == KOJI_UPLOAD_DIR
 
     def CGImport(self, metadata, server_dir):
         self.metadata = metadata
@@ -328,6 +330,7 @@ def create_runner(tasker, workflow, ssl_certs=False, principal=None,
         'kojihub': '',
         'url': '/',
         'build_json_dir': '',
+        'koji_upload_dir': KOJI_UPLOAD_DIR,
     }
     if ssl_certs:
         args['koji_ssl_certs_dir'] = '/'


### PR DESCRIPTION
This is so the orchestrator build can tell each worker to use the same upload directory.

Also: make orchestrate_build expose the value it used, for the benefit of koji_import (which will need it when calling CGImport).

Signed-off-by: Tim Waugh <twaugh@redhat.com>