### PR TITLE
Logging: try to disentangle overlapping log entries

### DIFF
--- a/atomic_reactor/__init__.py
+++ b/atomic_reactor/__init__.py
@@ -50,6 +50,9 @@ class EncodedStream(object):
             self.binarystream.write(text.encode(self.encoding))
         else:
             self.binarystream.write(text)
+        # We need to flush regularly, because launching plugins or running
+        # subprocess calls breaks serialization of logging output otherwise
+        self.binarystream.flush()
 
     def __del__(self):
         try:

--- a/atomic_reactor/__init__.py
+++ b/atomic_reactor/__init__.py
@@ -86,5 +86,8 @@ def set_logging(name="atomic_reactor", level=logging.DEBUG, handler=None):
     # add ch to logger
     logger.addHandler(handler)
 
+    logger = logging.getLogger('osbs')
+    for hdlr in list(logger.handlers):  # make a copy so it doesn't change
+        hdlr.setFormatter(formatter)
 
 set_logging(level=logging.WARNING)  # override this however you want


### PR DESCRIPTION
We have a few issues with the way we do logging right now. For the most part, the crux of the problem seems to be that python only serializes log entries from a single process when logging to a file or file-like handler, such as the StreamHandler we currently log to. Multiple threads are fine, but when you fire off a subprocess call, all bets are off, and we do actually have a fair number of those throughout the code, which appear to be the primary offender for getting themselves logged right in the middle of other log entries.