### PR TITLE
koji_import: don't overwrite 'id' with None

### DIFF
--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -117,7 +117,8 @@ class KojiImportPlugin(ExitPlugin):
                     if platform == "x86_64" and has_pulp_pull:
                         exit_results = self.workflow.exit_results
                         image_id, _ = exit_results[PLUGIN_PULP_PULL_KEY]
-                        instance['extra']['docker']['id'] = image_id
+                        if image_id is not None:
+                            instance['extra']['docker']['id'] = image_id
 
                     # update repositories to point to Crane
                     if crane_registry:

--- a/tests/plugins/test_koji_import.py
+++ b/tests/plugins/test_koji_import.py
@@ -1045,11 +1045,15 @@ class TestKojiImport(object):
          False),
     ])
     @pytest.mark.parametrize('tag_later', (True, False))
-    @pytest.mark.parametrize('pulp_pull', (("abcdef01234567", 'v1'), False))
+    @pytest.mark.parametrize('pulp_pull,expect_id', (
+        (("abcdef01234567", ['v1']), 'abcdef01234567'),
+        ((None, ['v1', 'v2']), '123456'),
+        (False, '123456'),
+    ))
     def test_koji_import_success(self, tmpdir, apis, docker_registry,
                                  pulp_registries,
                                  target, os_env, has_config, is_autorebuild,
-                                 tag_later, pulp_pull):
+                                 tag_later, pulp_pull, expect_id):
         session = MockedClientSession('')
         # When target is provided koji build will always be tagged,
         # either by koji_import or koji_tag_build.
@@ -1105,7 +1109,7 @@ class TestKojiImport(object):
         if pulp_pull:
             for output in output_files:
                 if 'extra' in output:
-                    assert output['extra']['docker']['id'] == pulp_pull[0]
+                    assert output['extra']['docker']['id'] == expect_id
 
         assert set(build.keys()) == set([
             'name',


### PR DESCRIPTION
When pulp_pull sees a v2 digest from Crane it returns None. In this case, don't overwrite the reported image ID.

Signed-off-by: Tim Waugh <twaugh@redhat.com>