### PR TITLE
koji_import: re-write pull specifications for Crane as needed

### DIFF
--- a/atomic_reactor/plugins/post_koji_upload.py
+++ b/atomic_reactor/plugins/post_koji_upload.py
@@ -473,7 +473,7 @@ class KojiUploadPlugin(PostBuildPlugin):
 
         digests = self.get_digests()
         repositories = self.get_repositories(digests)
-        tags = set(image.tag for image in self.workflow.tag_conf.primary_images)
+        tags = set(image.tag for image in self.workflow.tag_conf.images)
         metadata, output = self.get_image_output(arch)
         metadata.update({
             'arch': arch,

--- a/tests/plugins/test_koji_upload.py
+++ b/tests/plugins/test_koji_upload.py
@@ -834,7 +834,8 @@ class TestKojiUpload(object):
         assert isinstance(tags, list)
         expected_tags = set([version,
                              "{}-{}".format(version, release),
-                             'latest'])
+                             'latest',
+                             "{}-timestamp".format(version)])
         if additional_tags:
             expected_tags.update(additional_tags)
 


### PR DESCRIPTION
When Pulp and Koji integration are both in use, Koji metadata created by worker builds has incorrect pullspecs in the extra.docker.repositories field for the docker-image output. This is because the worker build only knows about the 'sync' Docker registry (used for syncing images into Pulp).

In this situation, koji_import needs to re-write these pull specifications so they use Pulp's Crane instead of the Docker registry.

Signed-off-by: Tim Waugh <twaugh@redhat.com>