### PR TITLE
flatpak: fix errors if exit_store_metadata_in_osv3 runs on early failure

### DIFF
--- a/atomic_reactor/build.py
+++ b/atomic_reactor/build.py
@@ -152,7 +152,7 @@ class InsideBuilder(LastLogger, BuilderStateMachine):
     @property
     def df_path(self):
         if self._df_path is None:
-            raise RuntimeError("Dockerfile has not yet been generated")
+            raise AttributeError("Dockerfile has not yet been generated")
 
         return self._df_path
 


### PR DESCRIPTION
If the build fails before the Dockerfile has been created, then `exit_store_metadata_in_osv3` was failing .

Fix problems if `build.base_image` and `build._df_path` are not set.