### PR TITLE
pre_bump_release: update all release labels

### DIFF
--- a/atomic_reactor/plugins/build_orchestrate_build.py
+++ b/atomic_reactor/plugins/build_orchestrate_build.py
@@ -27,13 +27,14 @@ from atomic_reactor.build import BuildResult
 from atomic_reactor.plugin import BuildStepPlugin
 from atomic_reactor.plugins.pre_reactor_config import get_config
 from atomic_reactor.plugins.pre_check_and_set_rebuild import is_rebuild
-from atomic_reactor.util import get_preferred_label, df_parser, get_build_json
+from atomic_reactor.util import df_parser, get_build_json
 from atomic_reactor.constants import (PLUGIN_ADD_FILESYSTEM_KEY, PLUGIN_BUILD_ORCHESTRATE_KEY,
                                       REPO_CONTAINER_CONFIG)
 from osbs.api import OSBS
 from osbs.exceptions import OsbsException
 from osbs.conf import Configuration
 from osbs.constants import BUILD_FINISHED_STATES
+from osbs.utils import Labels
 
 
 ClusterInfo = namedtuple('ClusterInfo', ('cluster', 'platform', 'osbs', 'load'))
@@ -344,8 +345,9 @@ class OrchestrateBuildPlugin(BuildStepPlugin):
         return ret
 
     def get_release(self):
-        labels = df_parser(self.workflow.builder.df_path, workflow=self.workflow).labels
-        return get_preferred_label(labels, 'release')
+        labels = Labels(df_parser(self.workflow.builder.df_path, workflow=self.workflow).labels)
+        _, release = labels.get_name_and_value(Labels.LABEL_TYPE_RELEASE)
+        return release
 
     @staticmethod
     def get_koji_upload_dir():

--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -42,7 +42,7 @@ from atomic_reactor.constants import (PLUGIN_KOJI_IMPORT_PLUGIN_KEY,
                                       PLUGIN_GROUP_MANIFESTS_KEY,
                                       PLUGIN_KOJI_PARENT_KEY,
                                       PLUGIN_RESOLVE_COMPOSES_KEY)
