### PR TITLE
squash plugin:  Fix setup_method in squash test

### DIFF
--- a/tests/plugins/test_squash.py
+++ b/tests/plugins/test_squash.py
@@ -59,7 +59,7 @@ class MockInsideBuilder(object):
 
 class TestSquashPlugin(object):
 
-    def setup_method(self):
+    def setup_method(self, method):
         if MOCK:
             mock_docker()
         self.workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image')


### PR DESCRIPTION
The squash test was failing for me locally because of a missing
parameter, 'method'. Upstream docs seems to imply this is needed.

Adding in the unused parameter allows the test to work for me again.