### PR TITLE
Group manifests bugfix

### DIFF
--- a/tests/plugins/test_koji_import.py
+++ b/tests/plugins/test_koji_import.py
@@ -1452,10 +1452,10 @@ class TestKojiImport(object):
         assert 'image' in extra
         image = extra['image']
         assert isinstance(image, dict)
+        expected_results = {}
+        expected_results['tags'] = [tag.tag for tag in workflow.tag_conf.images]
         if digests:
             assert 'index' in image.keys()
-            expected_results = {}
-            expected_results['tags'] = [tag.tag for tag in workflow.tag_conf.images]
             pullspec = "docker.example.com/myproject/hello-world@{0}".format(digests[0].v2_list)
             expected_results['pull'] = [pullspec]
             for tag in expected_results['tags']:
@@ -1466,3 +1466,12 @@ class TestKojiImport(object):
             assert image['index'] == expected_results
         else:
             assert 'index' not in image.keys()
+            assert 'output' in data
+            for output in data['output']:
+                if output['type'] == 'log':
+                    continue
+                assert 'extra' in output
+                extra = output['extra']
+                assert 'docker' in extra
+                assert 'tags' in extra['docker']
+                assert sorted(expected_results['tags']) == sorted(extra['docker']['tags'])


### PR DESCRIPTION
bugfixes to resolve bugs found in testing group_manifests. Contains two commits:

    group_manifests: add tags to push_conf
    
    Plugins running after group_manifests may expect all the tags to be in
    push_conf's docker_registry. Add them.

and

    group_manifests: adjust extra.docker.tags
    
    When group_manifests is run with group=False, the docker tags in the extra
    section of the output need to be adjusted to match the tags. In arrangement
    3 and earlier, they were set by koji_upload, but in arrangement 4
    koji_upload doesn't have enough information. If group=True, the
    image['index'] structure replaces extra.docker.tags for this information.