### PR TITLE
pull_base_image: make sure correct base image is stored in the annotations

### DIFF
--- a/atomic_reactor/plugins/pre_pull_base_image.py
+++ b/atomic_reactor/plugins/pre_pull_base_image.py
@@ -80,13 +80,13 @@ class PullBaseImagePlugin(PreBuildPlugin):
 
         # Use the OpenShift build name as the unique ID
         unique_id = get_build_json()['metadata']['name']
-        base_image = ImageName(repo=unique_id)
+        buildid_base_image = ImageName(repo=unique_id)
 
         for _ in range(20):
             try:
                 self.log.info("tagging pulled image")
                 response = self.tasker.tag_image(base_image_with_registry,
-                                                 base_image)
+                                                 buildid_base_image)
                 self.workflow.pulled_base_images.add(response)
                 break
             except docker.errors.NotFound:

--- a/tests/plugins/test_pull_base_image.py
+++ b/tests/plugins/test_pull_base_image.py
@@ -43,7 +43,6 @@ class MockBuilder(object):
 
     def set_base_image(self, base_image):
         self.base_image = base_image
-        assert base_image == UNIQUE_ID
 
 
 @pytest.fixture(autouse=True)
@@ -149,6 +148,7 @@ def test_pull_base_image_plugin(parent_registry, df_base, expected, not_expected
             tasker.remove_image(image)
         except:
             pass
+    assert workflow.builder.base_image == df_base
 
 
 def test_pull_base_wrong_registry():


### PR DESCRIPTION
Base image is now being tagged with buildid name to ensure base image
would not be removed in concurrent builds. This, however, makes
store_metadata plugin to save a wrong base-image-id annotation.

The solution to resolve this is to append a tagged base image to
workflow.pulled_base_images list and set_base_image to actual
base image. During exit_remove_built_image only images from
pulled_base_images would be attempted to be removed.

This fixes a regression introduced in https://github.com/projectatomic/atomic-reactor/pull/774

Signed-off-by: Vadim Rutkovsky <vrutkovs@redhat.com>