### PR TITLE
exit_sendmail: fetch and mail logs for failed autorebuilds

### DIFF
--- a/atomic_reactor/koji_util.py
+++ b/atomic_reactor/koji_util.py
@@ -9,7 +9,6 @@ of the BSD license. See the LICENSE file for details.
 from __future__ import print_function
 
 
-from collections import namedtuple
 import koji
 import logging
 import os
@@ -17,9 +16,7 @@ import time
 
 from atomic_reactor.constants import DEFAULT_DOWNLOAD_BLOCK_SIZE
 
-
 logger = logging.getLogger(__name__)
-Output = namedtuple('Output', ['file', 'metadata'])
 
 
 class KojiUploadLogger(object):

--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -42,11 +42,11 @@ from atomic_reactor.constants import (PLUGIN_KOJI_IMPORT_PLUGIN_KEY,
                                       PLUGIN_GROUP_MANIFESTS_KEY,
                                       PLUGIN_KOJI_PARENT_KEY,
                                       PLUGIN_RESOLVE_COMPOSES_KEY)
-from atomic_reactor.util import (get_build_json,
+from atomic_reactor.util import (Output, get_build_json,
                                  df_parser, ImageName, get_primary_images,
                                  get_manifest_media_type,
                                  get_digests_map_from_annotations)
-from atomic_reactor.koji_util import (create_koji_session, Output, KojiUploadLogger,
+from atomic_reactor.koji_util import (create_koji_session, KojiUploadLogger,
                                       get_koji_task_owner)
 from osbs.conf import Configuration
 from osbs.api import OSBS

--- a/atomic_reactor/plugins/exit_koji_promote.py
+++ b/atomic_reactor/plugins/exit_koji_promote.py
@@ -45,14 +45,14 @@ from atomic_reactor.constants import (PROG, PLUGIN_KOJI_PROMOTE_PLUGIN_KEY,
                                       PLUGIN_PULP_PULL_KEY,
                                       PLUGIN_KOJI_PARENT_KEY,
                                       PLUGIN_RESOLVE_COMPOSES_KEY)
-from atomic_reactor.util import (get_version_of_tools, get_checksums,
+from atomic_reactor.util import (Output, get_version_of_tools, get_checksums,
                                  get_build_json,
                                  get_docker_architecture, df_parser,
                                  are_plugins_in_order,
                                  get_image_upload_filename,
                                  get_manifest_media_type)
 from atomic_reactor.koji_util import (create_koji_session, tag_koji_build,
-                                      Output, KojiUploadLogger)
+                                      KojiUploadLogger)
 from atomic_reactor.rpm_util import parse_rpm_output, rpm_qf_args
 from osbs.conf import Configuration
 from osbs.api import OSBS

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -27,6 +27,7 @@ import yaml
 import codecs
 import string
 import time
+from collections import namedtuple
 
 from six.moves.urllib.parse import urlparse
 
@@ -47,7 +48,7 @@ from requests.utils import guess_json_utf
 
 from osbs.exceptions import OsbsException
 from tempfile import NamedTemporaryFile
-from atomic_reactor.koji_util import Output
+Output = namedtuple('Output', ['file', 'metadata'])
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -982,17 +982,19 @@ def test_osbs_logs_get_log_files(tmpdir):
                     LogEntry('x86_64', 'line 2')]
             return logs
 
-    x86_metadata = {
-        'checksum': 'c2487bf0142ea344df8b36990b0186be',
-        'checksum_type': 'md5',
-        'filename': 'x86_64.log',
-        'filesize': 29
-    }
-    orchestrator_metadata = {
-        'checksum': 'ac9ed4cc35a9a77264ca3a0fb81be117',
-        'checksum_type': 'md5',
-        'filename': 'orchestrator.log',
-        'filesize': 13
+    metadata = {
+        'x86_64.log': {
+            'checksum': 'c2487bf0142ea344df8b36990b0186be',
+            'checksum_type': 'md5',
+            'filename': 'x86_64.log',
+            'filesize': 29
+        },
+        'orchestrator.log': {
+            'checksum': 'ac9ed4cc35a9a77264ca3a0fb81be117',
+            'checksum_type': 'md5',
+            'filename': 'orchestrator.log',
+            'filesize': 13
+        }
     }
 
     logger = flexmock()
@@ -1000,5 +1002,5 @@ def test_osbs_logs_get_log_files(tmpdir):
     osbs_logs = OSBSLogs(logger)
     osbs = OSBS()
     output = osbs_logs.get_log_files(osbs, 1)
-    assert output[0][1] == x86_metadata
-    assert output[1][1] == orchestrator_metadata
+    for entry in output:
+        assert entry[1] == metadata[entry[1]['filename']]


### PR DESCRIPTION
When an autorebuild fails, fetch the logs from the obsbs build object
and attach them to the message in addition to providing a link to the
last koji job's log.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>