### PR TITLE
Make flatpak plugins optional

### DIFF
--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -20,7 +20,14 @@ from atomic_reactor.plugins.build_orchestrate_build import (get_worker_build_inf
                                                             get_koji_upload_dir)
 from atomic_reactor.plugins.pre_add_filesystem import AddFilesystemPlugin
 from atomic_reactor.plugins.pre_check_and_set_rebuild import is_rebuild
-from atomic_reactor.plugins.pre_flatpak_create_dockerfile import get_flatpak_source_info
+
+try:
+    from atomic_reactor.plugins.pre_flatpak_create_dockerfile import get_flatpak_source_info
+except ImportError:
+    # modulemd and/or pdc_client not available
+    def get_flatpak_source_info(_):
+        return None
+
 try:
     from atomic_reactor.plugins.post_pulp_sync import get_manifests_in_pulp_repository
 except ImportError:

--- a/atomic_reactor/plugins/exit_koji_promote.py
+++ b/atomic_reactor/plugins/exit_koji_promote.py
@@ -24,8 +24,15 @@ from atomic_reactor.source import GitSource
 from atomic_reactor.plugins.post_rpmqa import PostBuildRPMqaPlugin
 from atomic_reactor.plugins.pre_add_filesystem import AddFilesystemPlugin
 from atomic_reactor.plugins.pre_check_and_set_rebuild import is_rebuild
-from atomic_reactor.plugins.pre_flatpak_create_dockerfile import get_flatpak_source_info
 from atomic_reactor.plugins.pre_add_help import AddHelpPlugin
+
+try:
+    from atomic_reactor.plugins.pre_flatpak_create_dockerfile import get_flatpak_source_info
+except ImportError:
+    # modulemd and/or pdc_client not available
+    def get_flatpak_source_info(_):
+        return None
+
 try:
     from atomic_reactor.plugins.post_pulp_sync import get_manifests_in_pulp_repository
 except ImportError:

--- a/test.sh
+++ b/test.sh
@@ -67,7 +67,12 @@ if [[ $PYTHON_VERSION == 2* ]]; then
   $RUN $PIP install git+https://github.com/release-engineering/dockpulp
   $RUN $PIP install -r requirements-py2.txt
 fi
-$RUN $PIP install -r requirements-flatpak.txt
+
+# Install flatpak dependencies only on fedora
+if [[ $OS == "fedora" ]]; then
+  $RUN $PIP install -r requirements-flatpak.txt
+fi
+
 $RUN $PIP install docker-squash
 $RUN $PYTHON setup.py install
 

--- a/tests/plugins/test_flatpak_create_dockerfile.py
+++ b/tests/plugins/test_flatpak_create_dockerfile.py
@@ -9,15 +9,21 @@ of the BSD license. See the LICENSE file for details.
 from flexmock import flexmock
 
 import json
-from modulemd import ModuleMetadata
 import responses
 import os
+import pytest
 
 from atomic_reactor.inner import DockerBuildWorkflow
-from atomic_reactor.plugins.pre_resolve_module_compose import (ComposeInfo,
-                                                               ModuleInfo,
-                                                               set_compose_info)
-from atomic_reactor.plugins.pre_flatpak_create_dockerfile import FlatpakCreateDockerfilePlugin
+try:
+    from atomic_reactor.plugins.pre_resolve_module_compose import (ComposeInfo,
+                                                                   ModuleInfo,
+                                                                   set_compose_info)
+    from atomic_reactor.plugins.pre_flatpak_create_dockerfile import FlatpakCreateDockerfilePlugin
+    from modulemd import ModuleMetadata
+    MODULEMD_AVAILABLE = True
+except ImportError:
+    MODULEMD_AVAILABLE = False
+
 from atomic_reactor.plugin import PreBuildPluginsRunner
 from atomic_reactor.source import VcsInfo
 from atomic_reactor.util import ImageName
@@ -81,6 +87,8 @@ LATEST_VERSION_JSON = [{"modulemd": FLATPAK_APP_MODULEMD}]
 
 
 @responses.activate  # noqa - docker_tasker fixture
+@pytest.mark.skipif(not MODULEMD_AVAILABLE,
+                    reason='modulemd not available')
 def test_flatpak_create_dockerfile(tmpdir, docker_tasker):
     workflow = mock_workflow(tmpdir)
 

--- a/tests/plugins/test_flatpak_create_oci.py
+++ b/tests/plugins/test_flatpak_create_oci.py
@@ -17,17 +17,23 @@ import subprocess
 import tarfile
 from textwrap import dedent
 
-from modulemd import ModuleMetadata
 
 from atomic_reactor.constants import IMAGE_TYPE_OCI, IMAGE_TYPE_OCI_TAR
 from atomic_reactor.inner import DockerBuildWorkflow
 from atomic_reactor.plugin import PrePublishPluginsRunner, PluginFailedException
