### PR TITLE
logging: Add 'arch' to all log output

### DIFF
--- a/atomic_reactor/__init__.py
+++ b/atomic_reactor/__init__.py
@@ -14,7 +14,22 @@ import time
 
 from atomic_reactor.version import __version__
 
+try:
+    from osbs.constants import ATOMIC_REACTOR_LOGGING_FMT
+except ImportError:
+    # not available in osbs < 0.41
+    fmt = '%(asctime)s platform:%(arch)s - %(name)s - %(levelname)s - %(message)s'
+    ATOMIC_REACTOR_LOGGING_FMT = fmt
+
 start_time = time.time()
+
+
+class ArchFormatter(logging.Formatter):
+    def format(self, record):
+        if not hasattr(record, 'arch'):
+            record.arch = '-'
+
+        return super(ArchFormatter, self).format(record)
 
 
 def set_logging(name="atomic_reactor", level=logging.DEBUG, handler=None):
@@ -29,7 +44,7 @@ def set_logging(name="atomic_reactor", level=logging.DEBUG, handler=None):
         handler.setLevel(logging.DEBUG)
 
         # create formatter
-        formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+        formatter = ArchFormatter(ATOMIC_REACTOR_LOGGING_FMT)
 
         # add formatter to ch
         handler.setFormatter(formatter)

--- a/tests/plugins/test_fetch_worker.py
+++ b/tests/plugins/test_fetch_worker.py
@@ -9,6 +9,7 @@ of the BSD license. See the LICENSE file for details.
 from __future__ import print_function, unicode_literals
 
 import os
+import logging
 
 from flexmock import flexmock
 
@@ -115,6 +116,7 @@ def test_fetch_worker_plugin(tmpdir, fragment_key):
         'spam': 'bacon',
     }
     metadata = {'metadata.json': koji_metadata}
+    log = logging.getLogger("atomic_reactor.plugins." + OrchestrateBuildPlugin.key)
 
     build = None
     cluster = None
@@ -123,12 +125,12 @@ def test_fetch_worker_plugin(tmpdir, fragment_key):
     name = 'build-1-x86_64-md'
     osbs = MockOSBS({name: metadata})
     cluster_info = ClusterInfo(cluster, 'x86_64', osbs, load)
-    worker_x86_64 = WorkerBuildInfo(build, cluster_info)
+    worker_x86_64 = WorkerBuildInfo(build, cluster_info, log)
 
     name = 'build-1-ppc64le-md'
     osbs = MockOSBS({name: metadata})
     cluster_info = ClusterInfo(cluster, "ppc64le", osbs, load)
-    worker_ppc64le = WorkerBuildInfo(build, cluster_info)
+    worker_ppc64le = WorkerBuildInfo(build, cluster_info, log)
 
     workspace = {
         'build_info': {

--- a/tests/plugins/test_orchestrate_build.py
+++ b/tests/plugins/test_orchestrate_build.py
@@ -198,7 +198,7 @@ def make_worker_build_kwargs(**overrides):
     True,
     False
 ])
-def test_orchestrate_build(tmpdir, config_kwargs, worker_build_image, logs_return_bytes):
+def test_orchestrate_build(tmpdir, caplog, config_kwargs, worker_build_image, logs_return_bytes):
     workflow = mock_workflow(tmpdir)
     mock_osbs(logs_return_bytes=logs_return_bytes)
     mock_reactor_config(tmpdir)
@@ -255,6 +255,16 @@ def test_orchestrate_build(tmpdir, config_kwargs, worker_build_image, logs_retur
 
     build_info = get_worker_build_info(workflow, 'x86_64')
     assert build_info.osbs
+
+    for record in caplog.records():
+        if not record.name.startswith("atomic_reactor"):
+            continue
+
+        assert hasattr(record, 'arch')
+        if record.funcName == 'watch_logs':
+            assert record.arch == 'x86_64'
+        else:
+            assert record.arch == '-'
 
 
 @pytest.mark.parametrize('metadata_fragment', [


### PR DESCRIPTION
To help with multiplexing orchestrator logs and worker build logs,
add an 'arch' component to the log output.

Orchestrator has no 'arch' and outputs a '-'.

This is done by using the LoggerAdapter for the worker builds.  Instead
of littering LoggerAdapter all of the git tree, just use a custom LogFormatter
and default arch to '-' for the orchestrator logs.

Output goes from:

2017-07-07 16:10:52,214 - atomic_reactor.plugins.orchestrate_build - INFO - platform x86_64 will use cluster worker_x86_64
2017-07-07 16:10:52,214 - atomic_reactor.plugins.orchestrate_build - INFO - x86_64 - created build worker-build-x86_64
2017-07-07 16:10:52,215 - atomic_reactor.plugins.orchestrate_build - INFO - <generator object <genexpr> at 0x7f8fbe0a6460>

To:

2017-07-07 16:10:52,214 platform:- - atomic_reactor.plugins.orchestrate_build - INFO - platform x86_64 will use cluster worker_x86_64
2017-07-07 16:10:52,214 platform:- - atomic_reactor.plugins.orchestrate_build - INFO - x86_64 - created build worker-build-x86_64
2017-07-07 16:10:52,215 platform:x86_64 - atomic_reactor.plugins.orchestrate_build - INFO - <generator object <genexpr> at 0x7f8fbe0a6460>

Unit test updated to parse the capture log and verify record.arch is set correctly.

This change only affects atomic_reactor project logging.  Other modules are not
impacted and will not have the 'arch' set (ie Docker output).

Signed-off-by: Don Zickus <dzickus@redhat.com>