### PR TITLE
Add isolated boolean to koji_promote metadata

### DIFF
--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -365,7 +365,7 @@ class KojiImportPlugin(ExitPlugin):
             isolated = str(metadata['labels']['isolated']).lower() == 'true'
         except (IndexError, AttributeError, KeyError):
             isolated = False
-        self.log.info("build is isolated: {}".format(isolated))
+        self.log.info("build is isolated: %r", isolated)
         extra['image']['isolated'] = isolated
 
         fs_result = self.workflow.prebuild_results.get(AddFilesystemPlugin.key)

--- a/atomic_reactor/plugins/exit_koji_promote.py
+++ b/atomic_reactor/plugins/exit_koji_promote.py
@@ -582,6 +582,14 @@ class KojiPromotePlugin(ExitPlugin):
             else:
                 extra['image']['parent_build_id'] = parent_id
 
+        # Append isolated build flag
+        try:
+            isolated = str(metadata['labels']['isolated']).lower() == 'true'
+        except (IndexError, AttributeError, KeyError):
+            isolated = False
+        self.log.info("build is isolated: {}".format(isolated))
+        extra['image']['isolated'] = isolated
+
         help_result = self.workflow.prebuild_results.get(AddHelpPlugin.key)
         if isinstance(help_result, dict) and 'help_file' in help_result and 'status' in help_result:
             if help_result['status'] == AddHelpPlugin.NO_HELP_FILE_FOUND:

--- a/atomic_reactor/plugins/exit_koji_promote.py
+++ b/atomic_reactor/plugins/exit_koji_promote.py
@@ -587,7 +587,7 @@ class KojiPromotePlugin(ExitPlugin):
             isolated = str(metadata['labels']['isolated']).lower() == 'true'
         except (IndexError, AttributeError, KeyError):
             isolated = False
-        self.log.info("build is isolated: {}".format(isolated))
+        self.log.info("build is isolated: %r", isolated)
         extra['image']['isolated'] = isolated
 
         help_result = self.workflow.prebuild_results.get(AddHelpPlugin.key)


### PR DESCRIPTION
This commit is similar to #854, but it adds the same logic to the koji_promote plugin.

Signed-off-by: Bret Fontecchio <bfontecc@redhat.com>