### PR TITLE
post_group_manifests: add support for OCI Manifests and Indices

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -109,3 +109,4 @@ MEDIA_TYPE_DOCKER_V2_SCHEMA1 = "application/vnd.docker.distribution.manifest.v1+
 MEDIA_TYPE_DOCKER_V2_SCHEMA2 = "application/vnd.docker.distribution.manifest.v2+json"
 MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST = "application/vnd.docker.distribution.manifest.list.v2+json"
 MEDIA_TYPE_OCI_V1 = "application/vnd.oci.image.manifest.v1+json"
+MEDIA_TYPE_OCI_V1_INDEX = "application/vnd.oci.image.index.v1+json"

--- a/atomic_reactor/plugins/post_group_manifests.py
+++ b/atomic_reactor/plugins/post_group_manifests.py
@@ -18,10 +18,9 @@ from tempfile import NamedTemporaryFile
 import yaml
 from subprocess import check_output, CalledProcessError, STDOUT
 
-from six.moves.urllib.parse import urlparse
-
 from atomic_reactor.plugin import PostBuildPlugin, PluginFailedException
-from atomic_reactor.util import Dockercfg, get_manifest_digests, get_retrying_requests_session
+from atomic_reactor.util import (Dockercfg, get_manifest_digests, get_retrying_requests_session,
+                                 registry_hostname)
 from atomic_reactor.constants import PLUGIN_GROUP_MANIFESTS_KEY, MEDIA_TYPE_DOCKER_V2_SCHEMA2
 
 
@@ -134,7 +133,7 @@ class GroupManifestsPlugin(PostBuildPlugin):
             if not registry.startswith('http://') and not registry.startswith('https://'):
                 registry = 'https://' + registry
 
