### PR TITLE
Remove error log for exit plugin in post-build

### DIFF
--- a/atomic_reactor/plugin.py
+++ b/atomic_reactor/plugin.py
@@ -470,8 +470,6 @@ class PostBuildPluginsRunner(BuildPluginsRunner):
     def create_instance_from_plugin(self, plugin_class, plugin_conf):
         instance = super(PostBuildPluginsRunner, self).create_instance_from_plugin(plugin_class,
                                                                                    plugin_conf)
-        if isinstance(instance, ExitPlugin):
-            logger.error("running exit plugin '%s' as post-build plugin", plugin_class.key)
 
         return instance
 

--- a/tests/test_inner.py
+++ b/tests/test_inner.py
@@ -452,7 +452,7 @@ def test_workflow_compat(request):
 
     workflow.build_docker_image()
     assert watch_exit.was_called()
-    assert len(fake_logger.errors) > 0
+    assert len(fake_logger.errors) == 0  # This is explicitly allowed now
 
 
 class Pre(PreBuildPlugin):


### PR DESCRIPTION
The pulp_pull plugin is an ExitPlugin, but is allowed to run in the post-build phase for arrangement versions < 4.

Signed-off-by: Tim Waugh <twaugh@redhat.com>