### PR TITLE
Remove manifest list from the registry after pulp_sync

### DIFF
--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -302,8 +302,8 @@ class KojiImportPlugin(ExitPlugin):
             if not registries:
                 registries = self.workflow.push_conf.all_registries
             for registry in registries:
-                pullspec = "{0}/{1}@{2}".format(registry.uri, repo,
-                                                manifest_list_digests[0].v2_list)
+                manifest_list_digest = manifest_list_digests[repo]
+                pullspec = "{0}/{1}@{2}".format(registry.uri, repo, manifest_list_digest.default)
                 index['pull'] = [pullspec]
                 pullspec = "{0}/{1}:{2}".format(registry.uri, repo,
                                                 version_release)
@@ -311,14 +311,14 @@ class KojiImportPlugin(ExitPlugin):
 
                 # Store each digest with according media type
                 index['digests'] = {}
-                for version, digest in manifest_list_digests[0].items():
+                for version, digest in manifest_list_digest.items():
                     if digest:
                         media_type = get_manifest_media_type(version)
                         index['digests'][media_type] = digest
                 break
             extra['image']['index'] = index
-        # group_manifests returns None if didn't run, [] if group=False
-        elif manifest_list_digests == []:
+        # group_manifests returns None if didn't run, {} if group=False
+        else:
             for platform in worker_metadatas:
                 if platform == "x86_64":
                     for instance in worker_metadatas[platform]['output']:

--- a/atomic_reactor/plugins/post_group_manifests.py
+++ b/atomic_reactor/plugins/post_group_manifests.py
@@ -258,7 +258,7 @@ class GroupManifestsPlugin(PostBuildPlugin):
             push_conf_registry.digests[image.tag] = digest
 
         self.log.info("%s: Manifest list digest is %s", session.registry, digest_str)
-        return digest
+        return registry_image.repo, digest
 
     def tag_manifest_into_registry(self, session, worker_digest):
         """
@@ -345,14 +345,14 @@ class GroupManifestsPlugin(PostBuildPlugin):
         return RegistrySession(registry, insecure=insecure, dockercfg_path=secret_path)
 
     def run(self):
-        digests = set()
+        digests = dict()
         for registry, source in self.sort_annotations().items():
             session = self.get_registry_session(registry)
 
             if self.group:
-                digest = self.group_manifests_and_tag(session, source)
-                self.log.debug("digest: %s", digest)
-                digests.add(digest)
+                repo, digest = self.group_manifests_and_tag(session, source)
+                self.log.debug("repo: %s digest: %s", repo, digest)
+                digests[repo] = digest
             else:
                 found = False
                 for platform, digest in source.items():
@@ -361,4 +361,4 @@ class GroupManifestsPlugin(PostBuildPlugin):
                         found = True
                 if not found:
                     raise ValueError('failed to find an x86_64 platform')
-        return list(digests)
+        return digests

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -723,12 +723,7 @@ class RegistrySession(object):
         return self._do(self.session.delete, relative_url, **kwargs)
 
 
-class HashableDict(dict):
-    def __hash__(self):
-        return hash(frozenset(self.items()))
-
-
-class ManifestDigest(HashableDict):
+class ManifestDigest(dict):
     """Wrapper for digests for a docker manifest."""
 
     content_type = {

--- a/tests/plugins/test_group_manifests.py
+++ b/tests/plugins/test_group_manifests.py
@@ -548,8 +548,9 @@ def test_group_manifests(tmpdir, test_name,
 
         # Check that plugin returns ManifestDigest object
         plugin_result = results[GroupManifestsPlugin.key]
-        assert isinstance(plugin_result, list)
-        for digest in plugin_result:
+        assert isinstance(plugin_result, dict)
+
+        for repo, digest in plugin_result.items():
             assert isinstance(digest, ManifestDigest)
     else:
         with pytest.raises(PluginFailedException) as ex:


### PR DESCRIPTION
This also changes the return value of GroupManifest plugin to a map of repos as
keys and digests as values, as exit_delete_from_registry plugin needs to know which repo to remove digest from. 
As a result, `ManifestDigest` is no longer required to be hashable, so `HashableDict` class was removed

Signed-off-by: Vadim Rutkovsky <vrutkovs@redhat.com>