### PR TITLE
koji_import: use get_orchestrator_build_logs in plugin

### DIFF
--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -9,7 +9,9 @@ of the BSD license. See the LICENSE file for details.
 from __future__ import unicode_literals
 
 import json
+import os
 import time
+from tempfile import NamedTemporaryFile
 
 from atomic_reactor import start_time as atomic_reactor_start_time
 from atomic_reactor.plugin import ExitPlugin
@@ -23,10 +25,12 @@ from atomic_reactor.constants import (PLUGIN_KOJI_IMPORT_PLUGIN_KEY,
                                       PLUGIN_PULP_SYNC_KEY,
                                       PLUGIN_FETCH_WORKER_METADATA_KEY,
                                       PLUGIN_GROUP_MANIFESTS_KEY)
-from atomic_reactor.util import (get_build_json, get_preferred_label, df_parser, ImageName)
-from atomic_reactor.koji_util import create_koji_session
+from atomic_reactor.util import (get_build_json, get_preferred_label,
+                                 df_parser, ImageName, get_checksums)
+from atomic_reactor.koji_util import (create_koji_session, Output, KojiUploadLogger)
 from osbs.conf import Configuration
 from osbs.api import OSBS
+from osbs.exceptions import OsbsException
 
 
 class KojiImportPlugin(ExitPlugin):
@@ -58,6 +62,7 @@ class KojiImportPlugin(ExitPlugin):
                  verify_ssl=True, use_auth=True,
                  koji_ssl_certs=None, koji_proxy_user=None,
                  koji_principal=None, koji_keytab=None,
+                 blocksize=None,
                  target=None, poll_interval=5):
         """
         constructor
@@ -72,6 +77,7 @@ class KojiImportPlugin(ExitPlugin):
         :param koji_proxy_user: str, user to log in as (requires hub config)
         :param koji_principal: str, Kerberos principal (must specify keytab)
         :param koji_keytab: str, keytab name (must specify principal)
+        :param blocksize: int, blocksize to use for uploading files
         :param target: str, koji target
         :param poll_interval: int, seconds between Koji task status requests
         """
@@ -84,6 +90,7 @@ class KojiImportPlugin(ExitPlugin):
         self.koji_principal = koji_principal
         self.koji_keytab = koji_keytab
 
+        self.blocksize = blocksize
         self.target = target
         self.poll_interval = poll_interval
 
@@ -148,6 +155,46 @@ class KojiImportPlugin(ExitPlugin):
                 buildroots.append(instance)
 
         return buildroots
