### PR TITLE
logging: let docker-py handle utf8 and json decode

### DIFF
--- a/atomic_reactor/core.py
+++ b/atomic_reactor/core.py
@@ -432,10 +432,10 @@ class DockerTasker(LastLogger):
         logger.debug("image = '%s', insecure = '%s'", image, insecure)
         try:
             logs_gen = self.d.pull(image.to_str(tag=False), tag=image.tag,
-                                   insecure_registry=insecure, stream=True)
+                                   insecure_registry=insecure, decode=True, stream=True)
         except TypeError:
             # because changing api is fun
-            logs_gen = self.d.pull(image.to_str(tag=False), tag=image.tag, stream=True)
+            logs_gen = self.d.pull(image.to_str(tag=False), tag=image.tag, decode=True, stream=True)
         command_result = wait_for_command(logs_gen)
         self.last_logs = command_result.logs
         return image.to_str()
@@ -507,10 +507,10 @@ class DockerTasker(LastLogger):
             # push returns string composed of newline separated jsons; exactly what 'docker push'
             # outputs
             logs = self.d.push(image.to_str(tag=False), tag=image.tag, insecure_registry=insecure,
-                               stream=True)
+                               decode=True, stream=True)
         except TypeError:
             # because changing api is fun
-            logs = self.d.push(image.to_str(tag=False), tag=image.tag, stream=True)
+            logs = self.d.push(image.to_str(tag=False), tag=image.tag, decode=True, stream=True)
 
         command_result = wait_for_command(logs)
         self.last_logs = command_result.logs

--- a/atomic_reactor/core.py
+++ b/atomic_reactor/core.py
@@ -254,12 +254,12 @@ class DockerTasker(LastLogger):
         logger.info("building image '%s' from path '%s'", image, path)
         try:
             response = self.d.build(path=path, tag=image.to_str(), stream=stream,
-                                    nocache=not use_cache,
+                                    nocache=not use_cache, decode=True,
                                     rm=remove_im, forcerm=True, pull=False)  # returns generator
         except TypeError:
             # because changing api is fun
             response = self.d.build(path=path, tag=image.to_str(), stream=stream,
-                                    nocache=not use_cache,
+                                    nocache=not use_cache, decode=True,
                                     rm=remove_im, forcerm=True,)  # returns generator
         return response
 

--- a/atomic_reactor/core.py
+++ b/atomic_reactor/core.py
@@ -593,8 +593,9 @@ class DockerTasker(LastLogger):
         # returns bytes
         response = self.d.logs(container_id, stdout=True, stderr=stderr, stream=stream)
         if not stream:
-            response = response.decode("utf-8")  # py2 & 3 compat
-            response = [line for line in response.split('\n') if line]
+            if isinstance(response, bytes):
+                response = response.decode("utf-8")  # py2 & 3 compat
+            response = [line for line in response.splitlines() if line]
         return response
 
     def wait(self, container_id):

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -155,23 +155,17 @@ class CommandResult(object):
 
     def parse_item(self, item):
         """
-        :param item: str, json-encoded string
+        :param item: dict, decoded log data
         """
-        item = item.decode("utf-8")
-        try:
-            parsed_item = json.loads(item)
-        except ValueError:
-            parsed_item = None
-        else:
-            # append here just in case .get bellow fails
-            self._parsed_logs.append(parsed_item)
+        # append here just in case .get bellow fails
+        self._parsed_logs.append(item)
 
-        # make sure the json is a dictionary object
-        if isinstance(parsed_item, dict):
-            line = parsed_item.get("stream", "")
+        # make sure the log item is a dictionary object
+        if isinstance(item, dict):
+            line = item.get("stream", "")
         else:
-            parsed_item = None
             line = item
+            item = None
 
         for l in line.splitlines():
             l = l.strip()
@@ -179,11 +173,11 @@ class CommandResult(object):
             if l:
                 logger.debug(l)
 
-        if parsed_item is not None:
-            self._error = parsed_item.get("error", None)
-            self._error_detail = parsed_item.get("errorDetail", None)
+        if item is not None:
+            self._error = item.get("error", None)
+            self._error_detail = item.get("errorDetail", None)
             if self._error:
