### PR TITLE
Give OCI images uploaded to Koji an appropriate filename

### DIFF
--- a/atomic_reactor/plugins/exit_koji_promote.py
+++ b/atomic_reactor/plugins/exit_koji_promote.py
@@ -39,7 +39,8 @@ from atomic_reactor.constants import (PROG, PLUGIN_KOJI_PROMOTE_PLUGIN_KEY,
 from atomic_reactor.util import (get_version_of_tools, get_checksums,
                                  get_build_json, get_preferred_label,
                                  get_docker_architecture, df_parser,
-                                 are_plugins_in_order)
+                                 are_plugins_in_order,
+                                 get_image_upload_filename)
 from atomic_reactor.koji_util import (create_koji_session, tag_koji_build,
                                       Output, KojiUploadLogger)
 from osbs.conf import Configuration
@@ -387,11 +388,10 @@ class KojiPromotePlugin(ExitPlugin):
 
         """
 
-        image_id = self.workflow.builder.image_id
         saved_image = self.workflow.exported_image_sequence[-1].get('path')
-        ext = saved_image.split('.', 1)[1]
-        name_fmt = 'docker-image-{id}.{arch}.{ext}'
-        image_name = name_fmt.format(id=image_id, arch=arch, ext=ext)
+        image_name = get_image_upload_filename(self.workflow.exported_image_sequence[-1],
+                                               self.workflow.builder.image_id,
+                                               arch)
         if self.metadata_only:
             metadata = self.get_output_metadata(os.path.devnull, image_name)
             output = Output(file=None, metadata=metadata)

--- a/atomic_reactor/plugins/post_koji_upload.py
+++ b/atomic_reactor/plugins/post_koji_upload.py
@@ -19,7 +19,8 @@ from atomic_reactor.plugin import PostBuildPlugin
 from atomic_reactor.plugins.post_rpmqa import PostBuildRPMqaPlugin
 from atomic_reactor.constants import PROG, PLUGIN_KOJI_UPLOAD_PLUGIN_KEY
 from atomic_reactor.util import (get_version_of_tools, get_checksums,
-                                 get_build_json, get_docker_architecture)
+                                 get_build_json, get_docker_architecture,
+                                 get_image_upload_filename)
 from atomic_reactor.koji_util import create_koji_session
 from osbs.conf import Configuration
 from osbs.api import OSBS
@@ -364,12 +365,10 @@ class KojiUploadPlugin(PostBuildPlugin):
 
         """
 
-        image_id = self.workflow.builder.image_id
         saved_image = self.workflow.exported_image_sequence[-1].get('path')
-        ext = saved_image.split('.', 1)[1]
-        name_fmt = 'docker-image-{id}.{platform}.{ext}'
-        image_name = name_fmt.format(id=image_id, platform=self.platform,
-                                     ext=ext)
+        image_name = get_image_upload_filename(self.workflow.exported_image_sequence[-1],
+                                               self.workflow.builder.image_id,
+                                               self.platform)
         metadata = self.get_output_metadata(saved_image, image_name)
         output = Output(file=open(saved_image), metadata=metadata)
 

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -28,7 +28,8 @@ import codecs
 import string
 
 from atomic_reactor.constants import DOCKERFILE_FILENAME, FLATPAK_FILENAME, TOOLS_USED,\
-                                     INSPECT_CONFIG, IMAGE_TYPE_OCI,\
+                                     INSPECT_CONFIG,\
+                                     IMAGE_TYPE_DOCKER_ARCHIVE, IMAGE_TYPE_OCI, IMAGE_TYPE_OCI_TAR,\
                                      HTTP_MAX_RETRIES, HTTP_BACKOFF_FACTOR,\
                                      HTTP_CLIENT_STATUS_RETRY, HTTP_REQUEST_TIMEOUT
 
@@ -480,6 +481,21 @@ def get_exported_image_metadata(path, image_type):
         logger.debug('size: %d bytes', metadata['size'])
         metadata.update(get_checksums(path, ['md5', 'sha256']))
     return metadata
+
+
+def get_image_upload_filename(metadata, image_id, platform):
+    saved_image = metadata.get('path')
+    image_type = metadata.get('type')
+    if image_type == IMAGE_TYPE_DOCKER_ARCHIVE:
+        base_name = 'docker-image'
+    elif image_type == IMAGE_TYPE_OCI_TAR:
+        base_name = 'oci-image'
+    else:
+        raise ValueError("Unhandled image type for upload: {}".format(image_type))
+    ext = saved_image.split('.', 1)[1]
+    name_fmt = '{base_name}-{id}.{platform}.{ext}'
+    return name_fmt.format(base_name=base_name, id=image_id,
+                           platform=platform, ext=ext)
 
 
 def get_version_of_tools():