+
+    def get_logs(self):
+        """
+        Build list of log files
+
+        :return: list, of log files
+        """
+
+        logs = None
+        output = []
+
+        # Collect logs from server
+        try:
+            logs = self.osbs.get_orchestrator_build_logs(self.build_id)
+        except OsbsException as ex:
+            self.log.error("unable to get build logs: %r", ex)
+            return output
+        except TypeError:
+            # Older osbs-client has no get_orchestrator_build_logs
+            self.log.error("OSBS client does not support get_orchestrator_build_logs")
+            return output
+
+        platform_logs = {}
+        for entry in logs:
+            platform = entry.platform
+            if platform not in platform_logs:
+                filename = 'orchestrator' if platform is None else platform
+                platform_logs[platform] = NamedTemporaryFile(prefix="%s-%s" %
+                                                             (self.build_id, filename),
+                                                             suffix=".log", mode='wb')
+            platform_logs[platform].write(entry.line.encode('utf-8'))
+
+        for platform, logfile in platform_logs.items():
+            logfile.flush()
+            filename = 'orchestrator' if platform is None else platform
+            metadata = self.get_output_metadata(logfile.name, "%s.log" % filename)
+            output.append(Output(file=logfile, metadata=metadata))
+
+        return output
+
 
     def set_help(self, extra, worker_metadatas):
         all_annotations = [get_worker_build_info(self.workflow, platform).build.get_annotations()
@@ -217,6 +264,21 @@ class KojiImportPlugin(ExitPlugin):
                             self.log.debug("reset tags to so that docker is %s",
                                            instance['extra']['docker'])
 
+    def get_output_metadata(self, path, filename):
+        """
+        Describe a file by its metadata.
+
+        :return: dict
+        """
+
+        checksums = get_checksums(path, ['md5'])
+        metadata = {'filename': filename,
+                    'filesize': os.path.getsize(path),
+                    'checksum': checksums['md5sum'],
+                    'checksum_type': 'md5'}
+
+        return metadata
+
     def get_build(self, metadata, worker_metadatas):
         start_time = int(atomic_reactor_start_time)
 
@@ -272,6 +334,16 @@ class KojiImportPlugin(ExitPlugin):
         return build
 
     def combine_metadata_fragments(self):
+        def add_buildroot_id(output, buildroot_id):
+            logfile, metadata = output
+            metadata.update({'buildroot_id': buildroot_id})
+            return Output(file=logfile, metadata=metadata)
+
+        def add_log_type(output):
+            logfile, metadata = output
+            metadata.update({'type': 'log', 'arch': 'noarch'})
+            return Output(file=logfile, metadata=metadata)
+
         try:
             metadata = get_build_json()["metadata"]
             self.build_id = metadata["name"]
@@ -284,7 +356,11 @@ class KojiImportPlugin(ExitPlugin):
         worker_metadatas = self.workflow.postbuild_results.get(PLUGIN_FETCH_WORKER_METADATA_KEY)
         build = self.get_build(metadata, worker_metadatas)
         buildroot = self.get_buildroot(worker_metadatas)
+        buildroot_id = buildroot[0]['id']
         output = self.get_output(worker_metadatas)
+        output_files = [add_log_type(add_buildroot_id(md, buildroot_id))
+                        for md in self.get_logs()]
+        output.extend([of.metadata for of in output_files])
 
         koji_metadata = {
             'metadata_version': metadata_version,
@@ -292,7 +368,7 @@ class KojiImportPlugin(ExitPlugin):
             'buildroots': buildroot,
             'output': output,
         }
-        return koji_metadata
+        return koji_metadata, output_files
 
     def login(self):
         """
@@ -309,6 +385,28 @@ class KojiImportPlugin(ExitPlugin):
             "krb_keytab": str(self.koji_keytab)
         }
         return create_koji_session(str(self.kojihub), auth_info)
+
+    def upload_file(self, session, output, serverdir):
+        """
+        Upload a file to koji
+
+        :return: str, pathname on server
+        """
+        name = output.metadata['filename']
+        self.log.debug("uploading %r to %r as %r",
+                       output.file.name, serverdir, name)
+
+        kwargs = {}
+        if self.blocksize is not None:
+            kwargs['blocksize'] = self.blocksize
+            self.log.debug("using blocksize %d", self.blocksize)
+
+        upload_logger = KojiUploadLogger(self.log)
+        session.uploadWrapper(output.file.name, serverdir, name=name,
+                              callback=upload_logger.callback, **kwargs)
+        path = os.path.join(serverdir, name)
+        self.log.debug("uploaded %r", path)
+        return path
 
     def run(self):
         """
@@ -329,7 +427,16 @@ class KojiImportPlugin(ExitPlugin):
 
         server_dir = get_koji_upload_dir(self.workflow)
 
-        koji_metadata = self.combine_metadata_fragments()
+        koji_metadata, output_files = self.combine_metadata_fragments()
+
+        try:
+            for output in output_files:
+                if output.file:
+                    self.upload_file(session, output, server_dir)
+        finally:
+            for output in output_files:
+                if output.file:
+                    output.file.close()
 
         try:
             build_info = session.CGImport(koji_metadata, server_dir)

--- a/atomic_reactor/plugins/exit_koji_promote.py
+++ b/atomic_reactor/plugins/exit_koji_promote.py
@@ -8,7 +8,6 @@ of the BSD license. See the LICENSE file for details.
 
 from __future__ import unicode_literals
 
-from collections import namedtuple
 import json
 import os
 import random
@@ -32,34 +31,11 @@ from atomic_reactor.util import (get_version_of_tools, get_checksums,
                                  get_build_json, get_preferred_label,
                                  get_docker_architecture, df_parser,
                                  are_plugins_in_order)
-from atomic_reactor.koji_util import create_koji_session, tag_koji_build
+from atomic_reactor.koji_util import (create_koji_session, tag_koji_build,
+                                      Output, KojiUploadLogger)
 from osbs.conf import Configuration
 from osbs.api import OSBS
 from osbs.exceptions import OsbsException
-
-# An output file and its metadata
-Output = namedtuple('Output', ['file', 'metadata'])
-
-
-class KojiUploadLogger(object):
-    def __init__(self, logger, notable_percent=10):
-        self.logger = logger
-        self.notable_percent = notable_percent
-        self.last_percent_done = 0
-
-    def callback(self, offset, totalsize, size, t1, t2):  # pylint: disable=W0613
-        if offset == 0:
-            self.logger.debug("upload size: %.1fMiB", totalsize / 1024.0 / 1024)
-
-        if not totalsize or not t1:
-            return
-
-        percent_done = 100 * offset / totalsize
-        if (percent_done >= 99 or
-                percent_done - self.last_percent_done >= self.notable_percent):
-            self.last_percent_done = percent_done
-            self.logger.debug("upload: %d%% done (%.1f MiB/sec)",
-                              percent_done, size / t1 / 1024 / 1024)
 
 
 class KojiPromotePlugin(ExitPlugin):


### PR DESCRIPTION
Make use of osbs-client's new get_orchestrator_build_logs api to acquire
orchestrator and per-arch log files when importing a build.

Signed-off-by: Jarod Wilson <jarod@redhat.com>