### PR TITLE
pulp_pull, koji_import: pass pulp build_id schema information

### DIFF
--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -135,6 +135,13 @@ class KojiImportPlugin(ExitPlugin):
                 # They are all None
                 extra['image']['help'] = None
 
+    def set_media_types(self, extra, worker_metadatas):
+        for platform in worker_metadatas:
+            annotations = get_worker_build_info(self.workflow, platform).build.get_annotations()
+            if annotations.get('media-types'):
+                extra['image']['media_types'] = annotations['media-types']
+                return
+
     def get_build(self, metadata, worker_metadatas):
         start_time = int(atomic_reactor_start_time)
 
@@ -174,6 +181,8 @@ class KojiImportPlugin(ExitPlugin):
                     extra['filesystem_koji_task_id'] = task_id
 
         self.set_help(extra, worker_metadatas)
+
+        self.set_media_types(extra, worker_metadatas)
 
         build = {
             'name': component,

--- a/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
+++ b/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
@@ -15,6 +15,7 @@ from osbs.conf import Configuration
 from osbs.exceptions import OsbsResponseException
 
 from atomic_reactor.plugins.pre_add_help import AddHelpPlugin
+from atomic_reactor.plugins.post_pulp_pull import PulpPullPlugin
 from atomic_reactor.constants import (PLUGIN_KOJI_IMPORT_PLUGIN_KEY,
                                       PLUGIN_KOJI_PROMOTE_PLUGIN_KEY,
                                       PLUGIN_KOJI_UPLOAD_PLUGIN_KEY)
@@ -203,6 +204,11 @@ class StoreMetadataInOSv3Plugin(ExitPlugin):
                 annotations['help_file'] = json.dumps(help_result['help_file'])
             else:
                 self.log.error("Unknown result from add_help plugin: %s", help_result)
+
+        pulp_pull_results = self.workflow.postbuild_results.get(PulpPullPlugin.key)
+        if pulp_pull_results:
+            _, media_types = pulp_pull_results
+            annotations['media-types'] = media_types
 
         tar_path = tar_size = tar_md5sum = tar_sha256sum = None
         if len(self.workflow.exported_image_sequence) > 0:


### PR DESCRIPTION
pulp_pull, koji_import: pass pulp build_id schema information

Change pulp_pull to return build_id and a string list that describes
the type of image schema. store_metadata_in_osv3 consumes the list
and stores the version in the annotations. koji_import reads the
annotations and stores the version in build.extra.image.media_types.

Return the v2schemav2 information if there is a v2 digest, v2schema1
if pulp_sync ran, and v1 information if pulp_pull ran. Concat and 
sort the response so it is possible to return v2schema2, v2schema1,
and v1 information.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>