### PR TITLE
get_manifest_digests: skip version if registry/pulp didn't return required headers

### DIFF
--- a/atomic_reactor/plugins/post_pulp_pull.py
+++ b/atomic_reactor/plugins/post_pulp_pull.py
@@ -72,7 +72,8 @@ class PulpPullPlugin(PostBuildPlugin):
             if plugin['name'] is PLUGIN_PULP_PUSH_KEY:
                 media_types.append('application/json')
 
-        digests = get_manifest_digests(pullspec, registry.uri, self.insecure, self.secret)
+        digests = get_manifest_digests(pullspec, registry.uri, self.insecure, self.secret,
+                                       require_digest=False)
         if digests.v2:
             self.log.info("V2 schema 2 digest found, returning %s", self.workflow.builder.image_id)
             media_types.append('application/vnd.docker.distribution.manifest.v2+json')


### PR DESCRIPTION
Pulp won't return headers for schema 1 images, so get_manifest_digests should 
check those and not throw exception if throw_exception param is False