### PR TITLE
post_tag_from_config: take tag_suffixes from osbs-client

### DIFF
--- a/atomic_reactor/plugins/pre_add_labels_in_df.py
+++ b/atomic_reactor/plugins/pre_add_labels_in_df.py
@@ -53,12 +53,11 @@ from __future__ import unicode_literals
 from atomic_reactor import start_time as atomic_reactor_start_time
 from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.constants import INSPECT_CONFIG
-from atomic_reactor.util import get_docker_architecture, df_parser
+from atomic_reactor.util import get_docker_architecture, df_parser, LabelFormatter
 from osbs.utils import Labels
 import json
 import datetime
 import re
-import string
 
 
 class AddLabelsPlugin(PreBuildPlugin):
@@ -258,16 +257,7 @@ class AddLabelsPlugin(PreBuildPlugin):
         all_labels.update(df_labels)
         all_labels.update(plugin_labels)
 
-        class MyFormatter(string.Formatter):
-            """
-            using this because str.format can't handle keys with dots and dashes
-            which are included in some of the labels, such as
-            'authoritative-source-url', 'com.redhat.component', etc
-            """
-            def get_field(self, field_name, args, kwargs):
-                return (self.get_value(field_name, args, kwargs), field_name)
-
-        info_url = MyFormatter().vformat(self.info_url_format, [], all_labels)
+        info_url = LabelFormatter().vformat(self.info_url_format, [], all_labels)
         self.labels['url'] = info_url
 
     def run(self):

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -23,6 +23,7 @@ import logging
 import uuid
 import yaml
 import codecs
+import string
 
 from atomic_reactor.constants import DOCKERFILE_FILENAME, TOOLS_USED, INSPECT_CONFIG
 
@@ -912,3 +913,13 @@ def read_yaml(yaml_file_path, schema):
         raise
 
     return data
+
+
+class LabelFormatter(string.Formatter):
+    """
+    using this because str.format can't handle keys with dots and dashes
+    which are included in some of the labels, such as
+    'authoritative-source-url', 'com.redhat.component', etc
+    """
+    def get_field(self, field_name, args, kwargs):
+        return (self.get_value(field_name, args, kwargs), field_name)


### PR DESCRIPTION
add an optional tag_suffixes plugin parameter to post_tag_from_config. If
it is passed, do not get tag_suffixes from the git repository. Instead,
parse the tags dictionary for 'unique' and 'primary', which are
lists of strings of tag_suffixes. Append the unique tag_suffixes verbatim
to the component name and apply the resulting tags; expand the primary 
tag_suffixes, append them to the component name, and apply them. Return the 
list of tags applied.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>