### PR TITLE
Allow pulp_pull to act as an exit plugin

### DIFF
--- a/atomic_reactor/plugins/post_pulp_pull.py
+++ b/atomic_reactor/plugins/post_pulp_pull.py
@@ -16,7 +16,7 @@ discover the image ID Docker will give it.
 from __future__ import unicode_literals
 
 from atomic_reactor.constants import PLUGIN_PULP_PUSH_KEY, PLUGIN_PULP_SYNC_KEY
-from atomic_reactor.plugin import PostBuildPlugin
+from atomic_reactor.plugin import PostBuildPlugin, ExitPlugin
 from atomic_reactor.plugins.exit_remove_built_image import defer_removal
 from atomic_reactor.util import get_manifest_digests
 from docker.errors import NotFound
@@ -28,7 +28,11 @@ class CraneTimeoutError(Exception):
     pass
 
 
-class PulpPullPlugin(PostBuildPlugin):
+# Note: We use multiple inheritance here only to make it explicit that
+# this plugin needs to act as both an exit plugin (since arrangement
+# version 4) and as a post-build plugin (arrangement version < 4). In
+# fact, ExitPlugin is a subclass of PostBuildPlugin.
+class PulpPullPlugin(ExitPlugin, PostBuildPlugin):
     key = 'pulp_pull'
     is_allowed_to_fail = False
 

--- a/tests/plugins/test_pulp_pull.py
+++ b/tests/plugins/test_pulp_pull.py
@@ -6,6 +6,7 @@ This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
 
+from atomic_reactor.plugin import PostBuildPlugin, ExitPlugin
 from atomic_reactor.plugins.post_pulp_pull import (PulpPullPlugin,
                                                    CraneTimeoutError)
 from atomic_reactor.inner import TagConf, PushConf
@@ -336,3 +337,10 @@ class TestPostPulpPull(object):
 
         # Image ID is updated in workflow
         assert workflow.builder.image_id == test_id
+
+    def test_plugin_type(self):
+        # arrangement versions < 4
+        assert issubclass(PulpPullPlugin, PostBuildPlugin)
+
+        # arrangement version >= 4
+        assert issubclass(PulpPullPlugin, ExitPlugin)


### PR DESCRIPTION
This is required for arrangement version 4.

This is required for arrangement version 4, in which pulp_pull runs as an exit plugin. It must run in that phase because it has to run after pulp_publish, also an exit plugin -- pulp_publish has work to do when a build is failing, i.e. remove v1 content.
    
For arrangement versions earlier than 4, pulp_pull must still be able to run as a post-build plugin.

Signed-off-by: Tim Waugh <twaugh@redhat.com>