-                logger.error(item.strip())
+                logger.error(item)
 
     @property
     def parsed_logs(self):

--- a/tests/docker_mock.py
+++ b/tests/docker_mock.py
@@ -42,41 +42,42 @@ mock_image = \
 
 mock_images = None
 
-mock_logs = b'uid=0(root) gid=0(root) groups=10(wheel)'
+mock_logs = 'uid=0(root) gid=0(root) groups=10(wheel)'
 
 mock_build_logs = \
-    [b'{"stream":"Step 0 : FROM fedora:latest\\n"}\r\n',
-     b'{"status":"Pulling from fedora","id":"latest"}\r\n',
-     b'{"status":"Digest: sha256:c63476a082b960f6264e59ef0ff93a9169eac8daf59e24805e0382afdcc9082f"}\r\n',  # noqa
-     b'{"status":"Status: Image is up to date for fedora:latest"}\r\n',
-     b'{"stream":"Step 1 : RUN uname -a \\u0026\\u0026 env\\n"}\r\n',
-     b'{"stream":" ---\\u003e Running in 3600c91d1c40\\n"}\r\n',
-     b'{"stream":"Removing intermediate container 3600c91d1c40\\n"}\r\n',
-     b'{"stream":"Successfully built 1793c2380436\\n"}\r\n']
+    [{"stream": "Step 0 : FROM fedora:latest"},
+     {"status": "Pulling from fedora", "id": "latest"},
+     {"status": "Digest: sha256:c63476a082b960f6264e59ef0ff93a9169eac8daf59e24805e0382afdcc9082f"},  # noqa
+     {"status": "Status: Image is up to date for fedora:latest"},
+     {"stream": "Step 1 : RUN uname -a && env"},
+     {"stream": " ---> Running in 3600c91d1c40"},
+     {"stream": "Removing intermediate container 3600c91d1c40"},
+     {"stream": "Successfully built 1793c2380436"}]
 
 mock_build_logs_failed = mock_build_logs + \
-    [b'{"errorDetail":{"code":2,"message":"The command \\u0026{[/bin/sh -c ls -lha /a/b/c]} returned a non-zero code: 2"},\
-        "error":"The command \\u0026{[/bin/sh -c ls -lha /a/b/c]} returned a non-zero code: 2"}\r\n']  # noqa
+    [{"errorDetail": {"code": 2, "message":
+                      "The command &{[/bin/sh -c ls -lha /a/b/c]} returned a non-zero code: 2"},
+      "error": "The command &{[/bin/sh -c ls -lha /a/b/c]} returned a non-zero code: 2"}]  # noqa
 
 mock_pull_logs = \
-    [b'{"stream":"Trying to pull repository localhost:5000/busybox ..."}\r\n',
-     b'{"status":"Pulling image (latest) from localhost:5000/busybox","progressDetail":{},"id":"8c2e06607696"}',  # noqa
-     b'{"status":"Download complete","progressDetail":{},"id":"8c2e06607696"}',
-     b'{"status":"Status: Image is up to date for localhost:5000/busybox:latest"}\r\n']
+    [{"stream": "Trying to pull repository localhost:5000/busybox ..."},
+     {"status": "Pulling image (latest) from localhost:5000/busybox", "progressDetail": {}, "id": "8c2e06607696"},  # noqa
+     {"status": "Download complete", "progressDetail": {}, "id": "8c2e06607696"},
+     {"status": "Status: Image is up to date for localhost:5000/busybox:latest"}]
 
 mock_pull_logs_failed = \
-    [b'{"errorDetail":{"message":"Error: image ***:latest not found"},"error":"Error: image ***:latest not found"}']  # noqa
+    [{"errorDetail": {"message": "Error: image ***:latest not found"}, "error": "Error: image ***:latest not found"}]  # noqa
 
 mock_push_logs = \
