### PR TITLE
Add logging to report cluster used to start build in orchestrate build

### DIFF
--- a/atomic_reactor/plugins/build_orchestrate_build.py
+++ b/atomic_reactor/plugins/build_orchestrate_build.py
@@ -456,8 +456,8 @@ class OrchestrateBuildPlugin(BuildStepPlugin):
 
         if build_info.build:
             try:
-                self.log.info('%s - created build %s', cluster_info.platform,
-                              build_info.name)
+                self.log.info('%s - created build %s on cluster %s.', cluster_info.platform,
+                              build_info.name, cluster_info.cluster.name)
                 build_info.watch_logs()
                 build_info.wait_to_finish()
             except Exception as e:
@@ -504,6 +504,8 @@ class OrchestrateBuildPlugin(BuildStepPlugin):
             for cluster_info in possible_cluster_info:
                 ctx = retry_contexts[cluster_info.cluster.name]
                 try:
+                    self.log.info('Attempting to start build for platform %s on cluster %s',
+                                  platform, cluster_info.cluster.name)
                     self.do_worker_build(cluster_info)
                     return
                 except OsbsException:


### PR DESCRIPTION
This reports which cluster is being used as starting the build is attempted. It is possible that this will not be the cluster ultimately used, due to retry policy. Logging a cluster with certainty would involve logging it after the build is already done so this is a tradeoff.

Signed-off-by: Bret Fontecchio <bfontecc@redhat.com>