### PR TITLE
Disable rawhide testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,6 @@ env:
     - OS=fedora
       OS_VERSION=27
       PYTHON_VERSION=3
-    - OS=fedora
-      OS_VERSION=rawhide
-      PYTHON_VERSION=2
-    - OS=fedora
-      OS_VERSION=rawhide
-      PYTHON_VERSION=3
 script:
  - pip install coveralls
  - ./test.sh


### PR DESCRIPTION
There's been some Fedora rawhide issues lately that
prent unit tests from starting in rawhide. Let's
disable testing there since it's not expected to
always be stable.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>