### PR TITLE
koji_promote adds media_type to build metadata fix

### DIFF
--- a/atomic_reactor/plugins/exit_koji_promote.py
+++ b/atomic_reactor/plugins/exit_koji_promote.py
@@ -566,7 +566,7 @@ class KojiPromotePlugin(ExitPlugin):
                     extra['filesystem_koji_task_id'] = task_id
 
         # Append media_types from pulp pull
-        pulp_pull_results = self.workflow.exit_results.get(PLUGIN_PULP_PULL_KEY)
+        pulp_pull_results = self.workflow.postbuild_results.get(PLUGIN_PULP_PULL_KEY)
         if pulp_pull_results:
             extra['image']['media_types'] = sorted(list(set(pulp_pull_results)))
 

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -24,7 +24,7 @@ DOCKERFILE_OK_PATH = os.path.join(FILES, 'docker-hello-world')
 DOCKERFILE_ERROR_BUILD_PATH = os.path.join(FILES, 'docker-hello-world-error-build')
 DOCKERFILE_SUBDIR_PATH = os.path.join(FILES, 'df-in-subdir')
 
-FLATPAK_GIT = "git://pkgs.fedoraproject.org/modules/eog.git"
+FLATPAK_GIT = "http://pkgs.fedoraproject.org/modules/eog.git"
 FLATPAK_SHA1 = "dfb36e55a983d9957a32571f61deff0b1f06f86c"
 
 SOURCE = {

--- a/tests/plugins/test_koji_promote.py
+++ b/tests/plugins/test_koji_promote.py
@@ -1343,7 +1343,7 @@ class TestKojiPromote(object):
                                             release='1',
                                             session=session)
 
-        workflow.exit_results[PLUGIN_PULP_PULL_KEY] = expect_result
+        workflow.postbuild_results[PLUGIN_PULP_PULL_KEY] = expect_result
 
         runner = create_runner(tasker, workflow)
         runner.run()


### PR DESCRIPTION
Signed-off-by: Robert Cerven <rcerven@redhat.com>

in prod build, pulp_pull runs as postbuild plugin and not as exit plugin in orchestrator