### PR TITLE
Extend default odcs timeout to 30 minutes

### DIFF
--- a/atomic_reactor/odcs_util.py
+++ b/atomic_reactor/odcs_util.py
@@ -101,7 +101,7 @@ class ODCSClient(object):
                          burst_retry=1,
                          burst_length=30,
                          slow_retry=10,
-                         timeout=300):
+                         timeout=1800):
         """Wait for compose request to finalize
 
         :param compose_id: int, compose ID to wait for


### PR DESCRIPTION
A medium sized compose took about 7 minutes to complete.
After consulting with ODCS team, it's been suggested that
30 mins should be more than sufficient for OSBS builds.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>