### PR TITLE
Fix pulp pull

### DIFF
--- a/atomic_reactor/plugins/post_pulp_pull.py
+++ b/atomic_reactor/plugins/post_pulp_pull.py
@@ -77,6 +77,11 @@ class PulpPullPlugin(ExitPlugin, PostBuildPlugin):
             sleep(self.retry_delay)
 
     def run(self):
+        # Only run if the build was successful
+        if self.workflow.build_process_failed:
+            self.log.info("Not running for failed build")
+            return None, []
+
         # Work out the name of the image to pull
         assert self.workflow.tag_conf.unique_images  # must be set
         image = self.workflow.tag_conf.unique_images[0]

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -763,7 +763,7 @@ def get_manifest_digests(image, registry, insecure=False, dockercfg_path=None,
 
         # set it to truthy value so that koji_import would know pulp supports these digests
         digests[version] = True
-        logger.warning('received_media_type=%s', received_media_type)
+        logger.debug('received_media_type=%s', received_media_type)
 
         if not response.headers.get('Docker-Content-Digest'):
             logger.warning('Unable to fetch digest for %s, no Docker-Content-Digest header',


### PR DESCRIPTION
It was needlessly retrying its requests for media types. We only need to retry if we see a 404 response.

Signed-off-by: Tim Waugh <twaugh@redhat.com>