### PR TITLE
janitor work: clean up pep8 errors

### DIFF
--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -348,7 +348,6 @@ class KojiImportPlugin(ExitPlugin):
                                 digests = get_digests_map_from_annotations(annotations['digests'])
                                 instance['extra']['docker']['digests'] = digests
 
-
     def get_output_metadata(self, path, filename):
         """
         Describe a file by its metadata.

--- a/atomic_reactor/plugins/post_import_image.py
+++ b/atomic_reactor/plugins/post_import_image.py
@@ -8,8 +8,6 @@ of the BSD license. See the LICENSE file for details.
 
 from __future__ import unicode_literals
 
-from time import sleep
-
 from osbs.api import OSBS
 from osbs.conf import Configuration
 from osbs.exceptions import OsbsResponseException

--- a/atomic_reactor/plugins/post_koji_upload.py
+++ b/atomic_reactor/plugins/post_koji_upload.py
@@ -263,8 +263,8 @@ class KojiUploadPlugin(PostBuildPlugin):
         """
 
         build_logs = NamedTemporaryFile(prefix="buildstep-%s" % self.build_id,
-                                         suffix=".log",
-                                         mode='wb')
+                                        suffix=".log",
+                                        mode='wb')
         build_logs.write("\n".join(self.workflow.build_result.logs).encode('utf-8'))
         build_logs.flush()
         filename = "{platform}-build.log".format(platform=self.platform)

--- a/atomic_reactor/plugins/pre_check_and_set_rebuild.py
+++ b/atomic_reactor/plugins/pre_check_and_set_rebuild.py
@@ -10,9 +10,9 @@ from __future__ import unicode_literals
 
 from osbs.api import OSBS
 from osbs.conf import Configuration
-from osbs.exceptions import OsbsResponseException
 from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.util import get_build_json
