### PR TITLE
Sort out log encoding

### DIFF
--- a/atomic_reactor/cli/main.py
+++ b/atomic_reactor/cli/main.py
@@ -12,6 +12,7 @@ import logging
 import os
 import sys
 import pkg_resources
+import locale
 
 from atomic_reactor import set_logging
 from atomic_reactor.api import (build_image_here, build_image_in_privileged_container,
@@ -102,6 +103,8 @@ class CLI(object):
         self.build_parser = None
         self.bi_parser = None
         self.ib_parser = None
+
+        locale.setlocale(locale.LC_ALL, '')
 
     def set_arguments(self):
         try:

--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -30,6 +30,7 @@ from atomic_reactor.plugin import (
 from atomic_reactor.source import get_source_instance_for
 from atomic_reactor.util import ImageName
 from atomic_reactor.build import BuildResult
+from atomic_reactor import get_logging_encoding
 
 
 logger = logging.getLogger(__name__)
@@ -436,6 +437,10 @@ def build_inside(input_method, input_args=None, substitutions=None):
             key, value = arg.split("=", 1)
             processed_keyvals[key] = value
         return processed_keyvals
+
+    main = __name__.split('.', 1)[0]
+    log_encoding = get_logging_encoding(main)
+    logger.info("log encoding: %s", log_encoding)
 
     if not input_method:
         raise RuntimeError("No input method specified!")


### PR DESCRIPTION
Keep the log output in a consistent output format by forcing logging to
use UTF-8.  Forcing stderr to accomplish this wasn't straightforward, so
a new streamHandler was created to create the effect we want.  And an
appropriate test case to verify.

Based on Tim Waugh's original work.

I tweaked the test case to handle the different names for 'UTF8' and
added a check to not encode byte data for writer().