### PR TITLE
Handle koij-parent without result

### DIFF
--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -151,7 +151,7 @@ class KojiImportPlugin(ExitPlugin):
         return outputs
 
     def get_parent_image_koji_build_id(self):
-        res = self.workflow.prebuild_results.get(PLUGIN_KOJI_PARENT_KEY, {})
+        res = self.workflow.prebuild_results.get(PLUGIN_KOJI_PARENT_KEY) or {}
         return res.get('parent-image-koji-build-id')
 
     def get_buildroot(self, worker_metadatas):

--- a/tests/plugins/test_koji_import.py
+++ b/tests/plugins/test_koji_import.py
@@ -980,7 +980,8 @@ class TestKojiImport(object):
     @pytest.mark.parametrize(('parent_id', 'expect_success', 'expect_error'), [
         (1234, True, False),
         (None, False, False),
-        ('x', False, True)
+        ('x', False, True),
+        ('NO-RESULT', False, False),
     ])
     def test_koji_import_parent_id(self, parent_id, tmpdir, expect_success, os_env, expect_error,
                                    caplog):
@@ -990,9 +991,14 @@ class TestKojiImport(object):
                                             version='1.0',
                                             release='1',
                                             session=session)
-        workflow.prebuild_results[PLUGIN_KOJI_PARENT_KEY] = {
-            'parent-image-koji-build-id': parent_id,
-        }
+
+        koji_parent_result = None
+        if parent_id != 'NO-RESULT':
+            koji_parent_result = {
+                'parent-image-koji-build-id': parent_id,
+            }
+        workflow.prebuild_results[PLUGIN_KOJI_PARENT_KEY] = koji_parent_result
+
         runner = create_runner(tasker, workflow)
         runner.run()
 


### PR DESCRIPTION
The koji-parent plugin may return None, instead of a dict,
if it the base image does not have the required Labels.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>