### PR TITLE
tests: flexmock requests.Sessions functions instead of requests module functions

### DIFF
--- a/tests/plugins/test_add_yum_repo_by_url.py
+++ b/tests/plugins/test_add_yum_repo_by_url.py
@@ -47,7 +47,7 @@ def prepare():
     (flexmock(requests.Response, content=repocontent)
         .should_receive('raise_for_status')
         .and_return(None))
-    (flexmock(requests, get=lambda *_: requests.Response()))
+    (flexmock(requests.Session, get=lambda *_: requests.Response()))
     mock_get_retry_session()
 
     return tasker, workflow

--- a/tests/plugins/test_yum_inject.py
+++ b/tests/plugins/test_yum_inject.py
@@ -56,7 +56,7 @@ def prepare(df_path, inherited_user=''):
     (flexmock(requests.Response, content=repocontent)
      .should_receive('raise_for_status')
      .and_return(None))
-    (flexmock(requests, get=lambda *_: requests.Response()))
+    (flexmock(requests.Session, get=lambda *_: requests.Response()))
     return tasker, workflow
 
 


### PR DESCRIPTION
This fixes several yum inject tests on Fedora, as these are running with networking
disabled and were incorrectly mocked