### PR TITLE
tests: skip tests if dockpulp has no imgutils module

### DIFF
--- a/tests/plugins/test_pulp_tag.py
+++ b/tests/plugins/test_pulp_tag.py
@@ -150,7 +150,7 @@ def prepare(v1_image_ids={}):
     return tasker, workflow
 
 
-@pytest.mark.skipif(dockpulp is None,
+@pytest.mark.skipif(dockpulp is None or not hasattr(dockpulp, "imgutils"),
                     reason='dockpulp module not available')
 @pytest.mark.parametrize(("v1_image_ids", "should_raise"), [
     ({'x86_64': None, 'ppc64le': None}, False),
@@ -194,7 +194,7 @@ def test_pulp_tag_basic(tmpdir, monkeypatch, v1_image_ids, should_raise, caplog)
     assert results['pulp_tag'] == expected_results
 
 
-@pytest.mark.skipif(dockpulp is None,
+@pytest.mark.skipif(dockpulp is None or not hasattr(dockpulp, "imgutils"),
                     reason='dockpulp module not available')
 def test_pulp_tag_source_secret(tmpdir, monkeypatch, caplog):
     v1_image_ids = {'x86_64': None,
@@ -222,7 +222,7 @@ def test_pulp_tag_source_secret(tmpdir, monkeypatch, caplog):
     assert results['pulp_tag'] == expected_results
 
 
-@pytest.mark.skipif(dockpulp is None,
+@pytest.mark.skipif(dockpulp is None or not hasattr(dockpulp, "imgutils"),
                     reason='dockpulp module not available')
 def test_pulp_tag_service_account_secret(tmpdir, monkeypatch, caplog):
     v1_image_ids = {'x86_64': None,


### PR DESCRIPTION
I don't fully understand why tests in test_pulp_tag fail in Fedora,
but it seems previous runs are importing a mocked dockpulp and Python 
remembers that import. This PR would ensure that tests will not be 
executed on mocked dockpulp, as it doesn't have imgutils module