-from atomic_reactor.plugins.prepub_flatpak_create_oci import FlatpakCreateOciPlugin
-from atomic_reactor.plugins.pre_resolve_module_compose import (ModuleInfo,
-                                                               ComposeInfo,
-                                                               set_compose_info)
-from atomic_reactor.plugins.pre_flatpak_create_dockerfile import (FlatpakSourceInfo,
-                                                                  set_flatpak_source_info)
+
+try:
+    from atomic_reactor.plugins.prepub_flatpak_create_oci import FlatpakCreateOciPlugin
+    from atomic_reactor.plugins.pre_resolve_module_compose import (ModuleInfo,
+                                                                   ComposeInfo,
+                                                                   set_compose_info)
+    from atomic_reactor.plugins.pre_flatpak_create_dockerfile import (FlatpakSourceInfo,
+                                                                      set_flatpak_source_info)
+    from modulemd import ModuleMetadata
+    MODULEMD_AVAILABLE = True
+except ImportError:
+    MODULEMD_AVAILABLE = False
+
 from atomic_reactor.util import ImageName
 
 from tests.constants import TEST_IMAGE
@@ -634,7 +640,9 @@ class MockInspector(object):
             return '-{:05o}'.format(stat.S_IMODE(mode))
 
 
-@pytest.mark.parametrize('config_name, breakage', [ # noqa - docker_tasker fixture
+@pytest.mark.skipif(not MODULEMD_AVAILABLE,  # noqa - docker_tasker fixture
+                    reason="modulemd not available")
+@pytest.mark.parametrize('config_name, breakage', [
     ('app', None),
     ('app', 'stray_component'),
     ('app', 'no_runtime'),

--- a/tests/plugins/test_koji_promote.py
+++ b/tests/plugins/test_koji_promote.py
@@ -37,10 +37,6 @@ from atomic_reactor.plugins.exit_koji_tag_build import KojiTagBuildPlugin
 from atomic_reactor.plugins.pre_check_and_set_rebuild import CheckAndSetRebuildPlugin
 from atomic_reactor.plugins.pre_add_filesystem import AddFilesystemPlugin
 from atomic_reactor.plugins.pre_add_help import AddHelpPlugin
-from atomic_reactor.plugins.pre_flatpak_create_dockerfile import (FlatpakSourceInfo,
-                                                                  set_flatpak_source_info)
-from atomic_reactor.plugins.pre_resolve_module_compose import (ModuleInfo,
-                                                               ComposeInfo)
 from atomic_reactor.plugin import ExitPluginsRunner, PluginFailedException
 from atomic_reactor.inner import DockerBuildWorkflow, TagConf, PushConf
 from atomic_reactor.util import ImageName, ManifestDigest
@@ -55,7 +51,15 @@ try:
 except ImportError:
     PULP_SYNC_AVAILABLE = False
 
-from modulemd import ModuleMetadata
+try:
+    from atomic_reactor.plugins.pre_flatpak_create_dockerfile import (FlatpakSourceInfo,
+                                                                      set_flatpak_source_info)
+    from atomic_reactor.plugins.pre_resolve_module_compose import (ModuleInfo,
+                                                                   ComposeInfo)
+    from modulemd import ModuleMetadata
+    MODULEMD_AVAILABLE = True
+except ImportError:
+    MODULEMD_AVAILABLE = False
 
 from flexmock import flexmock
 import pytest
@@ -1361,6 +1365,8 @@ class TestKojiPromote(object):
         elif expect_result in ['skip', 'unknown_status']:
             assert 'help' not in image.keys()
 
+    @pytest.mark.skipif(not MODULEMD_AVAILABLE,
+                        reason="modulemd not available")
     def test_koji_promote_flatpak(self, tmpdir, os_env):
         session = MockedClientSession('')
         tasker, workflow = mock_environment(tmpdir,

--- a/tests/plugins/test_resolve_module_compose.py
+++ b/tests/plugins/test_resolve_module_compose.py
@@ -16,8 +16,13 @@ import six
 from six.moves.urllib.parse import urlparse, parse_qs
 
 from atomic_reactor.inner import DockerBuildWorkflow
-from atomic_reactor.plugins.pre_resolve_module_compose import (ResolveModuleComposePlugin,
-                                                               get_compose_info)
+try:
+    from atomic_reactor.plugins.pre_resolve_module_compose import (ResolveModuleComposePlugin,
+                                                                   get_compose_info)
+    MODULEMD_AVAILABLE = True
+except ImportError:
+    MODULEMD_AVAILABLE = False
+
 from atomic_reactor.plugin import PreBuildPluginsRunner
 from atomic_reactor.source import VcsInfo
 from atomic_reactor.util import ImageName
@@ -97,6 +102,8 @@ def compose_json(state, state_name):
 
 
 @responses.activate  # noqa - docker_tasker fixture
+@pytest.mark.skipif(not MODULEMD_AVAILABLE,
+                    reason="modulemd not available")
 @pytest.mark.parametrize('specify_version', [True, False])
 def test_resolve_module_compose(tmpdir, docker_tasker, specify_version):
     secrets_path = os.path.join(str(tmpdir), "secret")


### PR DESCRIPTION
Flatpak related plugin `pre_resolve_module_compose` pulls in
`modulemd` and `pdc_client` as a dependency. Through
`pre_resolve_module_compose` this gets propagated to
`exit_koji_promote` and `exit_koji_import`, which will render
buildroots having koji related plugins installed - but missing
these two flatpak related dependencies - unusable.

This change will catch import errors for get_flatpak_source_info()
and define the function to return None.

This is safe as the update of extra['image'] will only happen
if get_flatpak_source_info() returns *not None* (which is the case
when flatpak related plugins are disabled).

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>