### PR TITLE
docker_api: report syntax errors

### DIFF
--- a/atomic_reactor/plugins/build_docker_api.py
+++ b/atomic_reactor/plugins/build_docker_api.py
@@ -7,6 +7,7 @@ of the BSD license. See the LICENSE file for details.
 """
 from __future__ import print_function, unicode_literals
 
+import docker
 from atomic_reactor.plugin import BuildStepPlugin
 from atomic_reactor.util import wait_for_command
 from atomic_reactor.build import BuildResult
@@ -41,7 +42,10 @@ class DockerApiPlugin(BuildStepPlugin):
                                                      builder.image)
 
         self.log.debug('build is submitted, waiting for it to finish')
-        command_result = wait_for_command(logs_gen)
+        try:
+            command_result = wait_for_command(logs_gen)
+        except docker.errors.APIError as ex:
+            return BuildResult(logs=[], fail_reason=ex.explanation)
 
         if command_result.is_failed():
             return BuildResult(logs=command_result.logs,

--- a/tests/docker_mock.py
+++ b/tests/docker_mock.py
@@ -258,19 +258,13 @@ def _mock_tag(src_img, dest_repo, dest_tag='latest', **kwargs):
     return True
 
 
-def _mock_generator_raises():
-    raise RuntimeError("build generator failure")
-    yield {}
-
-
 def mock_docker(build_should_fail=False,
                 inspect_should_fail=False,
                 wait_should_fail=False,
                 provided_image_repotags=None,
                 should_raise_error={},
                 remember_images=False,
-                push_should_fail=False,
-                build_should_fail_generator=False):
+                push_should_fail=False):
     """
     mock all used docker.APIClient methods
 
@@ -286,10 +280,7 @@ def mock_docker(build_should_fail=False,
     push_result = mock_push_logs if not push_should_fail else mock_push_logs_failed
 
     if build_should_fail:
-        if build_should_fail_generator:
-            build_result = _mock_generator_raises()
-        else:
-            build_result = iter(mock_build_logs_failed)
+        build_result = iter(mock_build_logs_failed)
     else:
         build_result = iter(mock_build_logs)
 


### PR DESCRIPTION
When the Dockerfile is incorrectly formed, use the exception's "explanation" (the syntax error message) instead of the HTTP error (500 status code).

This includes an expected-fail commit adding the test-case, followed by the actual fix, showing that tests now pass.