### PR TITLE
Speed up some unit tests

### DIFF
--- a/tests/plugins/test_tag_and_push.py
+++ b/tests/plugins/test_tag_and_push.py
@@ -111,7 +111,7 @@ def test_tag_and_push_plugin(
         flexmock(docker.APIClient, push=lambda iid, **kwargs: iter(logs),
                  login=lambda username, registry, dockercfg_path: {'Status': 'Login Succeeded'})
 
-    tasker = DockerTasker()
+    tasker = DockerTasker(retry_times=0)
     workflow = DockerBuildWorkflow({"provider": "git", "uri": "asd"}, TEST_IMAGE)
     workflow.tag_conf.add_primary_image(image_name)
     setattr(workflow, 'builder', X)

--- a/tests/test_tasker.py
+++ b/tests/test_tasker.py
@@ -200,7 +200,7 @@ def test_push_image(temp_image_name, should_fail):
     if MOCK:
         mock_docker(push_should_fail=should_fail)
 
-    t = DockerTasker()
+    t = DockerTasker(retry_times=0)
     temp_image_name.registry = LOCALHOST_REGISTRY
     temp_image_name.tag = "1"
     t.tag_image(INPUT_IMAGE, temp_image_name)


### PR DESCRIPTION
When mocking docker API failures, disable retries.

Signed-off-by: Tim Waugh <twaugh@redhat.com>