### PR TITLE
janitor: clean up lint errors

### DIFF
--- a/atomic_reactor/__init__.py
+++ b/atomic_reactor/__init__.py
@@ -15,7 +15,7 @@ from os import fdopen, dup
 import sys
 import time
 
-from atomic_reactor.version import __version__
+from atomic_reactor.version import __version__  # noqa
 
 try:
     from osbs.constants import ATOMIC_REACTOR_LOGGING_FMT
@@ -92,5 +92,6 @@ def set_logging(name="atomic_reactor", level=logging.DEBUG, handler=None):
     logger = logging.getLogger('osbs')
     for hdlr in list(logger.handlers):  # make a copy so it doesn't change
         hdlr.setFormatter(formatter)
+
 
 set_logging(level=logging.WARNING)  # override this however you want

--- a/atomic_reactor/cli/main.py
+++ b/atomic_reactor/cli/main.py
@@ -74,7 +74,9 @@ def construct_kwargs(**kwargs):
     recognized_kwargs = ['image', 'parent_registry', 'parent_registry_insecure',
                          'target_registries', 'target_registries_insecure',
                          'dont_pull_base_image']
-    is_recognized_kwarg = lambda x: x in recognized_kwargs or x.startswith('source__')
+
+    def is_recognized_kwarg(x):
+        return x in recognized_kwargs or x.startswith('source__')
 
     for k, v in kwargs.items():
         if is_recognized_kwarg(k):

--- a/atomic_reactor/plugin.py
+++ b/atomic_reactor/plugin.py
@@ -519,7 +519,6 @@ class InputPlugin(Plugin):
         :param build_json: dict, build json
         :return: dict, substituted build json
         """
-        print(self.substitutions)
         process_substitutions(build_json, self.substitutions)
         return build_json
 

--- a/atomic_reactor/plugins/pre_inject_yum_repo.py
+++ b/atomic_reactor/plugins/pre_inject_yum_repo.py
@@ -20,7 +20,10 @@ logger = None
 
 def alter_yum_commands(df, wrap_str):
     regex = re.compile(r"RUN\s+(?P<yum_command>yum((\s.+\\\n)+)?(.+))", re.MULTILINE)
-    sub_func = lambda match: wrap_str % {'yum_command': match.group('yum_command').rstrip()}
+
+    def sub_func(match):
+        return wrap_str % {'yum_command': match.group('yum_command').rstrip()}
+
     return regex.sub(sub_func, df)
 
 

--- a/tests/plugins/test_pulp_publish.py
+++ b/tests/plugins/test_pulp_publish.py
@@ -143,7 +143,6 @@ def test_pulp_publish_success(caplog):
     tasker, workflow = prepare(success=True)
     plugin = PulpPublishPlugin(tasker, workflow, 'pulp_registry_name')
 
-
     (flexmock(dockpulp.Pulp).should_receive('crane')
      .with_args(set(['redhat-image-name1',
                      'redhat-image-name3',

--- a/tests/plugins/test_pulp_pull.py
+++ b/tests/plugins/test_pulp_pull.py
@@ -7,11 +7,9 @@ of the BSD license. See the LICENSE file for details.
 """
 
 from atomic_reactor.plugin import PostBuildPlugin, ExitPlugin
-from atomic_reactor.plugins.post_pulp_pull import (PulpPullPlugin,
-                                                   CraneTimeoutError)
+from atomic_reactor.plugins.post_pulp_pull import PulpPullPlugin
 from atomic_reactor.inner import TagConf, PushConf
 from atomic_reactor.util import ImageName
-from docker.errors import NotFound
 
 from flexmock import flexmock
 import pytest

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -135,8 +135,6 @@ def test_clone_git_repo_by_sha1(tmpdir):
     tmpdir_path = str(tmpdir.realpath())
     commit_id = clone_git_repo(DOCKERFILE_GIT, tmpdir_path, commit=DOCKERFILE_SHA1)
     assert commit_id is not None
-    print(six.text_type(commit_id))
-    print(commit_id)
     assert six.text_type(commit_id, encoding="ascii") == six.text_type(DOCKERFILE_SHA1)
     assert len(commit_id) == 40  # current git hashes are this long
     assert os.path.isdir(os.path.join(tmpdir_path, '.git'))


### PR DESCRIPTION
A couple of lint errors have crept back into the system, so get rid of them.
There should be no functional changes here.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>