### PR TITLE
Tag base images with the OpenShift build name

### DIFF
--- a/atomic_reactor/plugin.py
+++ b/atomic_reactor/plugin.py
@@ -17,6 +17,7 @@ import traceback
 import imp
 import datetime
 import inspect
+import time
 
 from atomic_reactor.build import BuildResult
 from atomic_reactor.util import process_substitutions
@@ -570,3 +571,20 @@ class InputPluginsRunner(PluginsRunner):
         if self.autoinput:
             result['auto'] = result.pop(autousable)
         return result
+
+
+# Built-in plugins
+class PreBuildSleepPlugin(PreBuildPlugin):
+    """
+    Sleep for a specified number of seconds.
+
+    This plugin is only intended to be used for debugging.
+    """
+
+    key = 'pre_sleep'
+
+    def __init__(self, tasker, workflow, seconds=60):
+        self.seconds = seconds
+
+    def run(self):
+        time.sleep(self.seconds)

--- a/tests/docker_mock.py
+++ b/tests/docker_mock.py
@@ -193,6 +193,7 @@ mock_inspect_container = {
 def _find_image(img, ignore_registry=False):
     global mock_images
 
+    img = ImageName.parse(img).to_str(explicit_tag=True)
     for im in mock_images:
         im_name = im['RepoTags'][0]
         if im_name == img:

--- a/tests/docker_mock.py
+++ b/tests/docker_mock.py
@@ -193,14 +193,14 @@ mock_inspect_container = {
 def _find_image(img, ignore_registry=False):
     global mock_images
 
-    img = ImageName.parse(img).to_str(explicit_tag=True)
+    tagged_img = ImageName.parse(img).to_str(explicit_tag=True)
     for im in mock_images:
         im_name = im['RepoTags'][0]
-        if im_name == img:
+        if im_name == tagged_img:
             return im
         if ignore_registry:
             im_name_wo_reg = ImageName.parse(im_name).to_str(registry=False)
-            if im_name_wo_reg == img:
+            if im_name_wo_reg == tagged_img:
                 return im
 
     return None


### PR DESCRIPTION
This avoids a race condition in which two builds are contending over the as-pulled image tag:

1. build A starts
2. build B starts
3. build A is nearly finished and is about to remove the parent image
4. build B tags the parent image
5. build A removes the parent image
6. build B tries to e.g. inspect the parent image, or build the Dockerfile

To avoid this race, each build adds an additional tag to the parent image it pulls, using the value of the OpenShift build name. This keeps the image around until the build is done with it at the end.

The race condition is then between pulling the image and tagging it with this unique ID. This is addressed by retrying the pull if tagging fails.

Also included in this pull request is a plugin for helping to test this.

Signed-off-by: Tim Waugh <twaugh@redhat.com>