### PR TITLE
exit_store_metadata: use repos from pulp_pull in exit plugins if available

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -73,6 +73,7 @@ PLUGIN_PULP_TAG_KEY = 'pulp_tag'
 PLUGIN_ADD_FILESYSTEM_KEY = 'add_filesystem'
 PLUGIN_FETCH_WORKER_METADATA_KEY = 'fetch_worker_metadata'
 PLUGIN_GROUP_MANIFESTS_KEY = 'group_manifests'
+PLUGIN_BUILD_ORCHESTRATE_KEY = 'orchestrate_build'
 
 # max retries for docker requests
 DOCKER_MAX_RETRIES = 3

--- a/atomic_reactor/plugins/build_orchestrate_build.py
+++ b/atomic_reactor/plugins/build_orchestrate_build.py
@@ -24,7 +24,7 @@ from atomic_reactor.plugin import BuildStepPlugin, BuildCanceledException
 from atomic_reactor.plugins.pre_reactor_config import get_config
 from atomic_reactor.plugins.pre_check_and_set_rebuild import is_rebuild
 from atomic_reactor.util import get_preferred_label, df_parser
-from atomic_reactor.constants import PLUGIN_ADD_FILESYSTEM_KEY
+from atomic_reactor.constants import PLUGIN_ADD_FILESYSTEM_KEY, PLUGIN_BUILD_ORCHESTRATE_KEY
 from osbs.api import OSBS
 from osbs.exceptions import OsbsException
 from osbs.conf import Configuration
@@ -155,7 +155,7 @@ class OrchestrateBuildPlugin(BuildStepPlugin):
     CONTAINER_FILENAME = 'container.yaml'
     UNREACHABLE_CLUSTER_LOAD = object()
 
-    key = 'orchestrate_build'
+    key = PLUGIN_BUILD_ORCHESTRATE_KEY
 
     def __init__(self, tasker, workflow, platforms, build_kwargs,
                  osbs_client_config=None, worker_build_image=None,


### PR DESCRIPTION
Not sure if tests were updated correctly, but actual code was tested with `next` branch and works