### PR TITLE
Improvements to get_manifest_digests utility function

### DIFF
--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -9,6 +9,7 @@ of the BSD license. See the LICENSE file for details.
 from __future__ import print_function, unicode_literals
 
 import hashlib
+from itertools import chain
 import json
 import jsonschema
 import os
@@ -754,9 +755,67 @@ def query_registry(registry_session, image, digest=None, version='v1', is_blob=F
     logger.debug("query_registry: querying {}, headers: {}".format(url, headers))
 
     response = registry_session.get(url, headers=headers)
+    for r in chain(response.history, [response]):
+        logger.debug("query_registry: [%s] %s", r.status_code, r.url)
+
+    logger.debug("query_registry: response headers: %s", response.headers)
     response.raise_for_status()
 
     return response
+
+
+def guess_manifest_media_type(content):
+    """
+    Guess the media type for the given manifest content
+
+    :param content: JSON content of manifest (bytes)
+    :return: media type (str), or None if unable to guess
+    """
+    encoding = guess_json_utf(content)
+    try:
+        manifest = json.loads(content.decode(encoding))
+    except (ValueError,           # Not valid JSON
+            TypeError,            # Not an object
+            UnicodeDecodeError):  # Unable to decode the bytes
+        logger.exception("Unable to decode JSON")
+        logger.debug("response content (%s): %r", encoding, content)
+        return None
+
+    try:
+        return manifest['mediaType']
+    except KeyError:
+        # no mediaType key
+        if manifest.get('schemaVersion') == 1:
+            return get_manifest_media_type('v1')
+
+        logger.warning("no mediaType or schemaVersion=1 in manifest, keys: %s",
+                       manifest.keys())
+
+
+def manifest_is_media_type(response, media_type):
+    """
+    Attempt to confirm the returned manifest is of a given media type
+
+    :param response: a requests.Response
+    :param media_type: media_type (str), or None to confirm
+        the media type cannot be guessed
+    """
+    try:
+        received_media_type = response.headers['Content-Type']
+    except KeyError:
+        # Guess media type from content
+        logger.debug("No Content-Type header; inspecting content")
+        received_media_type = guess_manifest_media_type(response.content)
+        logger.debug("guessed media type: %s", received_media_type)
+
+    if received_media_type is None:
+        return media_type is None
+
+    # Only compare prefix as response may use +prettyjws suffix
+    # which is the case for signed manifest
+    response_h_prefix = received_media_type.rsplit('+', 1)[0]
+    request_h_prefix = media_type.rsplit('+', 1)[0]
+    return response_h_prefix == request_h_prefix
 
 
 def get_manifest_digests(image, registry, insecure=False, dockercfg_path=None,
@@ -813,41 +872,19 @@ def get_manifest_digests(image, registry, insecure=False, dockercfg_path=None,
             # media type
             elif (ex.response.status_code == requests.codes.not_found or
                   ex.response.status_code == requests.codes.not_acceptable):
+                logger.debug("skipping version %s due to status code %s",
+                             version, ex.response.status_code)
                 continue
             else:
                 raise
 
-        received_media_type = None
-        try:
-            received_media_type = response.headers['Content-Type']
-        except KeyError:
-            # Guess content_type from contents
-            try:
-                encoding = guess_json_utf(response.content)
-                manifest = json.loads(response.content.decode(encoding))
-                received_media_type = manifest['mediaType']
-            except (ValueError,  # not valid JSON
-                    KeyError) as ex:  # no mediaType key
-                logger.warning("Unable to fetch media type: neither Content-Type header "
-                               "nor mediaType in output was found")
-
-        if not received_media_type:
+        if not manifest_is_media_type(response, media_type):
+            logger.error("content does not match expected media type")
             continue
-
-        # Only compare prefix as response may use +prettyjws suffix
-        # which is the case for signed manifest
-        response_h_prefix = received_media_type.rsplit('+', 1)[0]
-        request_h_prefix = media_type.rsplit('+', 1)[0]
-        if response_h_prefix != request_h_prefix:
-            logger.debug('request headers: %s', headers)
-            logger.debug('response headers: %s', response.headers)
-            logger.warning('Received media type %s mismatches the expected %s',
-                           received_media_type, media_type)
-            continue
+        logger.debug("content matches expected media type")
 
         # set it to truthy value so that koji_import would know pulp supports these digests
         digests[version] = True
-        logger.debug('Received media type %s', received_media_type)
 
         if not response.headers.get('Docker-Content-Digest'):
             logger.warning('Unable to fetch digest for %s, no Docker-Content-Digest header',

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -39,6 +39,7 @@ from atomic_reactor.util import (ImageName, wait_for_command, clone_git_repo,
                                  get_manifest_digests, ManifestDigest,
                                  get_build_json, is_scratch_build, df_parser,
                                  are_plugins_in_order, LabelFormatter,
+                                 guess_manifest_media_type,
                                  get_manifest_media_type,
                                  get_manifest_media_version,
                                  get_primary_images,
@@ -390,6 +391,23 @@ def test_get_manifest_media_type_unknown():
         assert get_manifest_media_type('no_such_version')
 
 
+@pytest.mark.parametrize(('content', 'media_type'), [
+    (b'{', None),
+    (b'{}', None),
+    (b'{"\xff', None),
+    (b'{"schemaVersion": 1}',
+     'application/vnd.docker.distribution.manifest.v1+json'),
+    (b'{"schemaVersion": 2}',
+     None),
+    (b'{"mediaType": "application/vnd.docker.distribution.manifest.v2+json"}',
+     'application/vnd.docker.distribution.manifest.v2+json'),
+    (b'{"mediaType": "application/vnd.oci.image.manifest.v1"}',
+     'application/vnd.oci.image.manifest.v1'),
+])
+def test_guess_manifest_media_type(content, media_type):
+    assert guess_manifest_media_type(content) == media_type
+
+
 @pytest.mark.parametrize('insecure', [
     True,
     False,
@@ -623,15 +641,7 @@ def test_get_manifest_digests_missing(tmpdir, has_content_type_header, has_conte
         .should_receive('get')
         .replace_with(custom_get))
 
-    if manifest_type == 'v1' and not has_content_type_header:
-        # v1 manifests don't have a mediaType field, so we can't fall back
-        # to looking at the returned manifest to detect the type.
-        with pytest.raises(RuntimeError):
-            get_manifest_digests(**kwargs)
-        return
-    else:
-        actual_digests = get_manifest_digests(**kwargs)
-
+    actual_digests = get_manifest_digests(**kwargs)
     if manifest_type == 'v1':
         if has_content_digest:
             assert actual_digests.v1 == 'v1-digest'
@@ -642,13 +652,10 @@ def test_get_manifest_digests_missing(tmpdir, has_content_type_header, has_conte
         assert actual_digests.oci_index is None
     elif manifest_type == 'v2':
         if can_convert_v2_v1:
-            if has_content_type_header:
-                if has_content_digest:
-                    assert actual_digests.v1 == 'v1-converted-digest'
-                else:
-                    assert actual_digests.v1 is True
-            else:  # don't even know the response is v1 without Content-Type
-                assert actual_digests.v1 is None
+            if has_content_digest:
+                assert actual_digests.v1 == 'v1-converted-digest'
+            else:
+                assert actual_digests.v1 is True
         else:
             assert actual_digests.v1 is None
         if has_content_digest:


### PR DESCRIPTION
This function now gives more debugging output to aid diagnosis of a
situation in which only one of the two expected media types is seen on
the Pulp server.

As part of this, the function has been improved to aid readability.
There are now two more functions:
* `guess_manifest_media_type()` takes a bytes object and attempts to
decode it and interpret the JSON in order to decide which manifest media
type it is
* `manifest_is_media_type()` takes a requests.Response object and an
expected media type and attempts to confirm or deny that the manifest
returned in the response is of the expected media type

The media type guessing has also been improved. Previously in the
absence of a Content-Type HTTP response header, API v1 manifests could
not be identified at all (they lack a mediaType key). Now, if there is
no mediaType key the schemaVersion key will be inspected. This allows us
to reasonably guess at the manifest being API v1.

Signed-off-by: Tim Waugh <twaugh@redhat.com>