-    [b'{"status":"The push refers to a repository [localhost:5000/busybox] (len: 1)"}\r\n',
-     b'{"status":"Image already exists","progressDetail":{},"id":"17583c7dd0da"}\r\n',
-     b'{"status":"Image already exists","progressDetail":{},"id":"d1592a710ac3"}\r\n'
-     b'{"status":"latest: digest: sha256:afe8a267153784d570bfea7d22699c612a61f984e2b9a93135660bb85a3113cf size: 2735"}\r\n']  # noqa
+    [{"status": "The push refers to a repository [localhost:5000/busybox] (len: 1)"},
+     {"status": "Image already exists", "progressDetail": {}, "id": "17583c7dd0da"},
+     {"status": "Image already exists", "progressDetail": {}, "id": "d1592a710ac3"},
+     {"status": "latest: digest: sha256:afe8a267153784d570bfea7d22699c612a61f984e2b9a93135660bb85a3113cf size: 2735"}]  # noqa
 
 mock_push_logs_failed = \
-    [b'{"status":"The push refers to a repository [localhost:5000/busybox] (len: 1)"}\r\n',
-     b'{"status":"Sending image list"}\r\n',
-     b'{"errorDetail":{"message":"Put http://localhost:5000/v1/repositories/busybox/: dial tcp [::1]:5000: getsockopt: connection refused"},"error":"Put http://localhost:5000/v1/repositories/busybox/: dial tcp [::1]:5000: getsockopt: connection refused"}\r\n']  # noqa
+    [{"status": "The push refers to a repository [localhost:5000/busybox] (len: 1)"},
+     {"status": "Sending image list"},
+     {"errorDetail": {"message": "Put http://localhost:5000/v1/repositories/busybox/: dial tcp [::1]:5000: getsockopt: connection refused"}, "error": "Put http://localhost:5000/v1/repositories/busybox/: dial tcp [::1]:5000: getsockopt: connection refused"}]  # noqa
 
 mock_info = {
     'BridgeNfIp6tables': True,
@@ -323,7 +324,7 @@ def mock_docker(build_should_fail=False,
     flexmock(docker.APIClient, import_image_from_stream=lambda url: mock_import_image)
 
     class GetImageResult(object):
-        data = b''
+        data = ''
 
         def __init__(self):
             self.fp = open(__file__, 'rb')

--- a/tests/plugins/test_tag_and_push.py
+++ b/tests/plugins/test_tag_and_push.py
@@ -32,42 +32,42 @@ DIGEST_V2 = 'sha256:85a7e3fb684787b86e64808c5b91d926afda9d6b35a0642a72d7a746452e
 
 DIGEST_LOG = 'sha256:hey-this-should-not-be-used'
 PUSH_LOGS_1_10 = [
-    b'{"status":"The push refers to a repository [localhost:5000/busybox]"}',
-    b'{"status":"Preparing","progressDetail":{},"id":"5f70bf18a086"}',
-    b'{"status":"Preparing","progressDetail":{},"id":"9508eff2c687"}',
-    b'{"status":"Pushing","progressDetail":{"current":721920,"total":1113436},"progress":"[================================\\u003e                  ] 721.9 kB/1.113 MB","id":"9508eff2c687"}',  # noqa
-    b'{"status":"Pushing","progressDetail":{"current":1024},"progress":"1.024 kB","id":"5f70bf18a086"}',  # noqa
-    b'{"status":"Pushing","progressDetail":{"current":820224,"total":1113436},"progress":"[====================================\\u003e              ] 820.2 kB/1.113 MB","id":"9508eff2c687"}',  # noqa
-    b'{"status":"Pushed","progressDetail":{},"id":"5f70bf18a086"}',
-    b'{"status":"Pushed","progressDetail":{},"id":"5f70bf18a086"}',
-    b'{"status":"Pushing","progressDetail":{"current":1300992,"total":1113436},"progress":"[==================================================\\u003e] 1.301 MB","id":"9508eff2c687"}',  # noqa
-    b'{"status":"Pushing","progressDetail":{"current":1310720,"total":1113436},"progress":"[==================================================\\u003e] 1.311 MB","id":"9508eff2c687"}',  # noqa
-    b'{"status":"Pushed","progressDetail":{},"id":"9508eff2c687"}',
-    b'{"status":"Pushed","progressDetail":{},"id":"9508eff2c687"}',
-    b'{"status":"latest: digest: ' + DIGEST_LOG.encode('utf-8') + b' size: 1920"}',
-    b'{"progressDetail":{},"aux":{"Tag":"latest","Digest":"' + DIGEST_LOG.encode('utf-8') + b'","Size":1920}}']  # noqa
+    {"status": "The push refers to a repository [localhost:5000/busybox]"},
+    {"status": "Preparing", "progressDetail": {}, "id": "5f70bf18a086"},
+    {"status": "Preparing", "progressDetail": {}, "id": "9508eff2c687"},
+    {"status": "Pushing", "progressDetail": {"current": 721920, "total": 1113436}, "progress":"[================================>                  ] 721.9 kB/1.113 MB", "id": "9508eff2c687"},  # noqa
+    {"status": "Pushing", "progressDetail": {"current": 1024}, "progress": "1.024 kB", "id": "5f70bf18a086"},  # noqa
+    {"status": "Pushing", "progressDetail": {"current": 820224, "total": 1113436}, "progress": "[====================================>              ] 820.2 kB/1.113 MB", "id": "9508eff2c687"},  # noqa
+    {"status": "Pushed", "progressDetail": {}, "id": "5f70bf18a086"},
+    {"status": "Pushed", "progressDetail": {}, "id": "5f70bf18a086"},
+    {"status": "Pushing", "progressDetail": {"current": 1300992, "total": 1113436}, "progress": "[==================================================>] 1.301 MB", "id": "9508eff2c687"},  # noqa
+    {"status": "Pushing", "progressDetail": {"current": 1310720, "total": 1113436}, "progress": "[==================================================>] 1.311 MB", "id": "9508eff2c687"},  # noqa
+    {"status": "Pushed", "progressDetail": {}, "id": "9508eff2c687"},
+    {"status": "Pushed", "progressDetail": {}, "id": "9508eff2c687"},
+    {"status": "latest: digest: + DIGEST_LOG.encode('utf-8') + size: 1920"},
+    {"progressDetail":{ }, "aux": {"Tag": "latest", "Digest": " + DIGEST_LOG.encode('utf-8') + ", "Size": 1920}}]  # noqa
 
 PUSH_LOGS_1_10_NOT_IN_STATUS = list(PUSH_LOGS_1_10)
 del PUSH_LOGS_1_10_NOT_IN_STATUS[-2]
 
 PUSH_LOGS_1_9 = [
-    b'{"status":"The push refers to a repository [172.17.42.1:5000/ns/test-image2] (len: 1)"}',
-    b'{"status":"Buffering to Disk","progressDetail":{},"id":"83bca0dcfd1b"}',
-    b'{"status":"Pushing","progressDetail":{"current":1,"total":32},"progress":"[=\\u003e                                                 ]      1 B/32 B","id":"83bca0dcfd1b"}',  # noqa
-    b'{"status":"Pushing","progressDetail":{"current":66813953,"total":66944370},"progress":"[=================================================\\u003e ] 66.81 MB/66.94 MB","id":"ded7cd95e059"}',  # noqa
-    b'{"status":"Pushing","progressDetail":{"current":66944370,"total":66944370},"progress":"[==================================================\\u003e] 66.94 MB/66.94 MB","id":"ded7cd95e059"}',  # noqa
-    b'{"status":"Image successfully pushed","progressDetail":{},"id":"ded7cd95e059"}',
-    b'{"status":"Image already exists","progressDetail":{},"id":"48ecf305d2cf"}',
-    b'{"status":"Digest: ' + DIGEST_LOG.encode('utf-8') + b'"}']
+    {"status": "The push refers to a repository [172.17.42.1:5000/ns/test-image2] (len: 1)"},
+    {"status": "Buffering to Disk", "progressDetail": {}, "id": "83bca0dcfd1b"},
+    {"status": "Pushing", "progressDetail": {"current": 1, "total": 32}, "progress": "[=>                                                 ]      1 B/32 B", "id": "83bca0dcfd1b"},  # noqa
+    {"status": "Pushing", "progressDetail": {"current": 66813953, "total": 66944370}, "progress": "[=================================================> ] 66.81 MB/66.94 MB", "id": "ded7cd95e059"},  # noqa
+    {"status": "Pushing", "progressDetail": {"current": 66944370, "total": 66944370}, "progress": "[==================================================>] 66.94 MB/66.94 MB", "id": "ded7cd95e059"},  # noqa
+    {"status": "Image successfully pushed", "progressDetail": {}, "id": "ded7cd95e059"},
+    {"status": "Image already exists", "progressDetail": {}, "id": "48ecf305d2cf"},
+    {"status": "Digest: + DIGEST_LOG.encode('utf-8') + "}]
 
 PUSH_LOGS_1_X = [  # don't remember which version does this
-    b'{"status":"The push refers to a repository [172.17.42.1:5000/ns/test-image2]"}',
-    b'{"status":"13cde7f2a483: Pushed "}',
-    b'{"status":"7.1-23: digest: ' + DIGEST_LOG.encode('utf-8') + b' size: 1539"}']
+    {"status": "The push refers to a repository [172.17.42.1:5000/ns/test-image2]"},
+    {"status": "13cde7f2a483: Pushed "},
+    {"status": "7.1-23: digest: + DIGEST_LOG.encode('utf-8') + size: 1539"}]
 
 PUSH_ERROR_LOGS = [
-    b'{"status":"The push refers to a repository [xyz/abc] (len: 1)"}\r\n',
-    b'{"errorDetail":{"message":"error message detail"},"error":"error message"}',
+    {"status": "The push refers to a repository [xyz/abc] (len: 1)"},
+    {"errorDetail": {"message": "error message detail"}, "error": "error message"},
 ]
 
 

