### PR TITLE
Build logs fixes

### DIFF
--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -185,7 +185,7 @@ class KojiImportPlugin(ExitPlugin):
                 platform_logs[platform] = NamedTemporaryFile(prefix="%s-%s" %
                                                              (self.build_id, filename),
                                                              suffix=".log", mode='wb')
-            platform_logs[platform].write(entry.line.encode('utf-8'))
+            platform_logs[platform].write((entry.line + '\n').encode('utf-8'))
 
         for platform, logfile in platform_logs.items():
             logfile.flush()


### PR DESCRIPTION
When koji_import writes logs, make sure to include newlines.

When koji_upload uploads logs, it now optionally only uploads buildstep logs using a provided name. This allows multiple workers to upload buildstep logs.