### PR TITLE
WIP: spec: add BuildConflicts due to missing osbs-client method and fix osbs-client name

### DIFF
--- a/atomic-reactor.spec
+++ b/atomic-reactor.spec
@@ -55,7 +55,7 @@ BuildRequires:  python-dockerfile-parse >= 0.0.5
 BuildRequires:  python-docker-py
 BuildRequires:  python-flexmock >= 0.10.2
 BuildRequires:  python-six
-BuildRequires:  python-osbs >= 0.15
+BuildRequires:  python2-osbs-client >= 0.44
 BuildRequires:  python-backports-lzma
 BuildRequires:  python2-responses
 %endif # with_check
@@ -77,7 +77,7 @@ BuildRequires:  python3-dockerfile-parse >= 0.0.5
 BuildRequires:  python3-docker-py
 BuildRequires:  python3-flexmock >= 0.10.2
 BuildRequires:  python3-six
-BuildRequires:  python3-osbs >= 0.15
+BuildRequires:  python3-osbs-client >= 0.44
 BuildRequires:  python3-responses
 %endif # with_check
 %endif # with_python3


### PR DESCRIPTION
Fedora builds can't complete with outdated osbs-client, as some are using get_orchestrator_logs,
thus, if check is enabled, the package should require osbs-client 0.44

This should not affect RHEL