### PR TITLE
Fix test URL for flatpak git repo

### DIFF
--- a/tests/constants.py
+++ b/tests/constants.py
@@ -24,7 +24,7 @@ DOCKERFILE_OK_PATH = os.path.join(FILES, 'docker-hello-world')
 DOCKERFILE_ERROR_BUILD_PATH = os.path.join(FILES, 'docker-hello-world-error-build')
 DOCKERFILE_SUBDIR_PATH = os.path.join(FILES, 'df-in-subdir')
 
-FLATPAK_GIT = "http://pkgs.fedoraproject.org/modules/eog.git"
+FLATPAK_GIT = "git://pkgs.fedoraproject.org/modules/eog.git"
 FLATPAK_SHA1 = "dfb36e55a983d9957a32571f61deff0b1f06f86c"
 
 SOURCE = {


### PR DESCRIPTION
Use git: instead of http: for this test URL.

Ideally the tests would be self-contained and not require any network access, but until then let's at least keep them working.

```
$ curl http://pkgs.fedoraproject.org/modules/eog.git
curl: (7) Failed to connect to pkgs.fedoraproject.org port 80: No route to host
```