### PR TITLE
flatpak_create_dockerfile: allow control chars in JSON

### DIFF
--- a/atomic_reactor/plugins/pre_flatpak_create_dockerfile.py
+++ b/atomic_reactor/plugins/pre_flatpak_create_dockerfile.py
@@ -89,7 +89,7 @@ class FlatpakCreateDockerfilePlugin(PreBuildPlugin):
     def _load_source(self):
         flatpak_path = os.path.join(self.workflow.builder.df_dir, FLATPAK_FILENAME)
         with open(flatpak_path, 'r') as fp:
-            flatpak_json = json.load(fp)
+            flatpak_json = json.load(fp, strict=False)
 
         compose_info = get_compose_info(self.workflow)
         if compose_info is None:


### PR DESCRIPTION
Some modules (e.g. [this test one](https://github.com/vrutkovs/module-eog-f27/blob/master/module-eog-f27.yaml)) may create JSONs, which have control chars in it. Standard python json would throw exception there:
```
  File "/usr/lib/python2.7/site-packages/atomic_reactor/plugin.py", line 242, in run
    plugin_response = plugin_instance.run()
  File "/usr/lib/python2.7/site-packages/atomic_reactor/plugins/pre_flatpak_create_dockerfile.py", line 106, in run
    source = self._load_source()
  File "/usr/lib/python2.7/site-packages/atomic_reactor/plugins/pre_flatpak_create_dockerfile.py", line 92, in _load_source
    flatpak_json = json.load(fp)
  File "/usr/lib64/python2.7/json/__init__.py", line 291, in load
    **kw)
  File "/usr/lib64/python2.7/json/__init__.py", line 339, in loads
    return _default_decoder.decode(s)
  File "/usr/lib64/python2.7/json/decoder.py", line 364, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib64/python2.7/json/decoder.py", line 380, in raw_decode
    obj, end = self.scan_once(s, idx)
ValueError: Invalid control character at: line 3 column 22 (char 54)
```

Making json load less strict fixes the issue.

/cc @owtaylor 