### PR TITLE
logging: re-use existing logs in pulp

### DIFF
--- a/atomic_reactor/plugins/post_pulp_sync.py
+++ b/atomic_reactor/plugins/post_pulp_sync.py
@@ -53,6 +53,8 @@ from __future__ import print_function, unicode_literals
 from atomic_reactor.constants import PLUGIN_PULP_SYNC_KEY, PLUGIN_PULP_PUSH_KEY
 from atomic_reactor.plugin import PostBuildPlugin
 from atomic_reactor.util import ImageName, Dockercfg, are_plugins_in_order
+# import pulp_util to get the dockpulp.log set up once
+from atomic_reactor.pulp_util import PulpLog
 import dockpulp
 import os
 import re
@@ -117,9 +119,10 @@ class PulpSyncPlugin(PostBuildPlugin):
         self.registry_secret_path = registry_secret_path
         self.insecure_registry = insecure_registry
         self.pulp_repo_prefix = pulp_repo_prefix
+        logger = PulpLog.get_pulp_logger()
 
         if dockpulp_loglevel is not None:
-            logger = dockpulp.setup_logger(dockpulp.log)
+            self.log.info("attempting to set loglevel")
             try:
                 logger.setLevel(dockpulp_loglevel)
             except (ValueError, TypeError) as ex:

--- a/atomic_reactor/pulp_util.py
+++ b/atomic_reactor/pulp_util.py
@@ -10,17 +10,16 @@ from __future__ import print_function, unicode_literals
 
 import os
 import re
-import logging
 import warnings
 from collections import namedtuple
 
 try:
     import dockpulp
-    from dockpulp import setup_logger
+
 except (ImportError, SyntaxError):
     dockpulp = None
+    import logging
 
-logger = logging.getLogger(__name__)
 
 PulpRepo = namedtuple('PulpRepo', ['registry_id', 'tags'])
 
@@ -28,6 +27,20 @@ PulpRepo = namedtuple('PulpRepo', ['registry_id', 'tags'])
 # which may result in tenths of messages: very annoying
 # with "module", it just prints one warning -- this should balance security and UX
 warnings.filterwarnings("module")
+
+
+class PulpLogWrapper(object):
+    def __init__(self):
+        if dockpulp:
+            self.pulp_log = dockpulp.setup_logger(dockpulp.log)
+        else:
+            self.pulp_log = logging.getLogger(__name__)
+
+    def get_pulp_logger(self):
+        return self.pulp_log
+
+
+PulpLog = PulpLogWrapper()
 
 
 class PulpHandler(object):
@@ -45,9 +58,9 @@ class PulpHandler(object):
         self.username = username
         self.password = password
         self.p = None
+        logger = PulpLog.get_pulp_logger()
 
         if dockpulp_loglevel is not None:
-            logger = setup_logger(dockpulp.log)
             try:
                 logger.setLevel(dockpulp_loglevel)
             except (ValueError, TypeError) as ex:

--- a/tests/plugins/test_pulp_sync.py
+++ b/tests/plugins/test_pulp_sync.py
@@ -33,6 +33,7 @@ except ImportError:
 
 from atomic_reactor.plugins.post_pulp_sync import PulpSyncPlugin, get_manifests_in_pulp_repository
 from atomic_reactor.constants import PLUGIN_PULP_PUSH_KEY
+from atomic_reactor.pulp_util import PulpLogWrapper
 
 from flexmock import flexmock
 import json
@@ -458,20 +459,17 @@ class TestPostPulpSync(object):
                        .should_receive('setLevel')
                        .with_args(loglevel)
                        .once())
+
         if fail:
             expectation.and_raise(ValueError)
 
-        (flexmock(dockpulp)
-            .should_receive('setup_logger')
-            .and_return(logger)
-            .once())
+        flexmock(PulpLogWrapper).should_receive('get_pulp_logger').and_return(logger).once()
 
         plugin = PulpSyncPlugin(tasker=None,
                                 workflow=self.workflow(['prod/myrepository']),
                                 pulp_registry_name='pulp',
                                 docker_registry='http://registry.example.com',
                                 dockpulp_loglevel=loglevel)
-
         plugin.run()
 
         errors = [record.getMessage() for record in caplog.records()


### PR DESCRIPTION
Call setup_logger once, from pulp_util, and have all other plugins
that want to use the pulp logger import pulp_util.

Fixes the issue of repeated pulp log entries.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>