--- a/tests/plugins/test_koji_import.py
+++ b/tests/plugins/test_koji_import.py
@@ -50,7 +50,8 @@ from atomic_reactor.inner import DockerBuildWorkflow, TagConf, PushConf
 from atomic_reactor.util import ImageName, ManifestDigest
 from atomic_reactor.source import GitSource, PathSource
 from atomic_reactor.build import BuildResult
-from atomic_reactor.constants import (PLUGIN_PULP_PULL_KEY, PLUGIN_PULP_SYNC_KEY,
+from atomic_reactor.constants import (IMAGE_TYPE_DOCKER_ARCHIVE,
+                                      PLUGIN_PULP_PULL_KEY, PLUGIN_PULP_SYNC_KEY,
                                       PLUGIN_GROUP_MANIFESTS_KEY, PLUGIN_KOJI_PARENT_KEY)
 from tests.constants import SOURCE, MOCK
 
@@ -288,7 +289,8 @@ def mock_environment(tmpdir, session=None, name=None,
 
     with open(os.path.join(str(tmpdir), 'image.tar.xz'), 'wt') as fp:
         fp.write('x' * 2**12)
-        setattr(workflow, 'exported_image_sequence', [{'path': fp.name}])
+        setattr(workflow, 'exported_image_sequence', [{'path': fp.name,
+                                                       'type': IMAGE_TYPE_DOCKER_ARCHIVE}])
 
     annotations = {
         'worker-builds': {

--- a/tests/plugins/test_koji_promote.py
+++ b/tests/plugins/test_koji_promote.py
@@ -27,7 +27,8 @@ except ImportError:
     del koji
     import koji
 
-from atomic_reactor.constants import (PLUGIN_PULP_SYNC_KEY, PLUGIN_PULP_PULL_KEY,
+from atomic_reactor.constants import (IMAGE_TYPE_DOCKER_ARCHIVE,
+                                      PLUGIN_PULP_SYNC_KEY, PLUGIN_PULP_PULL_KEY,
                                       PLUGIN_KOJI_PARENT_KEY)
 from atomic_reactor.core import DockerTasker
 from atomic_reactor.plugins.exit_koji_promote import (KojiUploadLogger,
@@ -277,7 +278,8 @@ def mock_environment(tmpdir, session=None, name=None,
 
     with open(os.path.join(str(tmpdir), 'image.tar.xz'), 'wt') as fp:
         fp.write('x' * 2**12)
-        setattr(workflow, 'exported_image_sequence', [{'path': fp.name}])
+        setattr(workflow, 'exported_image_sequence', [{'path': fp.name,
+                                                       'type': IMAGE_TYPE_DOCKER_ARCHIVE}])
 
     if build_process_failed:
         workflow.build_result = BuildResult(logs=["docker build log - \u2018 \u2017 \u2019 \n'"],

--- a/tests/plugins/test_koji_upload.py
+++ b/tests/plugins/test_koji_upload.py
@@ -29,6 +29,7 @@ except ImportError:
     del koji
     import koji
 
+from atomic_reactor.constants import IMAGE_TYPE_DOCKER_ARCHIVE
 from atomic_reactor.core import DockerTasker
 from atomic_reactor.plugins.post_koji_upload import (KojiUploadLogger,
                                                      KojiUploadPlugin)
@@ -302,7 +303,8 @@ def mock_environment(tmpdir, session=None, name=None,
 
     with open(os.path.join(str(tmpdir), 'image.tar.xz'), 'wt') as fp:
         fp.write('x' * 2**12)
-        setattr(workflow, 'exported_image_sequence', [{'path': fp.name}])
+        setattr(workflow, 'exported_image_sequence', [{'path': fp.name,
+                                                       'type': IMAGE_TYPE_DOCKER_ARCHIVE}])
 
     if build_process_failed:
         workflow.build_result = BuildResult(logs=["docker build log - \u2018 \u2017 \u2019 \n'"],


### PR DESCRIPTION
Instead of docker-image-{id}.tar.gz, call uploaded OCI images oci-image-{id}.tar.gz.

This involves moving the logic of creating the filename into a new utility function util.get_image_upload_filename()