### PR TITLE
Apply image ID from pulp_pull for all single-arch builds

### DIFF
--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -128,8 +128,12 @@ class KojiImportPlugin(ExitPlugin):
                 instance['buildroot_id'] = '{}-{}'.format(platform, instance['buildroot_id'])
 
                 if instance['type'] == 'docker-image':
-                    # update image ID with pulp_pull results
-                    if platform == "x86_64" and has_pulp_pull:
+                    # update image ID with pulp_pull results;
+                    # necessary when using Pulp < 2.14. Only do this
+                    # when building for a single architecture -- if
+                    # building for many, we know Pulp has schema 2
+                    # support.
+                    if len(worker_metadatas) == 1 and has_pulp_pull:
                         exit_results = self.workflow.exit_results
                         image_id, _ = exit_results[PLUGIN_PULP_PULL_KEY]
                         if image_id is not None:


### PR DESCRIPTION
If building for a single architecture, always look for pulp_pull's re-calculated image ID regardless of architecture.

Signed-off-by: Tim Waugh <twaugh@redhat.com>