--- a/tests/test_tasker.py
+++ b/tests/test_tasker.py
@@ -37,7 +37,7 @@ def setup_module(module):
         d.inspect_image(INPUT_IMAGE)
         setattr(module, 'HAS_IMAGE', True)
     except docker.errors.APIError:
-        _ = [x for x in d.pull(INPUT_IMAGE, decode=True, stream=True)]
+        [x for x in d.pull(INPUT_IMAGE, decode=True, stream=True)]
         setattr(module, 'HAS_IMAGE', False)
 
 

--- a/tests/test_tasker.py
+++ b/tests/test_tasker.py
@@ -37,7 +37,7 @@ def setup_module(module):
         d.inspect_image(INPUT_IMAGE)
         setattr(module, 'HAS_IMAGE', True)
     except docker.errors.APIError:
-        _ = [x for x in d.pull(INPUT_IMAGE, stream=True)]
+        _ = [x for x in d.pull(INPUT_IMAGE, decode=True, stream=True)]
         setattr(module, 'HAS_IMAGE', False)
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -101,10 +101,10 @@ def test_clone_git_repo(tmpdir):
 
 class TestCommandResult(object):
     @pytest.mark.parametrize(('item', 'expected'), [
-        (b'{"stream":"Step 0 : FROM ebbc51b7dfa5bcd993a[...]\\n"}\n',
+        ({"stream": "Step 0 : FROM ebbc51b7dfa5bcd993a[...]"},
          "Step 0 : FROM ebbc51b7dfa5bcd993a[...]"),
 
-        (b'this is not valid JSON\n',
+        ('this is not valid JSON',
          'this is not valid JSON'),
     ])
     def test_parse_item(self, item, expected):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -86,7 +86,7 @@ def test_wait_for_command():
         mock_docker()
 
     d = docker.APIClient()
-    logs_gen = d.pull(INPUT_IMAGE, stream=True)
+    logs_gen = d.pull(INPUT_IMAGE, decode=True, stream=True)
     assert wait_for_command(logs_gen) is not None
 
 


### PR DESCRIPTION
Rather than always calling .decode("utf-8") within CommandResult's
parse_item function and then interpreting the data as json, set
decode=True in callers to docker.Client.build, so decoding and de-json'ing
happens in docker-py, and we just get a nice clean generator full of
dicts.

Note: this also requires updating the inputs for
test_util.py::test_parse_item, since decoding is happening externally.

Signed-off-by: Jarod Wilson <jarod@redhat.com>