### PR TITLE
Add 'sha256:' prefix to image ID if needed

### DIFF
--- a/atomic_reactor/plugins/build_docker_api.py
+++ b/atomic_reactor/plugins/build_docker_api.py
@@ -48,4 +48,8 @@ class DockerApiPlugin(BuildStepPlugin):
                                fail_reason=command_result.error)
         else:
             image_id = builder.get_built_image_info()['Id']
+            if ':' not in image_id:
+                # Older versions of the daemon do not include the prefix
+                image_id = 'sha256:{}'.format(image_id)
+
             return BuildResult(logs=command_result.logs, image_id=image_id)


### PR DESCRIPTION
Older versions of Docker need this.

Signed-off-by: Tim Waugh <twaugh@redhat.com>