### PR TITLE
test.sh improvements

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -77,4 +77,4 @@ $RUN $PIP install -r tests/requirements.txt
 # Run tests
 $RUN $PIP install pytest-cov
 if [[ $OS != "fedora" ]]; then $RUN $PIP install -U pytest-cov; fi
-$RUN $PYTEST -vv tests --cov atomic_reactor
+$RUN $PYTEST -vv tests --cov atomic_reactor "$@"

--- a/test.sh
+++ b/test.sh
@@ -58,7 +58,7 @@ fi
 # Install latest osbs-client by installing dependencies from the master branch
 # and running pip install with '--no-deps' to avoid compilation
 # This would also ensure all the deps are specified in the spec
-$RUN git clone https://github.com/projectatomic/osbs-client /tmp/osbs-client
+$RUN rm -rf /tmp/osbs-client && $RUN git clone https://github.com/projectatomic/osbs-client /tmp/osbs-client
 $RUN $BUILDDEP -y /tmp/osbs-client/osbs-client.spec
 $RUN $PIP install --upgrade --no-deps --force-reinstall git+https://github.com/projectatomic/osbs-client
 


### PR DESCRIPTION
* Fix osbs-client cloning when container is reused
* Pass test.sh arguments to py.test: `sudo sh test.sh -k 'test_inspect_built_image' -x -s`