### PR TITLE
group_manifests: include namespace if its present in the results

### DIFF
--- a/atomic_reactor/plugins/post_group_manifests.py
+++ b/atomic_reactor/plugins/post_group_manifests.py
@@ -258,7 +258,7 @@ class GroupManifestsPlugin(PostBuildPlugin):
             push_conf_registry.digests[image.tag] = digest
 
         self.log.info("%s: Manifest list digest is %s", session.registry, digest_str)
-        return registry_image.repo, digest
+        return registry_image.get_repo(explicit_namespace=False), digest
 
     def tag_manifest_into_registry(self, session, worker_digest):
         """

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -86,7 +86,7 @@ class ImageName(object):
         if self.repo is None:
             raise RuntimeError('No image repository specified')
 
-        result = self.repo
+        result = self.get_repo(explicit_namespace)
 
         if tag and self.tag and ':' in self.tag:
             result = '{0}@{1}'.format(result, self.tag)
@@ -95,14 +95,17 @@ class ImageName(object):
         elif tag and explicit_tag:
             result = '{0}:{1}'.format(result, 'latest')
 
+        if registry and self.registry:
+            result = '{0}/{1}'.format(self.registry, result)
+
+        return result
+
+    def get_repo(self, explicit_namespace=False):
+        result = self.repo
         if self.namespace:
             result = '{0}/{1}'.format(self.namespace, result)
         elif explicit_namespace:
             result = '{0}/{1}'.format('library', result)
-
-        if registry and self.registry:
-            result = '{0}/{1}'.format(self.registry, result)
-
         return result
 
     @property

--- a/tests/plugins/test_delete_from_registry.py
+++ b/tests/plugins/test_delete_from_registry.py
@@ -65,7 +65,7 @@ class X(object):
 @pytest.mark.parametrize("orchestrator", [True, False])
 @pytest.mark.parametrize("manifest_list_digests", [
     {},
-    {'foo': ManifestDigest(v2_list=DIGEST_LIST)}
+    {'foo/bar': ManifestDigest(v2_list=DIGEST_LIST)}
 ])
 def test_delete_from_registry_plugin(saved_digests, req_registries, tmpdir, orchestrator,
                                      manifest_list_digests):

--- a/tests/plugins/test_group_manifests.py
+++ b/tests/plugins/test_group_manifests.py
@@ -550,8 +550,15 @@ def test_group_manifests(tmpdir, test_name,
         plugin_result = results[GroupManifestsPlugin.key]
         assert isinstance(plugin_result, dict)
 
-        for repo, digest in plugin_result.items():
+        for _, digest in plugin_result.items():
             assert isinstance(digest, ManifestDigest)
+
+        if group:
+            # Check that plugin returns correct list of repos
+            actual_repos = sorted(plugin_result.keys())
+            expected_repos = sorted(set([x.get_repo() for x in workflow.tag_conf.primary_images]))
+            assert expected_repos == actual_repos
+
     else:
         with pytest.raises(PluginFailedException) as ex:
             runner.run()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -700,6 +700,17 @@ def test_get_manifest_digests_connection_error(tmpdir):
         get_manifest_digests(**kwargs)
 
 
+@pytest.mark.parametrize('namespace,repo,explicit,expected', [
+    ('foo', 'bar', False, 'foo/bar'),
+    ('foo', 'bar', True, 'foo/bar'),
+    (None, 'bar', False, 'bar'),
+    (None, 'bar', True, 'library/bar'),
+])
+def test_image_name_get_repo(namespace, repo, explicit, expected):
+    image = ImageName(namespace=namespace, repo=repo)
+    assert image.get_repo(explicit) == expected
+
+
 @pytest.mark.parametrize('v1,v2,v2_list,oci,oci_index,default', [
     ('v1-digest', 'v2-digest', None, None, None, 'v2-digest'),
     ('v1-digest', None, None, None, None, 'v1-digest'),


### PR DESCRIPTION
The repo name is used in `exit_delete_from_registry` plugin to remove a manifest list - and the plugin can fail to find the digest in the results list if namespace was not added. 

This PR adds `ImageName.get_repo()` method, which returns namespace + repo (with `explicit_namespace` for V1 support) and updated plugins to use it.

Signed-off-by: Vadim Rutkovsky <vrutkovs@redhat.com>