-from atomic_reactor.util import (get_build_json, get_preferred_label,
+from atomic_reactor.util import (get_build_json,
                                  df_parser, ImageName, get_checksums, get_primary_images,
                                  get_manifest_media_type,
                                  get_digests_map_from_annotations)
@@ -51,6 +51,7 @@ from atomic_reactor.koji_util import (create_koji_session, Output, KojiUploadLog
 from osbs.conf import Configuration
 from osbs.api import OSBS
 from osbs.exceptions import OsbsException
+from osbs.utils import Labels
 
 
 class KojiImportPlugin(ExitPlugin):
@@ -366,11 +367,10 @@ class KojiImportPlugin(ExitPlugin):
     def get_build(self, metadata, worker_metadatas):
         start_time = int(atomic_reactor_start_time)
 
-        labels = df_parser(self.workflow.builder.df_path, workflow=self.workflow).labels
-
-        component = get_preferred_label(labels, 'com.redhat.component')
-        version = get_preferred_label(labels, 'version')
-        release = get_preferred_label(labels, 'release')
+        labels = Labels(df_parser(self.workflow.builder.df_path, workflow=self.workflow).labels)
+        _, component = labels.get_name_and_value(Labels.LABEL_TYPE_COMPONENT)
+        _, version = labels.get_name_and_value(Labels.LABEL_TYPE_VERSION)
+        _, release = labels.get_name_and_value(Labels.LABEL_TYPE_RELEASE)
 
         source = self.workflow.source
         if not isinstance(source, GitSource):

--- a/atomic_reactor/plugins/exit_koji_promote.py
+++ b/atomic_reactor/plugins/exit_koji_promote.py
@@ -46,7 +46,7 @@ from atomic_reactor.constants import (PROG, PLUGIN_KOJI_PROMOTE_PLUGIN_KEY,
                                       PLUGIN_KOJI_PARENT_KEY,
                                       PLUGIN_RESOLVE_COMPOSES_KEY)
 from atomic_reactor.util import (get_version_of_tools, get_checksums,
-                                 get_build_json, get_preferred_label,
+                                 get_build_json,
                                  get_docker_architecture, df_parser,
                                  are_plugins_in_order,
                                  get_image_upload_filename,
@@ -57,6 +57,7 @@ from atomic_reactor.rpm_util import parse_rpm_output, rpm_qf_args
 from osbs.conf import Configuration
 from osbs.api import OSBS
 from osbs.exceptions import OsbsException
+from osbs.utils import Labels
 
 
 class KojiPromotePlugin(ExitPlugin):
@@ -492,11 +493,11 @@ class KojiPromotePlugin(ExitPlugin):
     def get_build(self, metadata):
         start_time = int(atomic_reactor_start_time)
 
-        labels = df_parser(self.workflow.builder.df_path, workflow=self.workflow).labels
+        labels = Labels(df_parser(self.workflow.builder.df_path, workflow=self.workflow).labels)
 
-        component = get_preferred_label(labels, 'com.redhat.component')
-        version = get_preferred_label(labels, 'version')
-        release = get_preferred_label(labels, 'release')
+        _, component = labels.get_name_and_value(Labels.LABEL_TYPE_COMPONENT)
+        _, version = labels.get_name_and_value(Labels.LABEL_TYPE_VERSION)
+        _, release = labels.get_name_and_value(Labels.LABEL_TYPE_RELEASE)
 
         source = self.workflow.source
         if not isinstance(source, GitSource):

--- a/atomic_reactor/plugins/post_tag_from_config.py
+++ b/atomic_reactor/plugins/post_tag_from_config.py
@@ -11,7 +11,8 @@ import re
 
 from atomic_reactor.plugin import PostBuildPlugin
 from atomic_reactor.constants import INSPECT_CONFIG, TAG_NAME_REGEX
-from atomic_reactor.util import get_preferred_label_key, df_parser, LabelFormatter
+from atomic_reactor.util import df_parser, LabelFormatter
+from osbs.utils import Labels
 
 
 class TagFromConfigPlugin(PostBuildPlugin):
@@ -102,12 +103,11 @@ class TagFromConfigPlugin(PostBuildPlugin):
 
     def get_component_name(self):
         try:
-            name_label = str(get_preferred_label_key(self.labels, "name"))
-            name = self.labels[name_label]
+            labels = Labels(self.labels)
+            _, name = labels.get_name_and_value(Labels.LABEL_TYPE_NAME)
         except KeyError:
             self.log.error('Unable to determine component from "Labels"')
             raise
-
         return name
 
     def run(self):

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -543,60 +543,6 @@ def print_version_of_tools():
         logger.info("%s-%s at %s", tool["name"], tool["version"], tool["path"])
 
 
-# each tuple is sorted from most preferred to least
-_PREFERRED_LABELS = (
-    ('name', 'Name'),
-    ('version', 'Version'),
-    ('release', 'Release'),
-    ('architecture', 'Architecture'),
-    ('vendor', 'Vendor'),
-    ('authoritative-source', 'Authoritative_Registry'),
-    ('com.redhat.component', 'BZComponent'),
-    ('com.redhat.build-host', 'Build_Host'),
-)
-
-
-def get_all_label_keys(name):
-    """
-    Return the preference chain for the naming of a particular label.
-
-    :param name: string, label name to search for
-    :return: tuple, label names, most preferred first
-    """
-
-    for label_chain in _PREFERRED_LABELS:
-        if name in label_chain:
-            return label_chain
-    else:
-        # no variants known, return the name unchanged
-        return (name,)
-
-
-def get_preferred_label_key(labels, name):
-    """
-    We can have multiple variants of some labels (e.g. Version and version), sorted by preference.
-    This function returns the best label corresponding to "name" that is present in the "labels"
-    dictionary.
-
-    Returns unchanged name if we don't have it in the preference table. If name is in the table
-    but none of the variants are in the labels dict, returns the most-preferred label - the
-    assumption is that we're gonna raise an error later and the error message should contain
-    the preferred variant.
-    """
-    label_chain = get_all_label_keys(name)
-    for lbl in label_chain:
-        if lbl in labels:
-            return lbl
-
-    # none of the variants is in 'labels', return the best
-    return label_chain[0]
-
-
-def get_preferred_label(labels, name):
-    key = get_preferred_label_key(labels, name)
-    return labels.get(key)
-
-
 def get_build_json():
     try:
         return json.loads(os.environ["BUILD"])

--- a/tests/plugins/test_bump_release.py
+++ b/tests/plugins/test_bump_release.py
@@ -180,11 +180,8 @@ class TestBumpRelease(object):
 
         parser = df_parser(plugin.workflow.builder.df_path, workflow=plugin.workflow)
         assert parser.labels['release'] == next_release['expected']
-        # Old-style spellings will be asserted only if other old-style labels are present
-        if 'BZComponent' not in parser.labels.keys():
-            assert 'Release' not in parser.labels
-        else:
-            assert parser.labels['Release'] == next_release['expected']
+        # Old-style spellings should not be asserted
+        assert 'Release' not in parser.labels
 
     @pytest.mark.parametrize('base_release,builds,expected', [
         ('42', [], '42.1'),

--- a/tests/plugins/test_tag_from_config.py
+++ b/tests/plugins/test_tag_from_config.py
@@ -108,7 +108,7 @@ def test_tag_from_config_plugin_generated(tmpdir, docker_tasker, tags, name,
 
 
 @pytest.mark.parametrize(('inspect', 'error'), [  # noqa
-    ({'Labels': {}}, "KeyError('name'"),
+    ({'Labels': {}}, "KeyError(<object"),
     ({}, "KeyError('Labels'"),
     (None, "RuntimeError('There is no inspect data"),
 ])

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -33,7 +33,7 @@ from atomic_reactor.util import (ImageName, wait_for_command, clone_git_repo,
                                  LazyGit, figure_out_build_file,
                                  render_yum_repo, process_substitutions,
                                  get_checksums, print_version_of_tools,
-                                 get_version_of_tools, get_preferred_label_key,
+                                 get_version_of_tools,
                                  human_size, CommandResult,
                                  registry_hostname, Dockercfg, RegistrySession,
                                  get_manifest_digests, ManifestDigest,
@@ -279,19 +279,6 @@ def test_get_versions_of_tools():
 
 def test_print_versions_of_tools():
     print_version_of_tools()
-
-
-@pytest.mark.parametrize('labels, name, expected', [
-    ({'name': 'foo', 'Name': 'foo'}, 'name', 'name'),
-    ({'name': 'foo', 'Name': 'foo'}, 'Name', 'name'),
-    ({'name': 'foo'}, 'Name', 'name'),
-    ({'Name': 'foo'}, 'name', 'Name'),
-    ({}, 'Name', 'name'),
-    ({}, 'foobar', 'foobar')
-])
-def test_preferred_labels(labels, name, expected):
-    result = get_preferred_label_key(labels, name)
-    assert result == expected
 
 
 @pytest.mark.parametrize('size_input,expected', [


### PR DESCRIPTION
pre_bump_release: only update the newest release label

pre_bump_release currently adjusts the release value for the 'release' and
'Release' values, but not correctly. add_label sets it correctly for all
variants of the release label. Remove the duplicate functionality so that
bump_release only bumps the release value.
    
Convert pre_bump_release to use Labels from osbs.utils, and then change the
tests case to test that it only sets 'release'.

Fixes #601

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>