### PR TITLE
Fix indentation

### DIFF
--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -131,9 +131,9 @@ class KojiImportPlugin(ExitPlugin):
                     if annotations['help_file'] is not None:
                         extra['image']['help'] = annotations['help_file']
                         break
-                    else:
-                        # They are all None
-                        extra['image']['help'] = None
+            else:
+                # They are all None
+                extra['image']['help'] = None
 
     def get_build(self, metadata, worker_metadatas):
         start_time = int(atomic_reactor_start_time)


### PR DESCRIPTION
The 'else' clause here was intended to belong to the 'for', not the 'if', as the comment indicates.

It should only be executed once all the items in the loop have been checked, i.e. when 'break' is not executed. Otherwise it just wastes cycles setting it every time.

Signed-off-by: Tim Waugh <twaugh@redhat.com>