### PR TITLE
Add new plugin compare_components

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -75,6 +75,7 @@ PLUGIN_FETCH_WORKER_METADATA_KEY = 'fetch_worker_metadata'
 PLUGIN_GROUP_MANIFESTS_KEY = 'group_manifests'
 PLUGIN_BUILD_ORCHESTRATE_KEY = 'orchestrate_build'
 PLUGIN_KOJI_PARENT_KEY = 'koji_parent'
+PLUGIN_COMPARE_COMPONENTS_KEY = 'compare_components'
 
 # max retries for docker requests
 DOCKER_MAX_RETRIES = 3

--- a/atomic_reactor/plugins/post_compare_components.py
+++ b/atomic_reactor/plugins/post_compare_components.py
@@ -1,0 +1,112 @@
+"""
+Copyright (c) 2017 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+from atomic_reactor.plugin import PostBuildPlugin
+from atomic_reactor.constants import (PLUGIN_COMPARE_COMPONENTS_KEY,
+                                      PLUGIN_FETCH_WORKER_METADATA_KEY)
+
+
+SUPPORTED_TYPES = ("rpm",)
+
+
+class CompareComponentsPlugin(PostBuildPlugin):
+    """
+    Compare components from each worker build and verify the same version was
+    on each worker.
+    """
+
+    key = PLUGIN_COMPARE_COMPONENTS_KEY
+    is_allowed_to_fail = False
+
+    def rpm_compare(self, a, b):
+        """
+        Compare rpm component version 'a' with 'b'.
+        'name' is implied equal as it is the key() lookup
+        """
+        if a['version'] == b['version'] and \
+           a['release'] == b['release'] and \
+           a['signature'] == b['signature']:
+            return
+
+        raise ValueError("%s != %s" % (a, b))
+
+    def get_component_list_from_workers(self, worker_metadatas):
+        """
+        Find the component lists from each worker build.
+
+        The components that are interesting are under the 'output' key.  The
+        buildhost's components are ignored.
+
+        Inside the 'output' key are various 'instances'.  The only 'instance'
+        with a 'component list' is the 'docker-image' instance.  The 'log'
+        instances are ignored for now.
+
+        Reference plugin post_koji_upload for details on how this is created.
+
+        :return: list of component lists
+        """
+        comp_list = []
+        for platform in sorted(worker_metadatas.keys()):
+            for instance in worker_metadatas[platform]['output']:
+                if instance['type'] == 'docker-image':
+                    if 'components' not in instance or not instance['components']:
+                        self.log.warn("Missing 'components' key in 'output' metadata instance: %s",
+                                      instance)
+                        continue
+
+                    comp_list.append(instance['components'])
+
+        return comp_list
+
+    def run(self):
+        """
+        Run the plugin.
+        """
+
+        worker_metadatas = self.workflow.postbuild_results.get(PLUGIN_FETCH_WORKER_METADATA_KEY)
+        comp_list = self.get_component_list_from_workers(worker_metadatas)
+
+        if not comp_list:
+            raise ValueError("No components to compare")
+
+        # master compare list
+        master_comp = {}
+
+        # The basic strategy is to start with empty lists and add new component
+        # versions as we find them.  Upon next iteration, we should notice
+        # duplicates and be able to compare them.  If the match fails, we raise
+        # an exception.  If the component name does not exist, assume it was an
+        # arch dependency, add it to list and continue.  By the time we get to
+        # the last arch, we should have every possible component in the master
+        # list to compare with.
+
+        # Keep everything separated by component type
+        failed = False
+        for components in comp_list:
+            for component in components:
+                t = component['type']
+                name = component['name']
+
+                if t not in SUPPORTED_TYPES:
+                    raise ValueError("Type %s not supported")
+
+                identifier = (t, name)
+                if identifier not in master_comp:
+                    master_comp[identifier] = component
+                    continue
+
+                try:
+                    mc = master_comp[identifier]
+
+                    if t == 'rpm':
+                        self.rpm_compare(mc, component)
+                except ValueError as ex:
+                    self.log.warn("Comparison mismatch for component %s: %s", name, ex)
+                    failed = True
+
+        if failed:
+            raise ValueError("Failed component comparison")

--- a/tests/files/example-koji-metadata-ppc64le.json
+++ b/tests/files/example-koji-metadata-ppc64le.json
@@ -1,0 +1,307 @@
+{
+  "buildroots": [
+    {
+      "container": {
+        "type": "docker",
+        "arch": "ppc64le"
+      },
+      "content_generator": {
+        "version": "1.6.24.1",
+        "name": "atomic-reactor"
+      },
+      "host": {
+        "os": "Red Hat Enterprise Linux Server 7.3 (Maipo)",
+        "arch": "ppc64le"
+      },
+      "components": [
+        {
+          "name": "python-ethtool",
+          "sigmd5": "af8ee0374e8160dc19b2598da2b22162",
+          "arch": "ppc64le",
+          "epoch": null,
+          "version": "0.8",
+          "signature": "199e2f91fd431d51",
+          "release": "5.el7",
+          "type": "rpm"
+        },
+        {
+          "name": "python-kitchen",
+          "sigmd5": "25c2edc551a562b6d0f53444b439a895",
+          "arch": "noarch",
+          "epoch": null,
+          "version": "1.1.1",
+          "signature": "199e2f91fd431d51",
+          "release": "5.el7",
+          "type": "rpm"
+        },
+        {
+          "name": "rootfiles",
+          "sigmd5": "44409ce44e76605dacfa2aaece2daf31",
+          "arch": "noarch",
+          "epoch": null,
+          "version": "8.1",
+          "signature": "199e2f91fd431d51",
+          "release": "11.el7",
+          "type": "rpm"
+        },
+        {
+          "name": "bash",
+          "sigmd5": "f972a9919443a8f08420c99d8ad44b9d",
+          "arch": "ppc64le",
+          "epoch": null,
+          "version": "4.2.46",
+          "signature": "199e2f91fd431d51",
+          "release": "28.el7",
+          "type": "rpm"
+        },
+        {
+          "name": "perl-URI",
+          "sigmd5": "4bf2ed4cb63b3c2fbbf77664460d292b",
+          "arch": "noarch",
+          "epoch": 4,
+          "version": "1.71",
+          "signature": null,
+          "release": "1.el7eng",
+          "type": "rpm"
+        },
+        {
+          "name": "perl-HTTP-Date",
+          "sigmd5": "13f25441e44fb9f67a62144ac51772a6",
+          "arch": "noarch",
+          "epoch": null,
+          "version": "6.02",
+          "signature": "199e2f91fd431d51",
+          "release": "8.el7",
+          "type": "rpm"
+        }
+      ],
+      "tools": [
+        {
+          "version": "1.10.6",
+          "name": "docker-py"
+        },
+        {
+          "version": "1.0.5",
+          "name": "docker_squash"
+        },
+        {
+          "version": "1.6.24.1",
+          "name": "atomic_reactor"
+        },
+        {
+          "version": "0.40.1",
+          "name": "osbs-client"
+        },
+        {
+          "version": "1.42",
+          "name": "dockpulp"
+        },
+        {
+          "version": "1.12.6",
+          "name": "docker"
+        }
+      ],
+      "id": 1
+    }
+  ],
+  "build": {
+    "name": "osbs-buildroot-docker",
+    "extra": {
+      "image": {
+        "autorebuild": false,
+        "help": null
+      },
+      "container_koji_task_id": 13781698
+    },
+    "start_time": 1501847970,
+    "version": "1.0",
+    "end_time": 1501848733,
+    "release": "71"
+  },
+  "metadata_version": 0,
+  "output": [
+    {
+      "type": "log",
+      "arch": "noarch",
+      "filename": "openshift-final.log",
+      "filesize": 1265642,
+      "checksum": "178ac369bcb83ee3fc8f31a3face72f6",
+      "checksum_type": "md5",
+      "buildroot_id": 1
+    },
+    {
+      "type": "log",
+      "arch": "noarch",
+      "filename": "build.log",
+      "filesize": 99320,
+      "checksum": "0daaaa438d51f6a32eb8544646c2251d",
+      "checksum_type": "md5",
+      "buildroot_id": 1
+    },
+    {
+      "extra": {
+        "image": {
+          "arch": "ppc64le"
+        },
+        "docker": {
+          "repositories": [
+            "docker.example.com:8888/rcm/buildroot:1.0-71"
+          ],
+          "parent_id": "sha256:93bb76ddeb7a0a882f74f9ebc2c4d25b035823b2d3a4a98243e6f11f55b3f1d7",
+          "config": {
+            "created": "2017-08-04T12:04:12.191057Z",
+            "config": {
+              "Tty": false,
+              "Cmd": [
+                "atomic-reactor",
+                "--verbose",
+                "inside-build",
+                "--input",
+                "osv3"
+              ],
+              "Volumes": null,
+              "Domainname": "",
+              "WorkingDir": "",
+              "Image": "ff9b0d9e9c2bb087c0b906ba08467936addb4f8f514c84f9952dd37d50995bea",
+              "Hostname": "bb140734f94b",
+              "StdinOnce": false,
+              "ArgsEscaped": true,
+              "AttachStdin": false,
+              "User": "",
+              "Env": [
+                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+                "container=oci",
+                "LC_ALL=en_US.UTF-8"
+              ],
+              "Entrypoint": null,
+              "OnBuild": [],
+              "AttachStderr": false,
+              "AttachStdout": false,
+              "OpenStdin": false
+            },
+            "architecture": "amd64",
+            "docker_version": "1.12.6",
+            "rootfs": {
+              "type": "layers",
+              "diff_ids": [
+                "sha256:dda6e8dfdcf7a918d1fd7038a2a6de43f78c194c0bb220ea086af6c414254f4b",
+                "sha256:86888f0aea6df7a7a4ae5595c505b0abccc1002f717efa5be32fa0337099bf1d",
+                "sha256:4138467b7181b375094ab9a4a504450696a0e9eba26f786afd3348d970c23efc"
+              ]
+            },
+            "os": "linux",
+            "history": [
+              {
+                "comment": "Imported from -",
+                "created": "2017-06-21T15:53:59.772302644Z"
+              },
+              {
+                "author": "Red Hat, Inc.",
+                "created_by": "/bin/sh -c rm -f '/etc/yum.repos.d/compose-rpms-1.repo'",
+                "created": "2017-06-21T15:54:32.554216Z"
+              },
+              {
+                "comment": "",
+                "created": "2017-08-04T12:04:12.191057Z"
+              }
+            ]
+          },
+          "id": "sha256:8c52ac84e6421795491981dcc09bc449a268ac83f6d2893dcd124dbdba808aec",
+          "tags": [
+            "1.0-71",
+            "1.0",
+            "latest"
+          ]
+        }
+      },
+      "checksum": "0eea7b32a9a9fe99ebbcc59e82deb364",
+      "buildroot_id": 1,
+      "components": [
+        {
+          "name": "perl-Mozilla-CA",
+          "sigmd5": "6ed1c24f1780b6909e88968bed9c3957",
+          "arch": "noarch",
+          "epoch": null,
+          "version": "20130114",
+          "signature": "199e2f91fd431d51",
+          "release": "5.el7",
+          "type": "rpm"
+        },
+        {
+          "name": "tzdata",
+          "sigmd5": "2255a5807ca7e4d7274995db18e52bea",
+          "arch": "noarch",
+          "epoch": null,
+          "version": "2017b",
+          "signature": "199e2f91fd431d51",
+          "release": "1.el7",
+          "type": "rpm"
+        },
+        {
+          "name": "perl-IO-Socket-SSL",
+          "sigmd5": "e7ba0fe21165e9995b8644e546f9fc45",
+          "arch": "noarch",
+          "epoch": null,
+          "version": "1.94",
+          "signature": "199e2f91fd431d51",
+          "release": "6.el7",
+          "type": "rpm"
+        },
+        {
+          "name": "setup",
+          "sigmd5": "0a445b9930665e1b435ed08b792f4811",
+          "arch": "noarch",
+          "epoch": null,
+          "version": "2.8.71",
+          "signature": "199e2f91fd431d51",
+          "release": "7.el7",
+          "type": "rpm"
+        },
+        {
+          "name": "openssl",
+          "sigmd5": "83e8942ce054db9d039dd42bcc97d710",
+          "arch": "ppc64le",
+          "epoch": 1,
+          "version": "1.0.2k",
+          "signature": "199e2f91fd431d51",
+          "release": "8.el7",
+          "type": "rpm"
+        },
+        {
+          "name": "perl-URI",
+          "sigmd5": "4bf2ed4cb63b3c2fbbf77664460d292b",
+          "arch": "noarch",
+          "epoch": 4,
+          "version": "1.71",
+          "signature": null,
+          "release": "1.el7eng",
+          "type": "rpm"
+        },
+        {
+          "name": "perl-Mozilla-PublicSuffix",
+          "sigmd5": "cad070218512ed9864a895e8a58cb5b5",
+          "arch": "noarch",
+          "epoch": null,
+          "version": "0.1.19",
+          "signature": null,
+          "release": "1.el7eng",
+          "type": "rpm"
+        },
+        {
+          "name": "perl-Net-SSLeay",
+          "sigmd5": "0a1d1a777fdb2159792a3f435078da2e",
+          "arch": "ppc64le",
+          "epoch": null,
+          "version": "1.55",
+          "signature": "199e2f91fd431d51",
+          "release": "6.el7",
+          "type": "rpm"
+        }
+      ],
+      "type": "docker-image",
+      "checksum_type": "md5",
+      "arch": "ppc64le",
+      "filesize": 155732563
+    }
+  ]
+}

--- a/tests/files/example-koji-metadata-x86_64.json
+++ b/tests/files/example-koji-metadata-x86_64.json
@@ -1,0 +1,307 @@
+{
+  "buildroots": [
+    {
+      "container": {
+        "type": "docker",
+        "arch": "x86_64"
+      },
+      "content_generator": {
+        "version": "1.6.24.1",
+        "name": "atomic-reactor"
+      },
+      "host": {
+        "os": "Red Hat Enterprise Linux Server 7.3 (Maipo)",
+        "arch": "x86_64"
+      },
+      "components": [
+        {
+          "name": "python-ethtool",
+          "sigmd5": "af8ee0374e8160dc19b2598da2b22162",
+          "arch": "x86_64",
+          "epoch": null,
+          "version": "0.8",
+          "signature": "199e2f91fd431d51",
+          "release": "5.el7",
+          "type": "rpm"
+        },
+        {
+          "name": "python-kitchen",
+          "sigmd5": "25c2edc551a562b6d0f53444b439a895",
+          "arch": "noarch",
+          "epoch": null,
+          "version": "1.1.1",
+          "signature": "199e2f91fd431d51",
+          "release": "5.el7",
+          "type": "rpm"
+        },
+        {
+          "name": "rootfiles",
+          "sigmd5": "44409ce44e76605dacfa2aaece2daf31",
+          "arch": "noarch",
+          "epoch": null,
+          "version": "8.1",
+          "signature": "199e2f91fd431d51",
+          "release": "11.el7",
+          "type": "rpm"
+        },
+        {
+          "name": "bash",
+          "sigmd5": "f972a9919443a8f08420c99d8ad44b9d",
+          "arch": "x86_64",
+          "epoch": null,
+          "version": "4.2.46",
+          "signature": "199e2f91fd431d51",
+          "release": "28.el7",
+          "type": "rpm"
+        },
+        {
+          "name": "perl-URI",
+          "sigmd5": "4bf2ed4cb63b3c2fbbf77664460d292b",
+          "arch": "noarch",
+          "epoch": 4,
+          "version": "1.71",
+          "signature": null,
+          "release": "1.el7eng",
+          "type": "rpm"
+        },
+        {
+          "name": "perl-HTTP-Date",
+          "sigmd5": "13f25441e44fb9f67a62144ac51772a6",
+          "arch": "noarch",
+          "epoch": null,
+          "version": "6.02",
+          "signature": "199e2f91fd431d51",
+          "release": "8.el7",
+          "type": "rpm"
+        }
+      ],
+      "tools": [
+        {
+          "version": "1.10.6",
+          "name": "docker-py"
+        },
+        {
+          "version": "1.0.5",
+          "name": "docker_squash"
+        },
+        {
+          "version": "1.6.24.1",
+          "name": "atomic_reactor"
+        },
+        {
+          "version": "0.40.1",
+          "name": "osbs-client"
+        },
+        {
+          "version": "1.42",
+          "name": "dockpulp"
+        },
+        {
+          "version": "1.12.6",
+          "name": "docker"
+        }
+      ],
+      "id": 1
+    }
+  ],
+  "build": {
+    "name": "osbs-buildroot-docker",
+    "extra": {
+      "image": {
+        "autorebuild": false,
+        "help": null
+      },
+      "container_koji_task_id": 13781698
+    },
+    "start_time": 1501847970,
+    "version": "1.0",
+    "end_time": 1501848733,
+    "release": "71"
+  },
+  "metadata_version": 0,
+  "output": [
+    {
+      "type": "log",
+      "arch": "noarch",
+      "filename": "openshift-final.log",
+      "filesize": 1265642,
+      "checksum": "178ac369bcb83ee3fc8f31a3face72f6",
+      "checksum_type": "md5",
+      "buildroot_id": 1
+    },
+    {
+      "type": "log",
+      "arch": "noarch",
+      "filename": "build.log",
+      "filesize": 99320,
+      "checksum": "0daaaa438d51f6a32eb8544646c2251d",
+      "checksum_type": "md5",
+      "buildroot_id": 1
+    },
+    {
+      "extra": {
+        "image": {
+          "arch": "x86_64"
+        },
+        "docker": {
+          "repositories": [
+            "docker.example.com:8888/rcm/buildroot:1.0-71"
+          ],
+          "parent_id": "sha256:93bb76ddeb7a0a882f74f9ebc2c4d25b035823b2d3a4a98243e6f11f55b3f1d7",
+          "config": {
+            "created": "2017-08-04T12:04:12.191057Z",
+            "config": {
+              "Tty": false,
+              "Cmd": [
+                "atomic-reactor",
+                "--verbose",
+                "inside-build",
+                "--input",
+                "osv3"
+              ],
+              "Volumes": null,
+              "Domainname": "",
+              "WorkingDir": "",
+              "Image": "ff9b0d9e9c2bb087c0b906ba08467936addb4f8f514c84f9952dd37d50995bea",
+              "Hostname": "bb140734f94b",
+              "StdinOnce": false,
+              "ArgsEscaped": true,
+              "AttachStdin": false,
+              "User": "",
+              "Env": [
+                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+                "container=oci",
+                "LC_ALL=en_US.UTF-8"
+              ],
+              "Entrypoint": null,
+              "OnBuild": [],
+              "AttachStderr": false,
+              "AttachStdout": false,
+              "OpenStdin": false
+            },
+            "architecture": "amd64",
+            "docker_version": "1.12.6",
+            "rootfs": {
+              "type": "layers",
+              "diff_ids": [
+                "sha256:dda6e8dfdcf7a918d1fd7038a2a6de43f78c194c0bb220ea086af6c414254f4b",
+                "sha256:86888f0aea6df7a7a4ae5595c505b0abccc1002f717efa5be32fa0337099bf1d",
+                "sha256:4138467b7181b375094ab9a4a504450696a0e9eba26f786afd3348d970c23efc"
+              ]
+            },
+            "os": "linux",
+            "history": [
+              {
+                "comment": "Imported from -",
+                "created": "2017-06-21T15:53:59.772302644Z"
+              },
+              {
+                "author": "Red Hat, Inc.",
+                "created_by": "/bin/sh -c rm -f '/etc/yum.repos.d/compose-rpms-1.repo'",
+                "created": "2017-06-21T15:54:32.554216Z"
+              },
+              {
+                "comment": "",
+                "created": "2017-08-04T12:04:12.191057Z"
+              }
+            ]
+          },
+          "id": "sha256:8c52ac84e6421795491981dcc09bc449a268ac83f6d2893dcd124dbdba808aec",
+          "tags": [
+            "1.0-71",
+            "1.0",
+            "latest"
+          ]
+        }
+      },
+      "checksum": "0eea7b32a9a9fe99ebbcc59e82deb364",
+      "buildroot_id": 1,
+      "components": [
+        {
+          "name": "perl-Mozilla-CA",
+          "sigmd5": "6ed1c24f1780b6909e88968bed9c3957",
+          "arch": "noarch",
+          "epoch": null,
+          "version": "20130114",
+          "signature": "199e2f91fd431d51",
+          "release": "5.el7",
+          "type": "rpm"
+        },
+        {
+          "name": "tzdata",
+          "sigmd5": "2255a5807ca7e4d7274995db18e52bea",
+          "arch": "noarch",
+          "epoch": null,
+          "version": "2017b",
+          "signature": "199e2f91fd431d51",
+          "release": "1.el7",
+          "type": "rpm"
+        },
+        {
+          "name": "perl-IO-Socket-SSL",
+          "sigmd5": "e7ba0fe21165e9995b8644e546f9fc45",
+          "arch": "noarch",
+          "epoch": null,
+          "version": "1.94",
+          "signature": "199e2f91fd431d51",
+          "release": "6.el7",
+          "type": "rpm"
+        },
+        {
+          "name": "setup",
+          "sigmd5": "0a445b9930665e1b435ed08b792f4811",
+          "arch": "noarch",
+          "epoch": null,
+          "version": "2.8.71",
+          "signature": "199e2f91fd431d51",
+          "release": "7.el7",
+          "type": "rpm"
+        },
+        {
+          "name": "openssl",
+          "sigmd5": "83e8942ce054db9d039dd42bcc97d710",
+          "arch": "x86_64",
+          "epoch": 1,
+          "version": "1.0.2k",
+          "signature": "199e2f91fd431d51",
+          "release": "8.el7",
+          "type": "rpm"
+        },
+        {
+          "name": "perl-URI",
+          "sigmd5": "4bf2ed4cb63b3c2fbbf77664460d292b",
+          "arch": "noarch",
+          "epoch": 4,
+          "version": "1.71",
+          "signature": null,
+          "release": "1.el7eng",
+          "type": "rpm"
+        },
+        {
+          "name": "perl-Mozilla-PublicSuffix",
+          "sigmd5": "cad070218512ed9864a895e8a58cb5b5",
+          "arch": "noarch",
+          "epoch": null,
+          "version": "0.1.19",
+          "signature": null,
+          "release": "1.el7eng",
+          "type": "rpm"
+        },
+        {
+          "name": "perl-Net-SSLeay",
+          "sigmd5": "0a1d1a777fdb2159792a3f435078da2e",
+          "arch": "x86_64",
+          "epoch": null,
+          "version": "1.55",
+          "signature": "199e2f91fd431d51",
+          "release": "6.el7",
+          "type": "rpm"
+        }
+      ],
+      "type": "docker-image",
+      "checksum_type": "md5",
+      "arch": "x86_64",
+      "filesize": 155732563
+    }
+  ]
+}

--- a/tests/plugins/test_compare_components.py
+++ b/tests/plugins/test_compare_components.py
@@ -1,0 +1,162 @@
+"""
+Copyright (c) 2017 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+from __future__ import print_function, unicode_literals
+
+import os
+import json
+
+from flexmock import flexmock
+
+from atomic_reactor.constants import (PLUGIN_FETCH_WORKER_METADATA_KEY,
+                                      PLUGIN_COMPARE_COMPONENTS_KEY)
+from atomic_reactor.core import DockerTasker
+from atomic_reactor.inner import DockerBuildWorkflow
+from atomic_reactor.plugin import PostBuildPluginsRunner, PluginFailedException
+from atomic_reactor.util import ImageName
+
+from tests.constants import MOCK_SOURCE, TEST_IMAGE, INPUT_IMAGE, FILES
+from tests.docker_mock import mock_docker
+
+import pytest
+
+
+class MockSource(object):
+
+    def __init__(self, tmpdir):
+        tmpdir = str(tmpdir)
+        self.dockerfile_path = os.path.join(tmpdir, 'Dockerfile')
+        self.path = tmpdir
+
+    def get_dockerfile_path(self):
+        return self.dockerfile_path, self.path
+
+
+class MockInsideBuilder(object):
+
+    def __init__(self):
+        mock_docker()
+        self.tasker = DockerTasker()
+        self.base_image = ImageName(repo='fedora', tag='25')
+        self.image_id = 'image_id'
+        self.image = INPUT_IMAGE
+        self.df_path = 'df_path'
+        self.df_dir = 'df_dir'
+
+        def simplegen(x, y):
+            yield "some\u2018".encode('utf-8')
+        flexmock(self.tasker, build_image_from_path=simplegen)
+
+    def get_built_image_info(self):
+        return {'Id': 'some'}
+
+    def inspect_built_image(self):
+        return None
+
+    def ensure_not_built(self):
+        pass
+
+
+def mock_workflow(tmpdir):
+    workflow = DockerBuildWorkflow(MOCK_SOURCE, TEST_IMAGE)
+    setattr(workflow, 'builder', MockInsideBuilder())
+    setattr(workflow, 'source', MockSource(tmpdir))
+    setattr(workflow.builder, 'source', MockSource(tmpdir))
+    setattr(workflow, 'postbuild_result', {})
+    return workflow
+
+
+def mock_metadatas():
+    json_x_path = os.path.join(FILES, "example-koji-metadata-x86_64.json")
+    json_p_path = os.path.join(FILES, "example-koji-metadata-ppc64le.json")
+
+    with open(json_x_path) as json_data:
+        metadatas_x = json.load(json_data)
+
+    with open(json_p_path) as json_data:
+        metadatas_p = json.load(json_data)
+
+    # need to keep data separate otherwise deepcopy and edit 'arch'
+    worker_metadatas = {
+        'x86_64': metadatas_x,
+        'ppc64le': metadatas_p,
+    }
+
+    return worker_metadatas
+
+
+@pytest.mark.parametrize('fail', [True, False])
+def test_compare_components_plugin(tmpdir, fail):
+    workflow = mock_workflow(tmpdir)
+    worker_metadatas = mock_metadatas()
+
+    if fail:
+        # example data has 2 log items before component item hence output[2]
+        worker_metadatas['ppc64le']['output'][2]['components'][0]['version'] = "bacon"
+
+    workflow.postbuild_results[PLUGIN_FETCH_WORKER_METADATA_KEY] = worker_metadatas
+
+    runner = PostBuildPluginsRunner(
+        None,
+        workflow,
+        [{
+            'name': PLUGIN_COMPARE_COMPONENTS_KEY,
+            "args": {}
+        }]
+    )
+
+    if fail:
+        with pytest.raises(PluginFailedException):
+            runner.run()
+    else:
+        runner.run()
+
+
+def test_no_components(tmpdir):
+    workflow = mock_workflow(tmpdir)
+    worker_metadatas = mock_metadatas()
+
+    # example data has 2 log items before component item hence output[2]
+    del worker_metadatas['x86_64']['output'][2]['components']
+    del worker_metadatas['ppc64le']['output'][2]['components']
+
+    workflow.postbuild_results[PLUGIN_FETCH_WORKER_METADATA_KEY] = worker_metadatas
+
+    runner = PostBuildPluginsRunner(
+        None,
+        workflow,
+        [{
+            'name': PLUGIN_COMPARE_COMPONENTS_KEY,
+            "args": {}
+        }]
+    )
+
+    with pytest.raises(PluginFailedException):
+        runner.run()
+
+
+def test_bad_component_type(tmpdir):
+    workflow = mock_workflow(tmpdir)
+    worker_metadatas = mock_metadatas()
+
+    # example data has 2 log items before component item hence output[2]
+    worker_metadatas['x86_64']['output'][2]['components'][0]['type'] = "foo"
+
+    workflow.postbuild_results[PLUGIN_FETCH_WORKER_METADATA_KEY] = worker_metadatas
+
+    runner = PostBuildPluginsRunner(
+        None,
+        workflow,
+        [{
+            'name': PLUGIN_COMPARE_COMPONENTS_KEY,
+            "args": {}
+        }]
+    )
+
+    with pytest.raises(PluginFailedException):
+        runner.run()


### PR DESCRIPTION
This plugin takes the metadata from the worker and compares the components
version with that of other arches metadata.  The version info should be
identical otherwise fail the plugin.

The only component type supported initially is 'rpm'.

Test case attached using a copy of live koji data.