### PR TITLE
Add isolated variable to metadata.json

### DIFF
--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -361,6 +361,10 @@ class KojiImportPlugin(ExitPlugin):
             except ValueError:
                 self.log.error("invalid task ID %r", koji_task_id, exc_info=1)
 
+        isolated = metadata.get('labels', {}).get('isolated', False)
+        self.log.info("build is isolated: {}".format(isolated))
+        extra['image']['isolated'] = isolated
+
         fs_result = self.workflow.prebuild_results.get(AddFilesystemPlugin.key)
         if fs_result is not None:
             try:

--- a/tests/plugins/test_koji_import.py
+++ b/tests/plugins/test_koji_import.py
@@ -622,6 +622,43 @@ class TestKojiImport(object):
             runner.run()
         assert "plugin 'koji_import' raised an exception: RuntimeError" in str(exc)
 
+    @pytest.mark.parametrize(('isolated'), [
+        False,
+        True,
+        None
+    ])
+    def test_isolated_metadata_json(self, tmpdir, monkeypatch, os_env, isolated):
+        session = MockedClientSession('')
+        tasker, workflow = mock_environment(tmpdir,
+                                            session=session,
+                                            name='ns/name',
+                                            version='1.0',
+                                            release='1')
+        runner = create_runner(tasker, workflow)
+
+        patch = {
+            'metadata': {
+                'creationTimestamp': '2015-07-27T09:24:00Z',
+                'namespace': NAMESPACE,
+                'name': BUILD_ID,
+                'labels': {
+                },
+            }
+        }
+
+        if isolated is not None:
+            patch['metadata']['labels']['isolated'] = isolated
+
+        monkeypatch.setenv("BUILD", json.dumps(patch))
+
+        runner.run()
+
+        build_metadata = session.metadata['build']['extra']['image']['isolated']
+        if isolated:
+            assert build_metadata is True
+        else:
+            assert build_metadata is False
+
     @pytest.mark.parametrize(('koji_task_id', 'expect_success'), [
         (12345, True),
         ('x', False),


### PR DESCRIPTION
This adds isolated: True|False to the build metadata.

Signed-off-by: Bret Fontecchio <bfontecc@redhat.com>