### PR TITLE
Rework travis to make it run in different Fedora/CentOS containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 
 # Unit test / coverage reports
 .cache
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,33 @@
 language: python
-python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-# command to install dependencies
-install:
-  - "pip install -r requirements.txt"
-  - "pip install -r tests/requirements.txt"
-  - "pip install pytest-cov coveralls"
-  - "pip install git+https://github.com/projectatomic/osbs-client"
-  - "if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then pip install git+https://github.com/release-engineering/dockpulp; fi"
-  - "if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then pip install -r requirements-py2.txt; fi"
-# command to run tests
-script: "py.test -vv tests --cov atomic_reactor"
-# run in a docker container
-sudo: false
+sudo: "required"
+services:
+  - docker
+env:
+  matrix:
+    - OS=centos
+      OS_VERSION=7
+      PYTHON_VERSION=2
+    - OS=fedora
+      OS_VERSION=25
+      PYTHON_VERSION=2
+    - OS=fedora
+      OS_VERSION=25
+      PYTHON_VERSION=3
+    - OS=fedora
+      OS_VERSION=26
+      PYTHON_VERSION=2
+    - OS=fedora
+      OS_VERSION=26
+      PYTHON_VERSION=3
+    - OS=fedora
+      OS_VERSION=rawhide
+      PYTHON_VERSION=2
+    - OS=fedora
+      OS_VERSION=rawhide
+      PYTHON_VERSION=3
+script:
+ - pip install coveralls
+ - ./test.sh
+after_success: coveralls
 notifications:
   email: false
-after_success: "coveralls"
-deploy:
-  provider: pypi
-  user: bkabrda
-  on:
-    tags: true
-  password:
-    secure: Q4pXe0ARf2Mj7ZEqEICpzW6SBB554PxVPKErJkUcaD4V3zO3e/Ckbrk0aHeCMCPZlD5i/tfBXRMsMJhcvQht+jXTwUo5VD55WvkKBmpvQbJBsvmrIvrX+3C8SxVYXyLiSklQxCdGMCE/EN9dmQVI2574BQsXR43uVhwOzuL2V3k=
-addons:
-  apt:
-    packages:
-    - desktop-file-utils

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+set -eux
+
+# Prepare env vars
+OS=${OS:="centos"}
+OS_VERSION=${OS_VERSION:="7"}
+PYTHON_VERSION=${PYTHON_VERSION:="2"}
+IMAGE="$OS:$OS_VERSION"
+# Pull fedora images from registry.fedoraproject.org
+if [[ $OS == "fedora" ]]; then
+  IMAGE="registry.fedoraproject.org/$IMAGE"
+fi
+
+CONTAINER_NAME="atomic-reactor-$OS-$OS_VERSION-py$PYTHON_VERSION"
+RUN="docker exec -ti $CONTAINER_NAME"
+if [[ $OS == "fedora" ]]; then
+  if [[ $OS_VERSION == 25 && $PYTHON_VERSION == 2 ]]; then PIP_PKG="python-pip"; else PIP_PKG="python$PYTHON_VERSION-pip"; fi
+  PIP="pip$PYTHON_VERSION"
+  PKG="dnf"
+  # F25 has outdated flatpak, don't run flatpak tests on it
+  if [[ $OS_VERSION == 25 ]]; then PKG_EXTRA="dnf-plugins-core desktop-file-utils"; else PKG_EXTRA="dnf-plugins-core desktop-file-utils flatpak ostree"; fi
+  BUILDDEP="dnf builddep"
+  PYTHON="python$PYTHON_VERSION"
+  PYTEST="py.test-$PYTHON_VERSION"
+else
+  PIP_PKG="python-pip"
+  PIP="pip"
+  PKG="yum"
+  PKG_EXTRA="yum-utils epel-release git-core desktop-file-utils"
+  BUILDDEP="yum-builddep"
+  PYTHON="python"
+  PYTEST="py.test"
+fi
+# Create container if needed
+if [[ $(docker ps -q -f name=$CONTAINER_NAME | wc -l) -eq 0 ]]; then
+  docker run --name $CONTAINER_NAME -d -v $PWD:$PWD -w $PWD -ti $IMAGE sleep infinity
+fi
+
+# Install dependencies
+$RUN $PKG install -y $PKG_EXTRA
+$RUN $BUILDDEP -y atomic-reactor.spec
+if [[ $OS != "fedora" ]]; then
+  # Install dependecies for test, as check is disabled for rhel
+  $RUN yum install -y python-flexmock python-six \
+                      python-docker-py python-backports-lzma \
+                      python-responses \
+                      python-requests python-requests-kerberos # OSBS dependencies
+fi
+
+# Install package
+$RUN $PKG install -y $PIP_PKG
+if [[ $PYTHON_VERSION == 3 && $OS_VERSION == rawhide ]]; then
+  # https://fedoraproject.org/wiki/Changes/Making_sudo_pip_safe
+  $RUN mkdir -p /usr/local/lib/python3.6/site-packages/
+fi
+
+# Install other dependencies for tests
+
+# Install latest osbs-client by installing dependencies from the master branch
+# and running pip install with '--no-deps' to avoid compilation
+# This would also ensure all the deps are specified in the spec
+$RUN git clone https://github.com/projectatomic/osbs-client /tmp/osbs-client
+$RUN $BUILDDEP -y /tmp/osbs-client/osbs-client.spec
+$RUN $PIP install --upgrade --no-deps --force-reinstall git+https://github.com/projectatomic/osbs-client
+
+$RUN $PIP install --upgrade --no-deps --force-reinstall git+https://github.com/DBuildService/dockerfile-parse
+if [[ $PYTHON_VERSION == 2* ]]; then
+  $RUN $PIP install git+https://github.com/release-engineering/dockpulp
+  $RUN $PIP install -r requirements-py2.txt
+fi
+$RUN $PIP install docker-squash
+$RUN $PYTHON setup.py install
+
+# Install packages for tests
+$RUN $PIP install -r tests/requirements.txt
+
+# Run tests
+$RUN $PIP install pytest-cov
+if [[ $OS != "fedora" ]]; then $RUN $PIP install -U pytest-cov; fi
+$RUN $PYTEST -vv tests --cov atomic_reactor

