### PR TITLE
Omit unique tag from Koji metadata

### DIFF
--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -233,7 +233,8 @@ class KojiImportPlugin(ExitPlugin):
         manifest_list_digests = self.workflow.postbuild_results.get(PLUGIN_GROUP_MANIFESTS_KEY)
         if manifest_list_digests:
             index = {}
-            index['tags'] = [image.tag for image in self.workflow.tag_conf.images]
+            index['tags'] = [image.tag
+                             for image in self.workflow.tag_conf.primary_images]
             repositories = self.workflow.build_result.annotations['repositories']['unique']
             repo = ImageName.parse(repositories[0]).to_str(registry=False, tag=False)
             # group_manifests added the registry, so this should be valid
@@ -259,7 +260,8 @@ class KojiImportPlugin(ExitPlugin):
                         if instance['type'] == 'docker-image':
                             # koji_upload, running in the worker, doesn't have the full tags
                             # so set them here
-                            tags = [image.tag for image in self.workflow.tag_conf.images]
+                            tags = [image.tag
+                                    for image in self.workflow.tag_conf.primary_images]
                             instance['extra']['docker']['tags'] = tags
                             self.log.debug("reset tags to so that docker is %s",
                                            instance['extra']['docker'])

--- a/tests/plugins/test_koji_import.py
+++ b/tests/plugins/test_koji_import.py
@@ -1464,7 +1464,8 @@ class TestKojiImport(object):
         image = extra['image']
         assert isinstance(image, dict)
         expected_results = {}
-        expected_results['tags'] = [tag.tag for tag in workflow.tag_conf.images]
+        expected_results['tags'] = [tag.tag
+                                    for tag in workflow.tag_conf.primary_images]
         if digests:
             assert 'index' in image.keys()
             pullspec = "docker.example.com/myproject/hello-world@{0}".format(digests[0].v2_list)


### PR DESCRIPTION
The unique tag has never been included in the 'tags' list in the Koji metadata. In order to preserve compatibility and reduce surprises, omit the unique tag from the 'tags' field in both the output (for compatibility) and the image.index map (for consistency).

Signed-off-by: Tim Waugh <twaugh@redhat.com>