### PR TITLE
pulp_pull: fetch media type for manifest list too

### DIFF
--- a/atomic_reactor/plugins/post_pulp_pull.py
+++ b/atomic_reactor/plugins/post_pulp_pull.py
@@ -107,15 +107,19 @@ class PulpPullPlugin(ExitPlugin, PostBuildPlugin):
                                               pullspec, registry.uri,
                                               self.insecure, self.secret,
                                               require_digest=False)
-            if digests and digests.v2:
-                self.log.info("V2 schema 2 digest found, returning %s",
-                              self.workflow.builder.image_id)
-                media_types.append('application/vnd.docker.distribution.manifest.v2+json')
-                # No need to pull the image to work out the image ID as
-                # we already know it.
-                return self.workflow.builder.image_id, sorted(media_types)
+            if digests:
+                if digests.v2_list:
+                    self.log.info("Manifest list found")
+                    media_types.append('application/vnd.docker.distribution.manifest.list.v2+json')
+                if digests.v2:
+                    self.log.info("V2 schema 2 digest found, returning %s",
+                                  self.workflow.builder.image_id)
+                    media_types.append('application/vnd.docker.distribution.manifest.v2+json')
+                    # No need to pull the image to work out the image ID as
+                    # we already know it.
+                    return self.workflow.builder.image_id, sorted(media_types)
             else:
-                self.log.info("V2 schema 2 digest is not available")
+                self.log.info("No digests were found")
 
         # Pull the image from Crane to find out the image ID for the
         # v2 schema 1 manifest (which we have not seen before).

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -687,7 +687,7 @@ def query_registry(image, registry, digest=None, insecure=False, dockercfg_path=
 
     for idx, r in enumerate(registries):
         url = '{}/v2/{}/{}/{}'.format(r, context, object_type, reference)
-        logger.debug("url: {}".format(url))
+        logger.debug("url: {}, headers: {}".format(url, headers))
 
         try:
             response = requests.get(url, **kwargs)
@@ -702,7 +702,7 @@ def query_registry(image, registry, digest=None, insecure=False, dockercfg_path=
 
 
 def get_manifest_digests(image, registry, insecure=False, dockercfg_path=None,
-                         versions=('v1', 'v2'), require_digest=True):
+                         versions=('v1', 'v2', 'v2_list'), require_digest=True):
     """Return manifest digest for image.
 
     :param image: ImageName, the remote image to inspect
@@ -766,7 +766,7 @@ def get_manifest_digests(image, registry, insecure=False, dockercfg_path=None,
 
         # set it to truthy value so that koji_import would know pulp supports these digests
         digests[version] = True
-        logger.debug('received_media_type=%s', received_media_type)
+        logger.debug('Received media type %s', received_media_type)
 
         if not response.headers.get('Docker-Content-Digest'):
             logger.warning('Unable to fetch digest for %s, no Docker-Content-Digest header',

--- a/tests/plugins/test_tag_and_push.py
+++ b/tests/plugins/test_tag_and_push.py
@@ -211,6 +211,13 @@ def test_tag_and_push_plugin(
                 'Content-Type': 'application/vnd.docker.distribution.manifest.v2+json',
                 'Docker-Content-Digest': DIGEST_V2
               }))
+    manifest_response_v2_list = requests.Response()
+    (flexmock(manifest_response_v2_list,
+              raise_for_status=lambda: None,
+              json=manifest_json,
+              headers={
+                'Content-Type': 'application/vnd.docker.distribution.manifest.list.v2+json',
+              }))
 
     config_blob_response = requests.Response()
     (flexmock(config_blob_response, raise_for_status=lambda: None, json=config_json))
@@ -222,6 +229,9 @@ def test_tag_and_push_plugin(
 
             if headers['Accept'] == 'application/vnd.docker.distribution.manifest.v2+json':
                 return manifest_response_v2
+
+            if headers['Accept'] == 'application/vnd.docker.distribution.manifest.list.v2+json':
+                return manifest_response_v2_list
 
         if url == manifest_url:
             return manifest_response_v2


### PR DESCRIPTION
Not sure if the tests are correct, though, as currently its impossible to verify "list and v2 schema" case now