### PR TITLE
Add multi arch support for failing test

### DIFF
--- a/tests/plugins/test_koji_upload.py
+++ b/tests/plugins/test_koji_upload.py
@@ -924,7 +924,7 @@ class TestKojiUpload(object):
                                             prefer_schema1_digest=prefer_schema1_digest,
                                             )
         runner = create_runner(tasker, workflow, blocksize=blocksize, target=target,
-                               prefer_schema1_digest=prefer_schema1_digest)
+                               prefer_schema1_digest=prefer_schema1_digest, platform=LOCAL_ARCH)
         runner.run()
 
         data = get_metadata(workflow, osbs)


### PR DESCRIPTION
The test_koji_upload_success is failling on non x86_64 arch, this commit add the local platform to the runner so that it supports all arch.

Signed-off-by: Clement Verna <cverna@tutanota.com>