### PR TITLE
group_manifest: return ManifestDigest object when group=True

### DIFF
--- a/atomic_reactor/plugins/post_group_manifests.py
+++ b/atomic_reactor/plugins/post_group_manifests.py
@@ -242,22 +242,22 @@ class GroupManifestsPlugin(PostBuildPlugin):
                                               target_repo, target_repo, tag=image.tag)
         # Get the digest of the manifest list using one of the tags
         registry_image = self.workflow.tag_conf.unique_images[0]
-        _, digest, _, _ = self.get_manifest(session,
-                                            registry_image.to_str(registry=False, tag=False),
-                                            registry_image.tag)
+        _, digest_str, _, _ = self.get_manifest(session,
+                                                registry_image.to_str(registry=False, tag=False),
+                                                registry_image.tag)
 
         if list_type == MEDIA_TYPE_OCI_V1_INDEX:
-            digests = ManifestDigest(oci_index=digest)
+            digest = ManifestDigest(oci_index=digest_str)
         else:
-            digests = ManifestDigest(v2_list=digest)
+            digest = ManifestDigest(v2_list=digest_str)
 
         # And store the manifest list in the push_conf
         push_conf_registry = self.workflow.push_conf.add_docker_registry(session.registry,
                                                                          insecure=session.insecure)
         for image in self.workflow.tag_conf.images:
-            push_conf_registry.digests[image.tag] = digests
+            push_conf_registry.digests[image.tag] = digest
 
-        self.log.info("%s: Manifest list digest is %s", session.registry, digest)
+        self.log.info("%s: Manifest list digest is %s", session.registry, digest_str)
         return digest
 
     def tag_manifest_into_registry(self, session, worker_digest):

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -721,7 +721,12 @@ class RegistrySession(object):
         return self._do(self.session.delete, relative_url, **kwargs)
 
 
-class ManifestDigest(dict):
+class HashableDict(dict):
+    def __hash__(self):
+        return hash(frozenset(self.items()))
+
+
+class ManifestDigest(HashableDict):
     """Wrapper for digests for a docker manifest."""
 
     content_type = {


### PR DESCRIPTION
The plugin should return a list of ManifestDigest objects when
group=True, as its later on used by koji_import.

ManifestDigest is now a hashable type (derived from `HashableDict` class, which assigns a unique hash based on dict items).

Signed-off-by: Vadim Rutkovsky <vrutkovs@redhat.com>