### PR TITLE
Increase chunk for fetch_maven_artifacts downloads

### DIFF
--- a/atomic_reactor/plugins/pre_fetch_maven_artifacts.py
+++ b/atomic_reactor/plugins/pre_fetch_maven_artifacts.py
@@ -14,6 +14,7 @@ import os
 import requests
 
 from atomic_reactor import util
+from atomic_reactor.constants import DEFAULT_DOWNLOAD_BLOCK_SIZE
 from atomic_reactor.koji_util import create_koji_session
 from atomic_reactor.plugin import PreBuildPlugin
 from collections import namedtuple
@@ -206,7 +207,7 @@ class FetchMavenArtifactsPlugin(PreBuildPlugin):
             request = requests.get(download.url, stream=True)
             request.raise_for_status()
             with open(dest_path, 'wb') as f:
-                for chunk in request.iter_content():
+                for chunk in request.iter_content(chunk_size=DEFAULT_DOWNLOAD_BLOCK_SIZE):
                     f.write(chunk)
                     for checksum in checksums.values():
                         checksum.update(chunk)


### PR DESCRIPTION
By default requests module uses 1 byte chunks when iterating
over streamed content. This is optimal for responsive use
cases, not so much for downloading large files. The chunk size
is now set to 10Mb to improve throughput.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>