### PR TITLE
Store digests for all versions in koji metadata.

### DIFF
--- a/atomic_reactor/plugins/post_group_manifests.py
+++ b/atomic_reactor/plugins/post_group_manifests.py
@@ -258,6 +258,7 @@ class GroupManifestsPlugin(PostBuildPlugin):
             push_conf_registry.digests[image.tag] = digests
 
         self.log.info("%s: Manifest list digest is %s", session.registry, digest)
+        return digest
 
     def tag_manifest_into_registry(self, session, worker_digest):
         """
@@ -344,11 +345,14 @@ class GroupManifestsPlugin(PostBuildPlugin):
         return RegistrySession(registry, insecure=insecure, dockercfg_path=secret_path)
 
     def run(self):
+        digests = set()
         for registry, source in self.sort_annotations().items():
             session = self.get_registry_session(registry)
 
             if self.group:
                 digest = self.group_manifests_and_tag(session, source)
+                self.log.debug("digest: %s", digest)
+                digests.add(digest)
             else:
                 found = False
                 for platform, digest in source.items():
@@ -357,3 +361,4 @@ class GroupManifestsPlugin(PostBuildPlugin):
                         found = True
                 if not found:
                     raise ValueError('failed to find an x86_64 platform')
+        return list(digests)

--- a/tests/plugins/test_store_metadata.py
+++ b/tests/plugins/test_store_metadata.py
@@ -40,6 +40,7 @@ from tests.util import is_string_type
 
 DIGEST1 = "sha256:1da9b9e1c6bf6ab40f1627d76e2ad58e9b2be14351ef4ff1ed3eb4a156138189"
 DIGEST2 = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+DIGEST_NOT_USED = "not-used"
 
 
 class Y(object):
@@ -110,8 +111,8 @@ def prepare(pulp_registries=None, docker_registries=None, before_dockerfile=Fals
 
     for docker_registry in docker_registries:
         r = workflow.push_conf.add_docker_registry(docker_registry)
-        r.digests[TEST_IMAGE] = ManifestDigest(v1='not-used', v2=DIGEST1)
-        r.digests["namespace/image:asd123"] = ManifestDigest(v1='not-used',
+        r.digests[TEST_IMAGE] = ManifestDigest(v1=DIGEST_NOT_USED, v2=DIGEST1)
+        r.digests["namespace/image:asd123"] = ManifestDigest(v1=DIGEST_NOT_USED,
                                                              v2=DIGEST2)
 
     if before_dockerfile:
@@ -266,8 +267,20 @@ CMD blabla"""
         "registry": DOCKER0_REGISTRY,
         "repository": TEST_IMAGE,
         "tag": 'latest',
+        "digest": DIGEST_NOT_USED,
+        "version": "v1"
+    }, {
+        "registry": DOCKER0_REGISTRY,
+        "repository": TEST_IMAGE,
+        "tag": 'latest',
         "digest": DIGEST1,
         "version": "v2"
+    }, {
+        "registry": DOCKER0_REGISTRY,
+        "repository": "namespace/image",
+        "tag": 'asd123',
+        "digest": DIGEST_NOT_USED,
+        "version": "v1"
     }, {
         "registry": DOCKER0_REGISTRY,
         "repository": "namespace/image",
@@ -278,8 +291,20 @@ CMD blabla"""
         "registry": LOCALHOST_REGISTRY,
         "repository": TEST_IMAGE,
         "tag": 'latest',
+        "digest": DIGEST_NOT_USED,
+        "version": "v1"
+    }, {
+        "registry": LOCALHOST_REGISTRY,
+        "repository": TEST_IMAGE,
+        "tag": 'latest',
         "digest": DIGEST1,
         "version": "v2"
+    }, {
+        "registry": LOCALHOST_REGISTRY,
+        "repository": "namespace/image",
+        "tag": 'asd123',
+        "digest": DIGEST_NOT_USED,
+        "version": "v1"
     }, {
         "registry": LOCALHOST_REGISTRY,
         "repository": "namespace/image",


### PR DESCRIPTION
This PR changes exit_store_metadata, group_manifest and koji_import plugins 
to store all available image digests in worker annotations, group only v2 images 
(if needed) and save all image digests in koji image metadata