-            registry_noschema = urlparse(registry).netloc
+            registry_noschema = registry_hostname(registry)
             self.log.debug("evaluating registry %s", registry_noschema)
 
             insecure = registry_conf.get('insecure', False)

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -716,7 +716,7 @@ def query_registry(image, registry, digest=None, insecure=False, dockercfg_path=
     """
     auth = None
     if dockercfg_path:
-        dockercfg = Dockercfg(dockercfg_path).get_credentials(image.registry)
+        dockercfg = Dockercfg(dockercfg_path).get_credentials(registry)
 
         username = dockercfg.get('username')
         password = dockercfg.get('password')

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -35,7 +35,8 @@ from atomic_reactor.constants import (DOCKERFILE_FILENAME, FLATPAK_FILENAME, TOO
                                       HTTP_MAX_RETRIES, HTTP_BACKOFF_FACTOR,
                                       HTTP_CLIENT_STATUS_RETRY, HTTP_REQUEST_TIMEOUT,
                                       MEDIA_TYPE_DOCKER_V2_SCHEMA1, MEDIA_TYPE_DOCKER_V2_SCHEMA2,
-                                      MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST, MEDIA_TYPE_OCI_V1)
+                                      MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST, MEDIA_TYPE_OCI_V1,
+                                      MEDIA_TYPE_OCI_V1_INDEX)
 
 from dockerfile_parse import DockerfileParser
 from pkg_resources import resource_stream
@@ -727,7 +728,8 @@ class ManifestDigest(dict):
         'v1': MEDIA_TYPE_DOCKER_V2_SCHEMA1,
         'v2': MEDIA_TYPE_DOCKER_V2_SCHEMA2,
         'v2_list': MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST,
-        'oci': MEDIA_TYPE_OCI_V1
+        'oci': MEDIA_TYPE_OCI_V1,
+        'oci_index': MEDIA_TYPE_OCI_V1_INDEX,
     }
 
     @property
@@ -740,7 +742,7 @@ class ManifestDigest(dict):
         with the registry. An OCI digest will only be present when
         the manifest was pushed as an OCI digest.
         """
-        return self.v2_list or self.oci or self.v2 or self.v1
+        return self.v2_list or self.oci_index or self.oci or self.v2 or self.v1
 
     def __getattr__(self, attr):
         if attr not in self.content_type:
@@ -807,7 +809,7 @@ def query_registry(registry_session, image, digest=None, version='v1', is_blob=F
 
 
 def get_manifest_digests(image, registry, insecure=False, dockercfg_path=None,
-                         versions=('v1', 'v2', 'v2_list', 'oci'), require_digest=True):
+                         versions=('v1', 'v2', 'v2_list', 'oci', 'oci_index'), require_digest=True):
     """Return manifest digest for image.
 
     :param image: ImageName, the remote image to inspect

--- a/tests/plugins/test_group_manifests.py
+++ b/tests/plugins/test_group_manifests.py
@@ -9,14 +9,13 @@ of the BSD license. See the LICENSE file for details.
 from __future__ import print_function, unicode_literals
 import pytest
 import json
+import hashlib
+import re
 import responses
-from copy import deepcopy
 from tempfile import mkdtemp
 import os
-from flexmock import flexmock
-import subprocess
-from subprocess import CalledProcessError
-from requests.exceptions import ConnectionError
+import requests
+from six import binary_type, text_type
 
 from tests.constants import SOURCE, INPUT_IMAGE, MOCK, DOCKER0_REGISTRY
 
@@ -24,15 +23,250 @@ from atomic_reactor.core import DockerTasker
 from atomic_reactor.build import BuildResult
 from atomic_reactor.plugin import PostBuildPluginsRunner, PluginFailedException
 from atomic_reactor.inner import DockerBuildWorkflow, TagConf
-from atomic_reactor.util import ImageName
+from atomic_reactor.util import ImageName, registry_hostname
 from atomic_reactor.plugins.post_group_manifests import GroupManifestsPlugin
 
 if MOCK:
     from tests.docker_mock import mock_docker
 
 
-DIGEST1 = 'sha256:28b64a8b29fd2723703bb17acf907cd66898440270e536992b937899a4647414'
-DIGEST2 = 'sha256:0000000000000000000000000000000000000000000000000000000000000000'
+def to_bytes(value):
+    if isinstance(value, binary_type):
+        return value
+    else:
+        return value.encode('utf-8')
+
+
+def to_text(value):
+    if isinstance(value, text_type):
+        return value
+    else:
+        return text_type(value, 'utf-8')
+
+
+def make_digest(blob):
+    # Abbreviate the hexdigest for readability of debugging output if things fail
+    return 'sha256:' + hashlib.sha256(to_bytes(blob)).hexdigest()[0:10]
+
+
+class MockRegistry(object):
+    """
+    This class mocks a subset of the v2 Docker Registry protocol
+    """
+    def __init__(self, registry):
+        self.hostname = registry_hostname(registry)
+        self.repos = {}
+        self._add_pattern(responses.GET, r'/v2/(.*)/manifests/([^/]+)',
+                          self._get_manifest)
+        self._add_pattern(responses.HEAD, r'/v2/(.*)/manifests/([^/]+)',
+                          self._get_manifest)
+        self._add_pattern(responses.PUT, r'/v2/(.*)/manifests/([^/]+)',
+                          self._put_manifest)
+        self._add_pattern(responses.GET, r'/v2/(.*)/blobs/([^/]+)',
+                          self._get_blob)
+        self._add_pattern(responses.HEAD, r'/v2/(.*)/blobs/([^/]+)',
+                          self._get_blob)
+        self._add_pattern(responses.POST, r'/v2/(.*)/blobs/uploads/\?mount=([^&]+)&from=(.+)',
+                          self._mount_blob)
+
+    def get_repo(self, name):
+        return self.repos.setdefault(name, {
+            'blobs': {},
+            'manifests': {},
+            'tags': {},
+        })
+
+    def add_blob(self, name, blob):
+        repo = self.get_repo(name)
+        digest = make_digest(blob)
+        repo['blobs'][digest] = blob
+        return digest
+
+    def get_blob(self, name, digest):
+        return self.get_repo(name)['blobs'][digest]
+
+    def add_manifest(self, name, ref, manifest):
+        repo = self.get_repo(name)
+        digest = make_digest(manifest)
+        repo['manifests'][digest] = manifest
+        if ref.startswith('sha256:'):
+            assert ref == digest
+        else:
+            repo['tags'][ref] = digest
+        return digest
+
+    def get_manifest(self, name, ref):
+        repo = self.get_repo(name)
+        if not ref.startswith('sha256:'):
+            ref = repo['tags'][ref]
+        return repo['manifests'][ref]
+
+    def _add_pattern(self, method, pattern, callback):
+        pat = re.compile(r'^https://' + self.hostname + pattern + '$')
+
+        def do_it(req):
+            status, headers, body = callback(req, *(pat.match(req.url).groups()))
+            if method == responses.HEAD:
+                return status, headers, ''
+            else:
+                return status, headers, body
+
+        responses.add_callback(method, pat, do_it, match_querystring=True)
+
+    def _get_manifest(self, req, name, ref):
+        repo = self.get_repo(name)
+        if not ref.startswith('sha256:'):
+            try:
+                ref = repo['tags'][ref]
+            except KeyError:
+                return (requests.codes.NOT_FOUND, {}, {'error': 'NOT_FOUND'})
+
+        try:
+            blob = repo['manifests'][ref]
+        except KeyError:
+            return (requests.codes.NOT_FOUND, {}, {'error': 'NOT_FOUND'})
+
+        decoded = json.loads(to_text(blob))
+        content_type = decoded['mediaType']
+
+        accepts = re.split('\s*,\s*', req.headers['Accept'])
+        assert content_type in accepts
+
+        headers = {
+            'Docker-Content-Digest': ref,
+            'Content-Type': content_type,
+            'Content-Length': str(len(blob)),
+        }
+        return (200, headers, blob)
+
+    def _put_manifest(self, req, name, ref):
+        try:
+            json.loads(to_text(req.body))
+        except ValueError:
+            return (400, {}, {'error': 'BAD_MANIFEST'})
+
+        self.add_manifest(name, ref, req.body)
+        return (200, {}, '')
+
+    def _get_blob(self, req, name, digest):
+        repo = self.get_repo(name)
+        assert digest.startswith('sha256:')
+
+        try:
+            blob = repo['blobs'][digest]
+        except KeyError:
+            return (requests.codes.NOT_FOUND, {}, {'error': 'NOT_FOUND'})
+
+        headers = {
+            'Docker-Content-Digest': digest,
+            'Content-Type': 'application/json',
+            'Content-Length': str(len(blob)),
+        }
+        return (200, headers, blob)
+
+    def _mount_blob(self, req, target_name, digest, source_name):
+        source_repo = self.get_repo(source_name)
+        target_repo = self.get_repo(target_name)
+
+        try:
+            target_repo['blobs'][digest] = source_repo['blobs'][digest]
+            headers = {
+                'Location': '/v2/{}/blobs/{}'.format(target_name, digest),
+                'Docker-Content-Digest': digest,
+            }
+            return (201, headers, '')
+        except KeyError:
+            headers = {
+                'Location': '/v2/{}/blobs/uploads/some-uuid'.format(target_name),
+                'Docker-Upload-UUID': 'some-uuid',
+            }
+            return (202, headers, '')
+
+
+def mock_registries(registries, config, schema_version='v2', foreign_layers=False):
+    """
+    Creates MockRegistries objects and fills them in based on config, which specifies
+    which registries should be prefilled (as if by workers) with platform-specific
+    manifests, and with what tags.
+    """
+    reg_map = {}
+    for reg in registries:
+        reg_map[reg] = MockRegistry(reg)
+
+    worker_builds = {}
+
+    for platform, regs in config.items():
+        digests = []
+
+        for reg, tags in regs.items():
+            registry = reg_map[reg]
+            layer_digest = make_digest('layer-' + platform)
+            config_digest = make_digest('config-' + platform)
+
+            if schema_version == 'v2':
+                manifest = {
+                    'schemaVersion': 2,
+                    'mediaType': 'application/vnd.docker.distribution.manifest.v2+json',
+                    'config': {
+                        'mediaType': 'application/vnd.docker.container.image.v1+json',
+                        'digest':  config_digest,
+                        # 'size': required by spec, skipped for test
+                    },
+                    'layers': [{
+                        'mediaType': 'application/vnd.docker.image.rootfs.diff.tar.gzip',
+                        'digest': layer_digest,
+                        # 'size': required, skipped for test
+                    }]
+                }
+                if foreign_layers:
+                    manifest['layers'].append({
+                        'mediaType': 'application/vnd.docker.image.rootfs.foreign.diff.tar.gzip',
+                        'digest': make_digest('foreign-layer-' + platform),
+                        'urls': ['https://example.com/example-layer']
+                    })
+            elif schema_version == 'oci':
+                manifest = {
+                    'schemaVersion': 2,
+                    'mediaType': 'application/vnd.oci.image.manifest.v1+json',
+                    'config': {
+                        'mediaType': 'application/vnd.oci.image.config.v1+json',
+                        'digest': config_digest,
+                        # 'size': required by spec, skipped for test
+                    },
+                    'layers': [{
+                        'mediaType': 'application/vnd.oci.image.layer.v1.tar',
+                        'digest': layer_digest,
+                        # 'size': required, skipped for test
+                    }]
+                }
+                if foreign_layers:
+                    manifest['layers'].append({
+                        'mediaType': 'application/vnd.oci.image.layer.nondistributable.v1.tar',
+                        'digest': make_digest('foreign-layer-' + platform),
+                        'urls': ['https://example.com/example-layer']
+                    })
+
+            for t in tags:
+                name, tag = t.split(':')
+                registry.add_blob(name, 'layer-' + platform)
+                registry.add_blob(name, 'config-' + platform)
+                manifest_bytes = to_bytes(json.dumps(manifest))
+                digest = registry.add_manifest(name, tag, manifest_bytes)
+
+                digests.append({
+                    'registry': reg,
+                    'repository': name,
+                    'tag': tag,
+                    'digest': digest
+                })
+
+        worker_builds[platform] = {
+            'digests': digests
+        }
+
+    return reg_map, {
+        'worker-builds': worker_builds
+    }
 
 
 class Y(object):
@@ -47,60 +281,8 @@ class X(object):
     base_image = ImageName(repo="qwe", tag="asd")
 
 
-X86_DIGESTS = [
-    {
-        'digest': 'sha256:worker-build-x86_64-digest',
-        'tag': 'worker-build-x86_64-latest',
-        'registry': DOCKER0_REGISTRY,
-        'repository': 'worker-build-x86_64-repository',
-    },
-]
-X86_ANNOTATIONS = {
-    'build': {
-        'build-name': 'worker-build-x86_64',
-        'cluster-url': 'https://worker_x86_64.com/',
-        'namespace': 'worker_x86_64_namespace'
-    },
-    'digests': X86_DIGESTS,
-    'plugins-metadata': {},
-}
-PPC_DIGESTS = [
-    {
-        'digest': 'sha256:worker-build-ppc64le-digest',
-        'tag': 'worker-build-ppc64le-latest',
-        'registry': 'worker-build-ppc64le-registry',
-        'repository': 'worker-build-ppc64le-repository',
-    },
-]
-PPC_ANNOTATIONS = {
-    'build': {
-        'build-name': 'worker-build-ppc64le',
-        'cluster-url': 'https://worker_ppc64le.com/',
-        'namespace': 'worker_ppc64le_namespace'
-    },
-    'digests': PPC_DIGESTS,
-    'plugins-metadata': {}
-}
-
-BUILD_ANNOTATIONS = {
-        'worker-builds': {
-        },
-        'repositories': {
-            'unique': [
-                'worker-build-ppc64le-unique',
-                'worker-build-x86_64-unique',
-            ],
-            'primary': [
-                'worker-build-ppc64le-primary',
-                'worker-build-x86_64-primary',
-            ],
-        },
-    }
-V1_REGISTRY = "10.10.0.1:5000"
-
-
 def mock_environment(tmpdir, primary_images=None,
-                     worker_annotations={}):
+                     annotations={}):
     if MOCK:
         mock_docker()
     tasker = DockerTasker()
@@ -119,214 +301,239 @@ def mock_environment(tmpdir, primary_images=None,
         workflow.tag_conf.add_primary_images(primary_images)
         workflow.tag_conf.add_unique_image(primary_images[0])
 
-    annotations = deepcopy(BUILD_ANNOTATIONS)
-    if not worker_annotations:
-        worker_annotations = {'ppc64le': PPC_ANNOTATIONS}
-    for worker in worker_annotations:
-        annotations['worker-builds'][worker] = deepcopy(worker_annotations[worker])
-
     workflow.build_result = BuildResult(image_id='123456', annotations=annotations)
 
     return tasker, workflow
 
 
-def mock_url_responses(docker_registry, test_images, worker_digests, version='2', respond=True):
-    def verify_put_body(req):
-        assert req.body == body.encode('utf-8')
-        return (status, req.headers, '')
-
-    responses.reset()
-    for worker_digest in worker_digests:
-        digest = worker_digest[0]['digest']
-        repo = worker_digest[0]['repository']
-        for registry in docker_registry:
-            if not registry.startswith('http://') and not registry.startswith('https://'):
-                registry = 'https://' + registry
-            url = '{0}/v2/{1}/manifests/{2}'.format(registry, repo, digest)
-            body = json.dumps({'tag': 'testtag', 'schemaVersion': version}, indent=2)
-            responses.add(responses.GET, url, body=body)
-            if respond:
-                status = 200
-            else:
-                status = 400
-                body = json.dumps({'error': 'INVALID MANIFEST'})
-            for image_tag in test_images:
-                url = '{0}/v2/{1}/manifests/{2}'.format(registry, repo, image_tag.split(':')[1])
-                responses.add_callback(responses.PUT, url, callback=verify_put_body)
+REGISTRY_V1 = 'registry_v1.example.com'
+REGISTRY_V2 = 'registry_v2.example.com'
+OTHER_V2 = 'registry.example.com:5001'
 
 
-class TestGroupManifests(object):
-    @pytest.mark.parametrize(('goarch', 'worker_annotations', 'valid'), [
-        ({}, {}, False),
-        ({'ppc64le': 'powerpc', 'x86_64': 'amd64'},
-         {'ppc64le': PPC_ANNOTATIONS, 'x86_64': X86_ANNOTATIONS}, True),
-        ({'ppc64le': 'powerpc', 'x86_64': 'amd64'},
-         {'ppc64le': PPC_ANNOTATIONS, 'x86_64': X86_ANNOTATIONS}, False),
-    ])
-    @responses.activate  # noqa
-    def test_group_manifests_true(self, tmpdir, goarch, worker_annotations, valid):
-        if MOCK:
-            mock_docker()
+@pytest.mark.parametrize('schema_version', ('v2', 'oci'))
+@pytest.mark.parametrize(('test_name', 'group', 'foreign_layers',
+                          'registries', 'workers', 'expected_exception'), [
+    # Basic manifest grouping, v1 registry should be ignored
+    ("group",
+     True, False, [REGISTRY_V2, OTHER_V2, REGISTRY_V1],
+     {
+         'ppc64le': {
+             REGISTRY_V2: ['namespace/httpd:worker-build-ppc64le-latest'],
+             OTHER_V2: ['namespace/httpd:worker-build-ppc64le-latest'],
+         },
+         'x86_64': {
+             REGISTRY_V2: ['namespace/httpd:worker-build-x86_64-latest'],
+             OTHER_V2: ['namespace/httpd:worker-build-x86_64-latest'],
+         }
+     },
+     None),
+    # Have to copy the referenced manifests and link blobs from one repository to another
+    ("group_link_manifests",
+     True, False, [REGISTRY_V2],
+     {
+         'ppc64le': {
+             REGISTRY_V2: ['worker-build:worker-build-ppc64le-latest'],
+         },
+         'x86_64': {
+             REGISTRY_V2: ['worker-build:worker-build-x86_64-latest'],
+         }
+     },
+     None),
+    # Have to copy the referenced manifests and link blobs from one repository to another;
+    # some layers of the image are foreign and thus not found to copy
+    ("group_link_manifests_foreign",
+     True, True, [REGISTRY_V2],
+     {
+         'ppc64le': {
+             REGISTRY_V2: ['worker-build:worker-build-ppc64le-latest'],
+         },
+         'x86_64': {
+             REGISTRY_V2: ['worker-build:worker-build-x86_64-latest'],
+         }
+     },
+     None),
+    # Some architectures aren't present for a registry, should error out
+    ("group_missing_arches",
+     True, False, [REGISTRY_V2],
+     {
+         'ppc64le': {
+             REGISTRY_V2: ['namespace/httpd:worker-build-ppc64le-latest'],
+         },
+         'x86_64': {
+         }
+     },
+     "Missing platforms for registry"),
+    # No workers at all, should error out
+    ("group_no_workers",
+     True, False, [REGISTRY_V2],
+     {
+     },
+     "No worker builds found"),
+    # group=False, should tag x86_64 manifest with configured tags
+    ("tag",
+     False, False, [REGISTRY_V2, OTHER_V2, REGISTRY_V1],
+     {
+         'ppc64le': {
+             REGISTRY_V2: ['namespace/httpd:worker-build-ppc64le-latest'],
+             OTHER_V2: ['namespace/httpd:worker-build-ppc64le-latest'],
+         },
+         'x86_64': {
+             REGISTRY_V2: ['namespace/httpd:worker-build-x86_64-latest'],
+             OTHER_V2: ['namespace/httpd:worker-build-x86_64-latest'],
+         }
+     },
+     None),
+    # Have to copy the manifest and link blobs from one repository to another
+    ("tag_link_manifests",
+     False, False, [REGISTRY_V2],
+     {
+         'ppc64le': {
+             REGISTRY_V2: ['worker-build:worker-build-ppc64le-latest'],
+         },
+         'x86_64': {
+             REGISTRY_V2: ['worker-build:worker-build-x86_64-latest'],
+         }
+     },
+     None),
+    # No x86_64 found, should error out
+    ("tag_no_x86_64",
+     False, False, [REGISTRY_V2],
+     {
+         'ppc64le': {
+             REGISTRY_V2: ['namespace/httpd:worker-build-ppc64le-latest'],
+         },
+     },
+     "failed to find an x86_64 platform")
+])
+@responses.activate  # noqa
+def test_group_manifests(tmpdir, test_name,
+                         schema_version, group, foreign_layers, registries, workers,
+                         expected_exception):
+    if MOCK:
+        mock_docker()
 
-        test_images = ['registry.example.com/namespace/httpd:2.4',
-                       'registry.example.com/namespace/httpd:latest']
-        expected_results = set()
+    test_images = ['namespace/httpd:2.4',
+                   'namespace/httpd:latest']
 
-        registries = {
-            DOCKER0_REGISTRY: {'version': 'v2', 'insecure': True},
-            V1_REGISTRY: {'version': 'v2', 'insecure': True},
-        }
+    goarch = {
+        'ppc64le': 'powerpc',
+        'x86_64': 'amd64',
+    }
 
-        plugins_conf = [{
-            'name': GroupManifestsPlugin.key,
-            'args': {
-                'registries': registries,
-                'group': True,
-                'goarch': goarch,
-            },
-        }]
-        tasker, workflow = mock_environment(tmpdir, primary_images=test_images,
-                                            worker_annotations=worker_annotations)
+    all_registry_conf = {
+        REGISTRY_V1: {'version': 'v1', 'insecure': True},
+        REGISTRY_V2: {'version': 'v2', 'insecure': True},
+        OTHER_V2: {'version': 'v2', 'insecure': False},
+    }
 
-        def request_callback(request):
-            media_type = request.headers['Accept']
-            if media_type.endswith('list.v2+json'):
-                digest = 'v2_list-digest:{0}'.format(request.url)
-            else:
-                raise ValueError('Unexpected media type {}'.format(media_type))
-
-            media_type_prefix = media_type.split('+')[0]
-            headers = {
-                'Content-Type': '{}+jsonish'.format(media_type_prefix),
-                'Docker-Content-Digest': digest
+    temp_dir = mkdtemp(dir=str(tmpdir))
+    with open(os.path.join(temp_dir, ".dockercfg"), "w+") as dockerconfig:
+        dockerconfig_contents = {
+            REGISTRY_V2: {
+                "username": "user", "password": DOCKER0_REGISTRY
             }
-            return (200, headers, '')
-
-        for registry in registries:
-            if valid:
-                repo_and_tag = workflow.tag_conf.images[0].to_str(registry=False).split(':')
-                url = 'http://{0}/v2/{1}/manifests/{2}'.format(registry, repo_and_tag[0],
-                                                               repo_and_tag[1])
-                expected_results.add('v2_list-digest:{0}'.format(url))
-            for image in workflow.tag_conf.images:
-                repo_and_tag = image.to_str(registry=False).split(':')
-                path = '/v2/{0}/manifests/{1}'.format(repo_and_tag[0], repo_and_tag[1])
-                https_url = 'https://' + registry + path
-                responses.add(responses.GET, https_url, body=ConnectionError())
-                url = 'http://' + registry + path
-                if valid:
-                    responses.add_callback(responses.GET, url, callback=request_callback)
-
-        (flexmock(subprocess)
-         .should_receive("check_output"))
-
-        runner = PostBuildPluginsRunner(tasker, workflow, plugins_conf)
-        if valid:
-            result = runner.run()
-            test_results = set()
-            for digest in result['group_manifests']:
-                test_results.add(digest.v2_list)
-            assert test_results == expected_results
-        else:
-            with pytest.raises(PluginFailedException):
-                runner.run()
-
-    @responses.activate  # noqa
-    def test_group_manifests_manifest_tool_fail(self, tmpdir):
-        if MOCK:
-            mock_docker()
-
-        goarch = {'ppc64le': 'powerpc', 'x86_64': 'amd64'}
-        worker_annotations = {'ppc64le': PPC_ANNOTATIONS, 'x86_64': X86_ANNOTATIONS}
-
-        test_images = ['registry.example.com/namespace/httpd:2.4',
-                       'registry.example.com/namespace/httpd:latest']
-
-        registries = {
-            DOCKER0_REGISTRY: {'version': 'v2', 'insecure': True},
-            V1_REGISTRY: {'version': 'v2', 'insecure': True},
         }
+        dockerconfig.write(json.dumps(dockerconfig_contents))
+        dockerconfig.flush()
+        all_registry_conf[REGISTRY_V2]['secret'] = temp_dir
 
-        plugins_conf = [{
-            'name': GroupManifestsPlugin.key,
-            'args': {
-                'registries': registries,
-                'group': True,
-                'goarch': goarch,
-            },
-        }]
-        tasker, workflow = mock_environment(tmpdir, primary_images=test_images,
-                                            worker_annotations=worker_annotations)
+    registry_conf = {
+        k: v for k, v in all_registry_conf.items() if k in registries
+    }
 
-        (flexmock(subprocess)
-         .should_receive("check_output")
-         .and_raise(CalledProcessError))
+    plugins_conf = [{
+        'name': GroupManifestsPlugin.key,
+        'args': {
+            'registries': registry_conf,
+            'group': group,
+            'goarch': goarch,
+        },
+    }]
 
-        runner = PostBuildPluginsRunner(tasker, workflow, plugins_conf)
-        with pytest.raises(PluginFailedException):
+    mocked_registries, annotations = mock_registries(registry_conf, workers,
+                                                     schema_version=schema_version,
+                                                     foreign_layers=foreign_layers)
+    tasker, workflow = mock_environment(tmpdir, primary_images=test_images,
+                                        annotations=annotations)
+
+    runner = PostBuildPluginsRunner(tasker, workflow, plugins_conf)
+    if expected_exception is None:
+        runner.run()
+
+        manifest_type, list_type = {
+            'v2': (
+                'application/vnd.docker.distribution.manifest.v2+json',
+                'application/vnd.docker.distribution.manifest.list.v2+json',
+            ),
+            'oci': (
+                'application/vnd.oci.image.manifest.v1+json',
+                'application/vnd.oci.image.index.v1+json',
+            ),
+        }[schema_version]
+
+        def verify_manifest_in_repository(registry, repo, manifest, platform, tag=None):
+            config = 'config-' + platform
+            assert registry.get_blob(repo, make_digest(config)) == config
+            layer = 'layer-' + platform
+            assert registry.get_blob(repo, make_digest(layer)) == layer
+            assert registry.get_manifest(repo, make_digest(manifest)) == manifest
+            if tag is not None:
+                assert registry.get_manifest(repo, tag) == manifest
+
+        if group:
+            source_builds = {}
+            source_manifests = {}
+
+            for platform in workers:
+                build = annotations['worker-builds'][platform]['digests'][0]
+                source_builds[platform] = build
+                source_registry = mocked_registries[build['registry']]
+                source_manifests[platform] = source_registry.get_manifest(build['repository'],
+                                                                          build['digest'])
+
+            for registry, conf in registry_conf.items():
+                if conf['version'] == 'v1':
+                    continue
+
+                target_registry = mocked_registries[registry]
+                for image in test_images:
+                    name, tag = image.split(':')
+
+                    manifest_list = json.loads(to_text(target_registry.get_manifest(name, tag)))
+                    assert manifest_list['mediaType'] == list_type
+                    assert manifest_list['schemaVersion'] == 2
+
+                    manifests = manifest_list['manifests']
+                    assert all(d['mediaType'] == manifest_type for d in manifests)
+                    assert all(d['platform']['os'] == 'linux' for d in manifests)
+
+                    for platform in annotations['worker-builds']:
+                        descs = [d for d in manifests
+                                 if d['platform']['architecture'] == goarch[platform]]
+                        assert len(descs) == 1
+                        assert descs[0]['digest'] == source_builds[platform]['digest']
+
+                        verify_manifest_in_repository(target_registry, name,
+                                                      source_manifests[platform], platform)
+
+        else:
+            source_build = annotations['worker-builds']['x86_64']['digests'][0]
+            source_registry = mocked_registries[source_build['registry']]
+            source_manifest = source_registry.get_manifest(source_build['repository'],
+                                                           source_build['digest'])
+
+            for registry, conf in registry_conf.items():
+                if conf['version'] == 'v1':
+                    continue
+
+                target_registry = mocked_registries[registry]
+                for image in test_images:
+                    name, tag = image.split(':')
+                    verify_manifest_in_repository(target_registry, name,
+                                                  source_manifest, 'x86_64',
+                                                  tag)
+    else:
+        with pytest.raises(PluginFailedException) as ex:
             runner.run()
-
-    @pytest.mark.parametrize('use_secret', [True, False])
-    @pytest.mark.parametrize('version', ['1', '2'])
-    @pytest.mark.parametrize(('goarch', 'worker_annotations', 'valid', 'respond'), [
-        ({}, {}, False, True),
-        ({}, {'x86_64': X86_ANNOTATIONS}, False, True),
-        ({'x86_64': 'amd64'}, {}, False, True),
-        ({'x86_64': 'amd64'}, {'x86_64': X86_ANNOTATIONS}, True, True),
-        ({'ppc64le': 'powerpc', 'x86_64': 'amd64'},
-         {'ppc64le': PPC_ANNOTATIONS, 'x86_64': X86_ANNOTATIONS}, True, True),
-        ({'ppc64le': 'powerpc', 'x86_64': 'amd64'},
-         {'ppc64le': PPC_ANNOTATIONS, 'x86_64': X86_ANNOTATIONS}, True, False),
-    ])
-    @responses.activate  # noqa
-    def test_group_manifests_false(self, tmpdir, use_secret, goarch,
-                                   worker_annotations, version, valid, respond):
-        if MOCK:
-            mock_docker()
-
-        if version == '1':
-            valid = False
-
-        test_images = ['registry.example.com/namespace/httpd:2.4',
-                       'registry.example.com/namespace/httpd:latest']
-
-        registries = {
-            DOCKER0_REGISTRY: {'version': 'v2'},
-            V1_REGISTRY: {'version': 'v1'},
-        }
-        if use_secret:
-            temp_dir = mkdtemp(dir=str(tmpdir))
-            with open(os.path.join(temp_dir, ".dockercfg"), "w+") as dockerconfig:
-                dockerconfig_contents = {
-                    DOCKER0_REGISTRY: {
-                        "username": "user", "password": DOCKER0_REGISTRY
-                    }
-                }
-                dockerconfig.write(json.dumps(dockerconfig_contents))
-                dockerconfig.flush()
-                registries[DOCKER0_REGISTRY]['secret'] = temp_dir
-
-        plugins_conf = [{
-            'name': GroupManifestsPlugin.key,
-            'args': {
-                'registries': registries,
-                'group': False,
-                'goarch': goarch,
-            },
-        }]
-        tasker, workflow = mock_environment(tmpdir, primary_images=test_images,
-                                            worker_annotations=worker_annotations)
-        mock_url_responses([DOCKER0_REGISTRY], test_images, [X86_DIGESTS], version, respond)
-
-        runner = PostBuildPluginsRunner(tasker, workflow, plugins_conf)
-        if valid and respond:
-            result = runner.run()
-            assert result['group_manifests'] == []
-            expected_digests = {}
-            for image in workflow.tag_conf.primary_images:
-                expected_digests[image.tag] = "sha256:worker-build-x86_64-digest"
-            assert workflow.push_conf.docker_registries
-            assert expected_digests == workflow.push_conf.docker_registries[0].digests
-        else:
-            with pytest.raises(PluginFailedException):
-                runner.run()
+        assert expected_exception in str(ex)

--- a/tests/plugins/test_pulp_pull.py
+++ b/tests/plugins/test_pulp_pull.py
@@ -325,10 +325,10 @@ class TestPostPulpPull(object):
         not_found = requests.Response()
         flexmock(not_found, status_code=requests.codes.not_found)
         expectation = flexmock(requests.Session).should_receive('get')
-        # If pulp is returning a 404 for a manifest URL, we will get 4 requests
-        # (for v1, v2, list.v2, and oci media types) before get_manifest_digests
-        # gives up, so we need to return 4 404's to equal one "failure".
-        for _ in range(4 * failures):
+        # If pulp is returning a 404 for a manifest URL, we will get 5 requests
+        # (for v1, v2, list.v2, oci, and oci.index media types) before get_manifest_digests
+        # gives up, so we need to return 5 404's to equal one "failure".
+        for _ in range(5 * failures):
             expectation = expectation.and_return(not_found)
 
         expectation.and_return(self.config_response_config_v1)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -525,7 +525,8 @@ def test_get_manifest_digests(tmpdir, image, registry, insecure, creds,
     ('v1', False),
     ('v2', True),
     ('v2', False),
-    ('oci', False)
+    ('oci', False),
+    ('oci_index', False),
 ])
 def test_get_manifest_digests_missing(tmpdir, has_content_type_header, has_content_digest,
                                       manifest_type, can_convert_v2_v1):
@@ -585,6 +586,19 @@ def test_get_manifest_digests_missing(tmpdir, has_content_type_header, has_conte
                          headers=headers)
 
                 return response
+        elif manifest_type == 'oci_index':
+            if media_type_prefix == 'application/vnd.oci.image.index.v1':
+                digest = 'oci-index-digest'
+            else:
+                headers = {}
+                response_json = {"errors": [{"code": "MANIFEST_UNKNOWN"}]}
+                response = requests.Response()
+                flexmock(response,
+                         status_code=requests.codes.not_found,
+                         content=json.dumps(response_json).encode("utf-8"),
+                         headers=headers)
+
+                return response
 
         headers = {}
         if has_content_type_header:
@@ -626,6 +640,7 @@ def test_get_manifest_digests_missing(tmpdir, has_content_type_header, has_conte
             assert actual_digests.v1 is True
         assert actual_digests.v2 is None
         assert actual_digests.oci is None
+        assert actual_digests.oci_index is None
     elif manifest_type == 'v2':
         if can_convert_v2_v1:
             if has_content_type_header:
@@ -642,6 +657,7 @@ def test_get_manifest_digests_missing(tmpdir, has_content_type_header, has_conte
         else:
             assert actual_digests.v2 is True
         assert actual_digests.oci is None
+        assert actual_digests.oci_index is None
     elif manifest_type == 'oci':
         assert actual_digests.v1 is None
         assert actual_digests.v2 is None
@@ -649,6 +665,15 @@ def test_get_manifest_digests_missing(tmpdir, has_content_type_header, has_conte
             assert actual_digests.oci == 'oci-digest'
         else:
             assert actual_digests.oci is True
+        assert actual_digests.oci_index is None
+    elif manifest_type == 'oci_index':
+        assert actual_digests.v1 is None
+        assert actual_digests.v2 is None
+        assert actual_digests.oci is None
+        if has_content_digest:
+            assert actual_digests.oci_index == 'oci-index-digest'
+        else:
+            assert actual_digests.oci_index is True
 
 
 @responses.activate
@@ -667,21 +692,24 @@ def test_get_manifest_digests_connection_error(tmpdir):
         get_manifest_digests(**kwargs)
 
 
-@pytest.mark.parametrize('v1,v2,v2_list,oci,default', [
-    ('v1-digest', 'v2-digest', None, None, 'v2-digest'),
-    ('v1-digest', None, None, None, 'v1-digest'),
-    (None, 'v2-digest', None, None, 'v2-digest'),
-    (None, 'v2-digest', None, None, 'v2-digest'),
-    (None, None, None, 'oci-digest', 'oci-digest'),
-    (None, 'v2-digest', None, 'oci-digest', 'oci-digest'),
-    ('v1-digest', 'v2-digest', 'v2-list-digest', 'oci-digest', 'v2-list-digest'),
-    (None, 'v2-digest', 'v2-list-digest', 'oci-digest', 'v2-list-digest'),
-    ('v1-digest', None, 'v2-list-digest', 'oci-digest', 'v2-list-digest'),
-    ('v1-digest', 'v2-digest', 'v2-list-digest', None, 'v2-list-digest'),
-    (None, None, None, None, None),
+@pytest.mark.parametrize('v1,v2,v2_list,oci,oci_index,default', [
+    ('v1-digest', 'v2-digest', None, None, None, 'v2-digest'),
+    ('v1-digest', None, None, None, None, 'v1-digest'),
+    (None, 'v2-digest', None, None, None, 'v2-digest'),
+    (None, 'v2-digest', None, None, None, 'v2-digest'),
+    (None, None, None, 'oci-digest', None, 'oci-digest'),
+    (None, None, None, None, 'oci-index-digest', 'oci-index-digest'),
+    (None, 'v2-digest', None, 'oci-digest', None, 'oci-digest'),
+    ('v1-digest', 'v2-digest', 'v2-list-digest', 'oci-digest', 'oci-index-digest',
+     'v2-list-digest'),
+    (None, 'v2-digest', 'v2-list-digest', 'oci-digest', None, 'v2-list-digest'),
+    ('v1-digest', None, 'v2-list-digest', 'oci-digest', None, 'v2-list-digest'),
+    ('v1-digest', 'v2-digest', 'v2-list-digest', None, None, 'v2-list-digest'),
+    (None, None, None, 'oci-digest', 'oci-index-digest', 'oci-index-digest'),
+    (None, None, None, None, None, None),
 ])
-def test_manifest_digest(v1, v2, v2_list, oci, default):
-    md = ManifestDigest(v1=v1, v2=v2, v2_list=v2_list, oci=oci)
+def test_manifest_digest(v1, v2, v2_list, oci, oci_index, default):
+    md = ManifestDigest(v1=v1, v2=v2, v2_list=v2_list, oci=oci, oci_index=oci_index)
     assert md.v1 == v1
     assert md.v2 == v2
     assert md.v2_list == v2_list

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -360,7 +360,7 @@ def test_get_manifest_digests(tmpdir, image, registry, insecure, creds,
         temp_dir = mkdtemp(dir=str(tmpdir))
         with open(os.path.join(temp_dir, '.dockercfg'), 'w+') as dockerconfig:
             dockerconfig.write(json.dumps({
-                image.registry: {
+                registry: {
                     'username': creds[0], 'password': creds[1]
                 }
             }))


### PR DESCRIPTION
This PR adds support for OCI Manifests and Indices to post_group_manifests. The introductory commits fix some bugs in HTTP communication with the registry, and abstracts the registry specifics to a RegistrySession() wrapper around requests.Session(). Then the final patch restructures post_group_manifests to drop the use of manifest-tool and create and post manifests directly. The group=true and group=false cases are more unified and a single parameterized test tests them both.

A lot of the complexity (and the need to restructure) is from handling the case where the manifests that are being grouped and the resulting manifest lists aren't all in the same repository. This is possible in the local view of 'group manifests' - it has as input a list of repository:tag combinations from the workers, and a list of repository:tag combinations that it needs to apply to the resulting output, but after the fact I examined things thoroughly and I don't think it can actually happen with the current atomic-reactor code. (Previously, it superficially looked like the plugin handled multiple such multiple-repository situations, I think the code would have likely worked for group=true, assuming that manifest-tool did the right thing, but would not have worked for group=false.)

Things could be simplified by removing this code and simply asserting if the inputs and outputs aren't in the same repository. On the other, hand the unit tests cover this code pretty well, and it might be useful to have this logic in the future.