### PR TITLE
Pulp pull retries

### DIFF
--- a/atomic_reactor/plugins/post_pulp_sync.py
+++ b/atomic_reactor/plugins/post_pulp_sync.py
@@ -194,7 +194,8 @@ class PulpSyncPlugin(PostBuildPlugin):
 
         # Store the registry URI in the push configuration
         self.workflow.push_conf.add_pulp_registry(self.pulp_registry_name,
-                                                  pulp_registry)
+                                                  pulp_registry,
+                                                  server_side_sync=True)
 
         self.log.info("syncing from docker V2 registry %s",
                       self.docker_registry)

--- a/atomic_reactor/plugins/post_push_to_pulp.py
+++ b/atomic_reactor/plugins/post_push_to_pulp.py
@@ -164,7 +164,8 @@ class PulpPushPlugin(PostBuildPlugin):
         pulp_registry = self.pulp_handler.get_registry_hostname()
 
         self.workflow.push_conf.add_pulp_registry(self.pulp_handler.get_pulp_instance(),
-                                                  pulp_registry)
+                                                  pulp_registry,
+                                                  server_side_sync=False)
 
         # Return the set of qualified repo names for this image
         return top_layer, [ImageName(registry=pulp_registry, repo=repodata.registry_id, tag=tag)

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -32,7 +32,6 @@ from pkg_resources import resource_stream
 
 from importlib import import_module
 from requests.utils import guess_json_utf
-from time import sleep
 
 logger = logging.getLogger(__name__)
 
@@ -719,15 +718,10 @@ def get_manifest_digests(image, registry, insecure=False, dockercfg_path=None,
         media_type = get_manifest_media_type(version)
         headers = {'Accept': media_type}
 
-        for attempts in range(10):
-            response = query_registry(
-                image, registry, digest=None,
-                insecure=insecure, dockercfg_path=dockercfg_path,
-                version=version)
-            if response.status_code == 404:
-                sleep(1)
-            else:
-                break
+        response = query_registry(
+            image, registry, digest=None,
+            insecure=insecure, dockercfg_path=dockercfg_path,
+            version=version)
 
         # If the registry has a v2 manifest that can't be converted into a v1
         # manifest, the registry fails with status=400, and a error code of

--- a/tests/plugins/test_pulp_pull.py
+++ b/tests/plugins/test_pulp_pull.py
@@ -206,7 +206,12 @@ class TestPostPulpPull(object):
         # to make really sure we get a different string object back.
         workflow.postbuild_plugins_conf = json.loads(json.dumps(pulp_plugin))
 
-        plugin = PulpPullPlugin(tasker, workflow, insecure=insecure)
+        # Set the timeout parameters so that we retry exactly once, but quickly.
+        # With the get_manifest_digests() API, the 'broken_response' case isn't
+        # distinguishable from no manifest yet, so we retry until timout and then
+        # fall through to pulp_pull.
+        plugin = PulpPullPlugin(tasker, workflow, insecure=insecure,
+                                timeout=0.1, retry_delay=0.25)
         results, version = plugin.run()
 
         # Plugin return value is the new ID and schema

--- a/tests/plugins/test_pulp_sync.py
+++ b/tests/plugins/test_pulp_sync.py
@@ -509,7 +509,8 @@ class TestPostPulpSync(object):
             .and_return(mockpulp))
 
         if already_exists:
-            workflow.push_conf.add_pulp_registry(env, mockpulp.registry)
+            workflow.push_conf.add_pulp_registry(env, mockpulp.registry,
+                                                 server_side_sync=False)
 
         plugin = PulpSyncPlugin(tasker=None,
                                 workflow=workflow,

--- a/tests/test_inner.py
+++ b/tests/test_inner.py
@@ -1282,3 +1282,25 @@ def test_show_version(request, has_version):
     workflow.build_docker_image()
     expected_log_message = ("build json was built by osbs-client %s", VERSION)
     assert (expected_log_message in fake_logger.debugs) == has_version
+
+
+def test_add_pulp_registry():
+    push_conf = atomic_reactor.inner.PushConf()
+
+    push_conf.add_pulp_registry("example.com", "http://example.com", False)
+    assert push_conf.pulp_registries[0].name == "example.com"
+    assert push_conf.pulp_registries[0].uri == "http://example.com"
+    assert not push_conf.pulp_registries[0].server_side_sync
+
+    push_conf.add_pulp_registry("example.com", "http://example.com", True)
+    assert push_conf.pulp_registries[0].server_side_sync
+    push_conf.add_pulp_registry("example.com", "http://example.com", False)
+    assert push_conf.pulp_registries[0].server_side_sync
+
+    with pytest.raises(RuntimeError):
+        push_conf.add_pulp_registry("example2.com", None, False)
+    with pytest.raises(RuntimeError):
+        push_conf.add_pulp_registry("example.com", "http://example2.com", False)
+
+    push_conf.add_pulp_registry("registry2.example.com", "http://registry2.example.com", True)
+    assert len(push_conf.pulp_registries) == 2


### PR DESCRIPTION
The main point of this PR is to move the retrying when pulp_pull calls get_manifest_digests() back into the plugin, since it's not actually generic. The patch uses the same retry logic as was already in the plugin for the pull.

However, since the default parameters for the plugin wait for 10 minutes rather than the hardcoded 10 second retry that was added to get_manifest_digests(), this makes a problem much worse - if no manifests ever show up, then we'll retry until we time out. In my understanding, this will be the case when only pulp_push is configured (osbs-client is configured with registry_api_versions=v1).

The second patch in this PR deals with this by recording whether a pulp registry was used for syncing or just for pushing. If this problem is considered unimportant, it could be dropped for simplicity.