--- a/test.sh
+++ b/test.sh
@@ -17,8 +17,7 @@ if [[ $OS == "fedora" ]]; then
   if [[ $OS_VERSION == 25 && $PYTHON_VERSION == 2 ]]; then PIP_PKG="python-pip"; else PIP_PKG="python$PYTHON_VERSION-pip"; fi
   PIP="pip$PYTHON_VERSION"
   PKG="dnf"
-  # F25 has outdated flatpak, don't run flatpak tests on it
-  if [[ $OS_VERSION == 25 ]]; then PKG_EXTRA="dnf-plugins-core desktop-file-utils"; else PKG_EXTRA="dnf-plugins-core desktop-file-utils flatpak ostree"; fi
+  PKG_EXTRA="dnf-plugins-core desktop-file-utils flatpak ostree"
   BUILDDEP="dnf builddep"
   PYTHON="python$PYTHON_VERSION"
   PYTEST="py.test-$PYTHON_VERSION"

--- a/tests/plugins/test_resolve_module_compose.py
+++ b/tests/plugins/test_resolve_module_compose.py
@@ -12,6 +12,7 @@ import json
 import responses
 import os
 import pytest
+import six
 from six.moves.urllib.parse import urlparse, parse_qs
 
 from atomic_reactor.inner import DockerBuildWorkflow
@@ -108,7 +109,11 @@ def test_resolve_module_compose(tmpdir, docker_tasker, specify_version):
     def handle_composes_post(request):
         assert request.headers['OIDC_access_token'] == 'green_eggs_and_ham'
 
-        body_json = json.loads(request.body.decode())
+        if isinstance(request.body, six.text_type):
+            body = request.body
+        else:
+            body = request.body.decode()
+        body_json = json.loads(body)
         assert body_json['source']['type'] == 'module'
         if specify_version:
             assert body_json['source']['source'] == MODULE_NSV


### PR DESCRIPTION
* Travis failures can be reproduced locally: 
`sudo env OS=centos OS_VERSION=7 ./test.sh` or 
`sudo env OS=fedora OS_VERSION=26 PYTHON_VERSION=3 ./test.sh`. 
By default it would run tests on CentOS 7
* Tests would run against actual packages in distributions, not latest from pypi (with exception of osbs-client and dockerfile-parse)