### PR TITLE
Fix test

### DIFF
--- a/tests/plugins/test_store_metadata.py
+++ b/tests/plugins/test_store_metadata.py
@@ -312,7 +312,8 @@ CMD blabla"""
         "digest": DIGEST2,
         "version": "v2"
     }]
-    assert digests == expected or digests == reversed(expected)
+    assert all(digest in expected for digest in digests)
+    assert all(digest in digests for digest in expected)
 
     assert "plugins-metadata" in annotations
     assert "errors" in annotations["plugins-metadata"]


### PR DESCRIPTION
Instead of directly comparing the lists of dicts, check every element of each is in the other.

Signed-off-by: Tim Waugh <twaugh@redhat.com>