### PR TITLE
Export appropriate metadata to Koji for flatpaks

### DIFF
--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -20,6 +20,7 @@ from atomic_reactor.plugins.build_orchestrate_build import (get_worker_build_inf
                                                             get_koji_upload_dir)
 from atomic_reactor.plugins.pre_add_filesystem import AddFilesystemPlugin
 from atomic_reactor.plugins.pre_check_and_set_rebuild import is_rebuild
+from atomic_reactor.plugins.pre_flatpak_create_dockerfile import get_flatpak_source_info
 try:
     from atomic_reactor.plugins.post_pulp_sync import get_manifests_in_pulp_repository
 except ImportError:
@@ -392,6 +393,10 @@ class KojiImportPlugin(ExitPlugin):
             else:
                 extra.setdefault('image', {})
                 extra['image']['parent_build_id'] = parent_id
+
+        flatpak_source_info = get_flatpak_source_info(self.workflow)
+        if flatpak_source_info is not None:
+            extra['image'].update(flatpak_source_info.koji_metadata())
 
         self.set_help(extra, worker_metadatas)
         self.set_media_types(extra, worker_metadatas)

--- a/atomic_reactor/plugins/pre_flatpak_create_dockerfile.py
+++ b/atomic_reactor/plugins/pre_flatpak_create_dockerfile.py
@@ -51,6 +51,12 @@ class FlatpakSourceInfo(object):
         mmd = compose.base_module.mmd
         self.runtime = 'runtime' in mmd.profiles
 
+    def koji_metadata(self):
+        metadata = self.compose.koji_metadata()
+        metadata['flatpak'] = True
+
+        return metadata
+
 
 WORKSPACE_SOURCE_KEY = 'source_info'
 

--- a/docs/koji.md
+++ b/docs/koji.md
@@ -47,6 +47,9 @@ Data which is placed here includes:
 - `build.extra.image.media_types` (str list): Container image media types for which this image is available, where "application/json" is for a Docker Registry HTTP API V1 image; currently this key is only set when Pulp integration is enabled
 - `build.extra.image.parent_build_id` (int): Koji build id of the parent image, if found
 - `build.extra.image.index` (map): information about the manifest list
