### PR TITLE
plugins: Support orchestrator node in delete_from_registry plugin

### DIFF
--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -217,6 +217,9 @@ class PushConf(object):
         for registry_uri in registry_uris:
             self.add_docker_registry(registry_uri, insecure=insecure)
 
+    def remove_docker_registry(self, docker_registry):
+        self._registries["docker"].remove(docker_registry)
+
     def add_pulp_registry(self, name, crane_uri, server_side_sync=True):
         if crane_uri is None:
             raise RuntimeError("registry URI cannot be None")

--- a/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
+++ b/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
@@ -85,11 +85,9 @@ class StoreMetadataInOSv3Plugin(ExitPlugin):
 
     def _get_registries(self):
         """
-        Return a list of registries that are exposed to user
-        If pulp registries are used, only those will be returned
+        Return a list of registries that this build updated
         """
-        return (self.workflow.push_conf.pulp_registries or
-                self.workflow.push_conf.all_registries)
+        return self.workflow.push_conf.all_registries
 
     def get_repositories(self):
         # usually repositories formed from NVR labels

--- a/tests/plugins/test_delete_from_registry.py
+++ b/tests/plugins/test_delete_from_registry.py
@@ -14,8 +14,9 @@ from flexmock import flexmock
 from atomic_reactor.util import ImageName, ManifestDigest
 from atomic_reactor.core import DockerTasker
 from atomic_reactor.inner import DockerBuildWorkflow, DockerRegistry
-from atomic_reactor.plugin import ExitPluginsRunner
+from atomic_reactor.plugin import ExitPluginsRunner, PluginFailedException
 from atomic_reactor.plugins.exit_delete_from_registry import DeleteFromRegistryPlugin
+from atomic_reactor.plugins.build_orchestrate_build import OrchestrateBuildPlugin
 from tests.constants import LOCALHOST_REGISTRY, DOCKER0_REGISTRY, MOCK, TEST_IMAGE, INPUT_IMAGE
 
 from tempfile import mkdtemp
@@ -58,9 +59,107 @@ class X(object):
     {DOCKER0_REGISTRY: True, LOCALHOST_REGISTRY: True},
     {DOCKER0_REGISTRY: False, LOCALHOST_REGISTRY: True},
 ])
-def test_delete_from_registry_plugin(saved_digests, req_registries, tmpdir):
+@pytest.mark.parametrize("orchestrator", [True, False])
+def test_delete_from_registry_plugin(saved_digests, req_registries, tmpdir, orchestrator):
     if MOCK:
         mock_docker()
+
+    buildstep_plugin = None
+    if orchestrator:
+        ann_digests = []
+        buildstep_plugin = [{
+            'name': OrchestrateBuildPlugin.key,
+            'args': {
+                'platforms': "x86_64"
+            },
+        }]
+
+    tasker = DockerTasker()
+    workflow = DockerBuildWorkflow({"provider": "git", "uri": "asd"}, TEST_IMAGE,
+                                   buildstep_plugins=buildstep_plugin, )
+    setattr(workflow, 'builder', X)
+
+    args_registries = {}
+    for reg, use_secret in req_registries.items():
+        if use_secret:
+            temp_dir = mkdtemp(dir=str(tmpdir))
+            with open(os.path.join(temp_dir, ".dockercfg"), "w+") as dockerconfig:
+                dockerconfig_contents = {
+                    reg: {
+                        "username": "user", "password": reg
+                    }
+                }
+                dockerconfig.write(json.dumps(dockerconfig_contents))
+                dockerconfig.flush()
+                args_registries[reg] = {'secret': temp_dir}
+        else:
+            args_registries[reg] = {}
+
+    for reg, digests in saved_digests.items():
+        if orchestrator:
+            for tag, dig in digests.items():
+                repo = tag.split(':')[0]
+                t = tag.split(':')[1]
+                ann_digests.append({
+                    'digest': dig,
+                    'tag': t,
+                    'repository': repo,
+                    'registry': reg,
+                })
+        else:
+            r = DockerRegistry(reg)
+            for tag, dig in digests.items():
+                r.digests[tag] = ManifestDigest(v1='not-used', v2=dig)
+            workflow.push_conf._registries['docker'].append(r)
+
+    if orchestrator:
+        build_annotations = {'digests': ann_digests}
+        annotations = {'worker-builds': {'x86_64': build_annotations}}
+        setattr(workflow, 'build_result', Y)
+        setattr(workflow.build_result, 'annotations', annotations)
+
+    runner = ExitPluginsRunner(
+        tasker,
+        workflow,
+        [{
+            'name': DeleteFromRegistryPlugin.key,
+            'args': {
+                'registries': args_registries
+            },
+        }]
+    )
+
+    deleted_digests = set()
+    for reg, digests in saved_digests.items():
+        if reg not in req_registries:
+            continue
+
+        for tag, dig in digests.items():
+            if dig in deleted_digests:
+                continue
+            url = "https://" + reg + "/v2/" + tag.split(":")[0] + "/manifests/" + dig
+            auth_type = requests.auth.HTTPBasicAuth if req_registries[reg] else None
+            (flexmock(requests)
+                .should_receive('delete')
+                .with_args(url, verify=bool, auth=auth_type)
+                .once()
+                .and_return(flexmock(status_code=202, ok=True)))
+            deleted_digests.add(dig)
+
+    result = runner.run()
+    assert result[DeleteFromRegistryPlugin.key] == deleted_digests
+
+
+@pytest.mark.parametrize("status_codes", [requests.codes.ACCEPTED,
+                                          requests.codes.NOT_FOUND,
+                                          requests.codes.METHOD_NOT_ALLOWED,
+                                          999])
+def test_delete_from_registry_failures(tmpdir, status_codes):
+    if MOCK:
+        mock_docker()
+
+    req_registries = {DOCKER0_REGISTRY: True}
+    saved_digests = {DOCKER0_REGISTRY: {'foo/bar:latest': DIGEST1}}
 
     tasker = DockerTasker()
     workflow = DockerBuildWorkflow({"provider": "git", "uri": "asd"}, TEST_IMAGE)
