### PR TITLE
pull_base_image: tag image with base_image name too

### DIFF
--- a/atomic_reactor/plugins/pre_pull_base_image.py
+++ b/atomic_reactor/plugins/pre_pull_base_image.py
@@ -101,5 +101,11 @@ class PullBaseImagePlugin(PreBuildPlugin):
             self.log.error("giving up trying to pull image")
             raise RuntimeError("too many attempts to pull and tag image")
 
+        # Make sure registry image is tagged with plain base image name
+        # as other plugins would use base_image to inspect it
+        response = self.tasker.tag_image(base_image_with_registry,
+                                         base_image)
+        self.workflow.pulled_base_images.add(response)
+
         self.workflow.builder.set_base_image(base_image.to_str())
         self.log.debug("image '%s' is available", pulled_base)

--- a/tests/plugins/test_pull_base_image.py
+++ b/tests/plugins/test_pull_base_image.py
@@ -104,8 +104,7 @@ def set_build_json(monkeypatch):
      # expected:
      [LOCALHOST_REGISTRY + "/library/library-only:latest"],
      # not expected:
-     ["library-only:latest",
-      LOCALHOST_REGISTRY + "/library-only:latest"]),
+     [LOCALHOST_REGISTRY + "/library-only:latest"]),
 ])
 def test_pull_base_image_plugin(parent_registry, df_base, expected, not_expected):
     if MOCK:
@@ -118,6 +117,7 @@ def test_pull_base_image_plugin(parent_registry, df_base, expected, not_expected
 
     expected = set(expected)
     expected.add(UNIQUE_ID)
+    expected.add(df_base)
     all_images = set(expected).union(not_expected)
     for image in all_images:
         assert not tasker.image_exists(image)
@@ -178,6 +178,7 @@ def test_retry_pull_base_image(exc, failures, should_succeed):
         expectation = expectation.and_raise(exc('', MockResponse()))
 
     expectation.and_return('foo')
+    expectation.and_return('parent-image')
 
     runner = PreBuildPluginsRunner(
         tasker,


### PR DESCRIPTION
If a non-default docker registry is used, the base image
would not be inspectable using plain base image name.

The pulled image should be tagged with base name without
registry, as it would later on be used by other plugins.

Signed-off-by: Vadim Rutkovsky <vrutkovs@redhat.com>