### PR TITLE
Set Koji pull-specification metadata according to availability in the registry

### DIFF
--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -260,7 +260,7 @@ class KojiImportPlugin(ExitPlugin):
                     if '@' not in pullspec:
                         continue
 
-                    image, digest = pullspec.split('@', 1)
+                    _, digest = pullspec.split('@', 1)
                     if digest not in available:
                         self.log.info("%s: %s not available, removing", platform, pullspec)
                         unavailable.append(pullspec)

--- a/tests/plugins/test_pulp_sync.py
+++ b/tests/plugins/test_pulp_sync.py
@@ -71,6 +71,9 @@ class MockPulp(object):
     def crane(self, repos, wait=True):
         pass
 
+    def listRepo(self, repos, content=False):
+        return {'manifests': ['sha256:1234']}
+
 
 class TestPostPulpSync(object):
     @staticmethod
@@ -85,7 +88,8 @@ class TestPostPulpSync(object):
         push_conf = PushConf()
         return flexmock(tag_conf=tag_conf,
                         push_conf=push_conf,
-                        postbuild_plugins_conf=[])
+                        postbuild_plugins_conf=[],
+                        plugin_workspace={})
 
     @pytest.mark.parametrize('get_prefix', [True, False])
     @pytest.mark.parametrize(('pulp_repo_prefix', 'expected_prefix'), [


### PR DESCRIPTION
In order to include the correct image manifest digests in the Koji metadata (`output[].extra.docker.repositories`), we need to collect both the v2 schema 1 and v2 schema 2 image digests in the worker build, then after syncing to Pulp in the orchestrator build, remove any that do not appear in the Pulp repository.

To achieve this:
* koji_upload should be told to report multiple digests based on whether Pulp is in use
* pulp_sync should collect the content of the repository after sync
* koji_import should remove any digests not present after sync

Additionally, update koji_promote to mirror this behaviour.