### PR TITLE
util.py: make sure that the git commit ID is a string, not bytes

### DIFF
--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -276,7 +276,7 @@ def clone_git_repo(git_url, target_dir, commit=None, retry_times=GIT_MAX_RETRIES
     subprocess.check_call(cmd, cwd=target_dir)
     cmd = ["git", "rev-parse", "HEAD"]
     logger.debug("getting SHA-1 of provided ref '%s'", cmd)
-    commit_id = subprocess.check_output(cmd, cwd=target_dir)
+    commit_id = subprocess.check_output(cmd, cwd=target_dir, universal_newlines=True)
     commit_id = commit_id.strip()
     logger.info("commit ID = %s", commit_id)
     return commit_id

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -153,7 +153,7 @@ def test_clone_git_repo_by_sha1(tmpdir):
     tmpdir_path = str(tmpdir.realpath())
     commit_id = clone_git_repo(DOCKERFILE_GIT, tmpdir_path, commit=DOCKERFILE_SHA1)
     assert commit_id is not None
-    assert six.text_type(commit_id, encoding="ascii") == six.text_type(DOCKERFILE_SHA1)
+    assert commit_id == DOCKERFILE_SHA1
     assert len(commit_id) == 40  # current git hashes are this long
     assert os.path.isdir(os.path.join(tmpdir_path, '.git'))
 


### PR DESCRIPTION
subprocess.check_output() by default returns bytes for python3. Using
universal_newlines=True is a trick to get strings for both python2
and python3, since the encoding option is python3 only.

I hit this in testing atomic-reactor running with Python-3.6 - not sure why it hasn't previously been encountered since the code hasn't apparently changed for quite a while. The symptom that is seen is that the code in add_labels_in_df that escapes the environment values blows up if an environment value is bytes instead of string since b"Foo".translate() wants a different argument than "foo".translate().