### PR TITLE
store_metadata: handle base image builds correctly

### DIFF
--- a/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
+++ b/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
@@ -201,7 +201,10 @@ class StoreMetadataInOSv3Plugin(ExitPlugin):
         except AttributeError:
             commit_id = ""
 
-        base_image = self.workflow.builder.original_base_image
+        if hasattr(self.workflow.builder, "original_base_image"):
+            base_image = self.workflow.builder.original_base_image
+        else:
+            base_image = self.workflow.builder.base_image
         if base_image is not None:
             base_image_name = base_image.to_str()
             try:

--- a/tests/plugins/test_store_metadata.py
+++ b/tests/plugins/test_store_metadata.py
@@ -63,7 +63,6 @@ class XBeforeDockerfile(object):
     source.dockerfile_path = None
     source.path = None
     base_image = None
-    original_base_image = None
 
     @property
     def df_path(self):


### PR DESCRIPTION
Previos PR was failing on base image builds (as these don't set `original_base_image`) -
and the test was setting it incorrectly.

Signed-off-by: Vadim Rutkovsky <vrutkovs@redhat.com>