@@ -107,14 +206,21 @@ def test_delete_from_registry_plugin(saved_digests, req_registries, tmpdir):
         for tag, dig in digests.items():
             if dig in deleted_digests:
                 continue
+            ok = True if status_codes == requests.codes.ACCEPTED else False
             url = "https://" + reg + "/v2/" + tag.split(":")[0] + "/manifests/" + dig
             auth_type = requests.auth.HTTPBasicAuth if req_registries[reg] else None
             (flexmock(requests)
                 .should_receive('delete')
                 .with_args(url, verify=bool, auth=auth_type)
-                .once()
-                .and_return(flexmock(status_code=202)))
+                .and_return(flexmock(status_code=status_codes, ok=ok, reason="blah", text="foo")))
             deleted_digests.add(dig)
 
-    result = runner.run()
-    assert result[DeleteFromRegistryPlugin.key] == deleted_digests
+    if status_codes == 999:
+        with pytest.raises(PluginFailedException):
+            runner.run()
+    else:
+        result = runner.run()
+        if status_codes == requests.codes.ACCEPTED:
+            assert result[DeleteFromRegistryPlugin.key] == deleted_digests
+        else:
+            assert result[DeleteFromRegistryPlugin.key] == set([])

--- a/tests/plugins/test_store_metadata.py
+++ b/tests/plugins/test_store_metadata.py
@@ -243,6 +243,16 @@ CMD blabla"""
     assert is_string_type(annotations['digests'])
     digests = json.loads(annotations['digests'])
     expected = [{
+        "registry": DOCKER0_REGISTRY,
+        "repository": TEST_IMAGE,
+        "tag": 'latest',
+        "digest": DIGEST1,
+    }, {
+        "registry": DOCKER0_REGISTRY,
+        "repository": "namespace/image",
+        "tag": 'asd123',
+        "digest": DIGEST2,
+    }, {
         "registry": LOCALHOST_REGISTRY,
         "repository": TEST_IMAGE,
         "tag": 'latest',
@@ -543,7 +553,7 @@ def test_store_metadata_fail_update_labels(tmpdir, caplog, koji_plugin):
     [
         [['spam', 'spam:8888'], ],
         ['bacon:8888'],
-        ['spam:8888', ]
+        ['spam:8888', 'bacon:8888']
     ],
 ])
 def test_filter_repositories(tmpdir, pulp_registries, docker_registries,


### PR DESCRIPTION
The orchestrator node needs to process some of the digests before they
are deleted.  As a result, the delete_from_registry plugin needs to
move from the worker node to the orchestrator node.

This requires detecting which node the plugin is running from and using
the correct data lookup to find the registry information.

This plugin should still function correctly for older arrangements.