+
 
 def is_rebuild(workflow):
     return (CheckAndSetRebuildPlugin.key in workflow.prebuild_results and

--- a/atomic_reactor/plugins/pre_resolve_module_compose.py
+++ b/atomic_reactor/plugins/pre_resolve_module_compose.py
@@ -24,7 +24,6 @@ Example configuration:
 """
 
 import os
-import re
 import yaml
 from modulemd import ModuleMetadata
 from pdc_client import PDCClient

--- a/tests/plugins/test_assert_labels.py
+++ b/tests/plugins/test_assert_labels.py
@@ -35,6 +35,7 @@ RUN yum install -y python-django
 CMD blabla"""
 DF_CONTENT_LABELS = DF_CONTENT+'\nLABEL "name"="rainbow" "version"="123" "release"="1"'
 
+
 @pytest.mark.parametrize('df_content, req_labels, expected', [  # noqa
     (DF_CONTENT, None, PluginFailedException()),
     (DF_CONTENT_LABELS, None, None),

--- a/tests/plugins/test_check_and_set_rebuild.py
+++ b/tests/plugins/test_check_and_set_rebuild.py
@@ -103,7 +103,7 @@ class TestCheckRebuild(object):
 
         workflow, runner = self.prepare(key, value,
                                         update_labels_args=(buildconfig,
-                                                         {key: value}),
+                                                            {key: value}),
                                         update_labels_kwargs=namespace_dict)
 
         build_json = {

--- a/tests/plugins/test_docker_api.py
+++ b/tests/plugins/test_docker_api.py
@@ -29,6 +29,7 @@ class MockDocker(object):
     def history(self, name):
         return []
 
+
 class MockDockerTasker(object):
     def __init__(self):
         self.d = MockDocker()

--- a/tests/plugins/test_fetch_maven_artifacts.py
+++ b/tests/plugins/test_fetch_maven_artifacts.py
@@ -36,9 +36,10 @@ from atomic_reactor.plugins.pre_fetch_maven_artifacts import FetchMavenArtifacts
 from atomic_reactor.util import ImageName
 from tests.constants import MOCK_SOURCE, MOCK
 from tests.fixtures import docker_tasker  # noqa
+from textwrap import dedent
+
 if MOCK:
     from tests.retry_mock import mock_get_retry_session
-from textwrap import dedent
 
 KOJI_HUB = 'https://koji-hub.com'
 KOJI_ROOT = 'https://koji-root.com'

--- a/tests/plugins/test_koji_import.py
+++ b/tests/plugins/test_koji_import.py
@@ -344,7 +344,6 @@ def mock_environment(tmpdir, session=None, name=None,
             'brew-pulp-docker:8888/{0}:latest'.format(name),
         ]
 
-
     if build_process_failed:
         workflow.build_result = BuildResult(logs=["docker build log - \u2018 \u2017 \u2019 \n'"],
                                             fail_reason="not built")

--- a/tests/plugins/test_koji_parent.py
+++ b/tests/plugins/test_koji_parent.py
@@ -64,6 +64,7 @@ BASE_IMAGE_LABELS_W_ALIASES = {
     'Release': '99',
 }
 
+
 class MockInsideBuilder(object):
     def __init__(self):
         self.tasker = DockerTasker()

--- a/tests/plugins/test_pulp_pull.py
+++ b/tests/plugins/test_pulp_pull.py
@@ -10,14 +10,14 @@ from atomic_reactor.plugin import PostBuildPlugin, ExitPlugin
 from atomic_reactor.plugins.post_pulp_pull import PulpPullPlugin
 from atomic_reactor.inner import TagConf, PushConf
 from atomic_reactor.util import ImageName
-from tests.constants import MOCK
-if MOCK:
-    from tests.retry_mock import mock_get_retry_session
-
 from flexmock import flexmock
 import pytest
 import requests
 import json
+
+from tests.constants import MOCK
+if MOCK:
+    from tests.retry_mock import mock_get_retry_session
 
 DIGEST_V1 = 'sha256:7de72140ec27a911d3f88d60335f08d6530a4af136f7beab47797a196e840afd'
 DIGEST_V2 = 'sha256:85a7e3fb684787b86e64808c5b91d926afda9d6b35a0642a72d7a746452e71c1'

--- a/tests/plugins/test_tag_and_push.py
+++ b/tests/plugins/test_tag_and_push.py
@@ -40,7 +40,7 @@ PUSH_LOGS_1_10 = [
     {"status": "The push refers to a repository [localhost:5000/busybox]"},
     {"status": "Preparing", "progressDetail": {}, "id": "5f70bf18a086"},
     {"status": "Preparing", "progressDetail": {}, "id": "9508eff2c687"},
-    {"status": "Pushing", "progressDetail": {"current": 721920, "total": 1113436}, "progress":"[================================>                  ] 721.9 kB/1.113 MB", "id": "9508eff2c687"},  # noqa
+    {"status": "Pushing", "progressDetail": {"current": 721920, "total": 1113436}, "progress": "[================================>                  ] 721.9 kB/1.113 MB", "id": "9508eff2c687"},  # noqa
     {"status": "Pushing", "progressDetail": {"current": 1024}, "progress": "1.024 kB", "id": "5f70bf18a086"},  # noqa
     {"status": "Pushing", "progressDetail": {"current": 820224, "total": 1113436}, "progress": "[====================================>              ] 820.2 kB/1.113 MB", "id": "9508eff2c687"},  # noqa
     {"status": "Pushed", "progressDetail": {}, "id": "5f70bf18a086"},
@@ -50,7 +50,7 @@ PUSH_LOGS_1_10 = [
     {"status": "Pushed", "progressDetail": {}, "id": "9508eff2c687"},
     {"status": "Pushed", "progressDetail": {}, "id": "9508eff2c687"},
     {"status": "latest: digest: + DIGEST_LOG.encode('utf-8') + size: 1920"},
-    {"progressDetail":{ }, "aux": {"Tag": "latest", "Digest": " + DIGEST_LOG.encode('utf-8') + ", "Size": 1920}}]  # noqa
+    {"progressDetail": {}, "aux": {"Tag": "latest", "Digest": " + DIGEST_LOG.encode('utf-8') + ", "Size": 1920}}]  # noqa
 
 PUSH_LOGS_1_10_NOT_IN_STATUS = list(PUSH_LOGS_1_10)
 del PUSH_LOGS_1_10_NOT_IN_STATUS[-2]

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -152,6 +152,7 @@ def test_required_plugin_failure(tmpdir, docker_tasker, runner_type, required):
     else:
         assert workflow.plugin_failed is required
 
+
 @pytest.mark.parametrize('success1', [True, False])  # noqa
 @pytest.mark.parametrize('success2', [True, False])
 def test_buildstep_phase_build_plugin(caplog, tmpdir, docker_tasker, success1, success2):


### PR DESCRIPTION
I'm not sure how these got past the linter, but they're all non-functional
white-space errors, so get rid of them.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>