+- `build.extra.image.flatpak` (boolean): true if this image is a Flatpak
+- `build.extra.image.modules` (boolean): the [modules](https://docs.pagure.org/modularity/) that provide the packages for this image, resolved to `NAME-STREAM-VERSION`. This will include the resolved versions of the modules in `source_modules`, and the dependencies of those modules. (Currently only for Flatpaks)
+- `build.extra.image.source_modules` (boolean): the modules that were specified as input to the build process. (Currently only for Flatpaks)
 
 The index map has these entries:
 

--- a/tests/plugins/test_flatpak_create_dockerfile.py
+++ b/tests/plugins/test_flatpak_create_dockerfile.py
@@ -94,7 +94,8 @@ def test_flatpak_create_dockerfile(tmpdir, docker_tasker):
     base_module = ModuleInfo(MODULE_NAME, MODULE_STREAM, LATEST_VERSION,
                              mmd, FLATPAK_APP_RPMS)
     repo_url = 'http://odcs.example/composes/latest-odcs-42-1/compose/Temporary/$basearch/os/'
-    compose_info = ComposeInfo(42, base_module,
+    compose_info = ComposeInfo(MODULE_STREAM + '-' + MODULE_STREAM,
+                               42, base_module,
                                {'eog': base_module},
                                repo_url)
     set_compose_info(workflow, compose_info)

--- a/tests/plugins/test_flatpak_create_oci.py
+++ b/tests/plugins/test_flatpak_create_oci.py
@@ -726,7 +726,8 @@ def test_flatpak_create_oci(tmpdir, docker_tasker, config_name, breakage, mock_f
     base_module = modules[config['base_module']]
 
     repo_url = 'http://odcs.example/composes/latest-odcs-42-1/compose/Temporary/$basearch/os/'
-    compose_info = ComposeInfo(42, base_module,
+    compose_info = ComposeInfo(base_module.name + '-' + base_module.stream,
+                               42, base_module,
                                modules,
                                repo_url)
     set_compose_info(workflow, compose_info)

--- a/tests/plugins/test_koji_promote.py
+++ b/tests/plugins/test_koji_promote.py
@@ -37,6 +37,10 @@ from atomic_reactor.plugins.exit_koji_tag_build import KojiTagBuildPlugin
 from atomic_reactor.plugins.pre_check_and_set_rebuild import CheckAndSetRebuildPlugin
 from atomic_reactor.plugins.pre_add_filesystem import AddFilesystemPlugin
 from atomic_reactor.plugins.pre_add_help import AddHelpPlugin
+from atomic_reactor.plugins.pre_flatpak_create_dockerfile import (FlatpakSourceInfo,
+                                                                  set_flatpak_source_info)
+from atomic_reactor.plugins.pre_resolve_module_compose import (ModuleInfo,
+                                                               ComposeInfo)
 from atomic_reactor.plugin import ExitPluginsRunner, PluginFailedException
 from atomic_reactor.inner import DockerBuildWorkflow, TagConf, PushConf
 from atomic_reactor.util import ImageName, ManifestDigest
@@ -50,6 +54,8 @@ try:
     PULP_SYNC_AVAILABLE = True
 except ImportError:
     PULP_SYNC_AVAILABLE = False
+
+from modulemd import ModuleMetadata
 
 from flexmock import flexmock
 import pytest
@@ -1354,6 +1360,56 @@ class TestKojiPromote(object):
             assert image['help'] is None
         elif expect_result in ['skip', 'unknown_status']:
             assert 'help' not in image.keys()
+
+    def test_koji_promote_flatpak(self, tmpdir, os_env):
+        session = MockedClientSession('')
+        tasker, workflow = mock_environment(tmpdir,
+                                            name='ns/name',
+                                            version='1.0',
+                                            release='1',
+                                            session=session)
+
+        modules = {
+            'eog': ModuleInfo(name='eog',
+                              stream='f26',
+                              version='20170629213428',
+                              mmd=ModuleMetadata(),
+                              rpms=[]),
+            'flatpak-runtime': ModuleInfo(name='flatpak-runtime',
+                                          stream='f26',
+                                          version='20170701152209',
+                                          mmd=ModuleMetadata(),
+                                          rpms=[]),
+        }
+        base_module = modules['eog']
+
+        repo_url = 'http://odcs.example/composes/latest-odcs-42-1/compose/Temporary/$basearch/os/'
+        compose_info = ComposeInfo(base_module.name + '-' + base_module.stream,
+                                   42, base_module,
+                                   modules,
+                                   repo_url)
+
+        source = FlatpakSourceInfo(flatpak_json={}, compose=compose_info)
+        set_flatpak_source_info(workflow, source)
+
+        runner = create_runner(tasker, workflow)
+        runner.run()
+
+        data = session.metadata
+        assert 'build' in data
+        build = data['build']
+        assert isinstance(build, dict)
+        assert 'extra' in build
+        extra = build['extra']
+        assert isinstance(extra, dict)
+        assert 'image' in extra
+        image = extra['image']
+        assert isinstance(image, dict)
+
+        assert image.get('flatpak') is True
+        assert image.get('modules') == ['eog-f26-20170629213428',
+                                        'flatpak-runtime-f26-20170701152209']
+        assert image.get('source_modules') == ['eog-f26']
 
     @pytest.mark.parametrize('logs_return_bytes', [
         True,


### PR DESCRIPTION
In the extra data we send to Koji for a Flatpak build, include:

```    
'flatpak': True,
'source_modules': [<specified module for the build>],
'modules': [<resolved list of module name-stream-version>]
```
    
This is sufficient information to know when a rebuild needs to be triggered and to start a rebuild.