### PR TITLE
recognize scratch builds

### DIFF
--- a/atomic_reactor/build.py
+++ b/atomic_reactor/build.py
@@ -13,7 +13,7 @@ import json
 
 import logging
 from atomic_reactor.core import DockerTasker, LastLogger
-from atomic_reactor.util import ImageName, print_version_of_tools, df_parser
+from atomic_reactor.util import ImageName, print_version_of_tools, df_parser, base_image_is_scratch
 from atomic_reactor.constants import DOCKERFILE_FILENAME
 
 logger = logging.getLogger(__name__)
@@ -173,7 +173,11 @@ class InsideBuilder(LastLogger, BuilderStateMachine):
         :return: dict
         """
         logger.info("inspecting base image '%s'", self.base_image)
-        inspect_data = self.tasker.inspect_image(self.base_image)
+        if base_image_is_scratch(self.base_image.to_str()):
+            logger.debug("base image is scratch, setting empty inspect data")
+            inspect_data = {}
+        else:
+            inspect_data = self.tasker.inspect_image(self.base_image)
         return inspect_data
 
     def inspect_built_image(self):

--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -29,7 +29,7 @@ from atomic_reactor.plugin import (
 )
 from atomic_reactor.source import get_source_instance_for
 from atomic_reactor.constants import INSPECT_ROOTFS, INSPECT_ROOTFS_LAYERS
-from atomic_reactor.util import ImageName
+from atomic_reactor.util import ImageName, base_image_is_scratch
 from atomic_reactor.build import BuildResult
 from atomic_reactor import get_logging_encoding
 
@@ -350,6 +350,9 @@ class DockerBuildWorkflow(object):
     def base_image_inspect(self):
         if self._base_image_inspect is None:
             try:
+                if base_image_is_scratch(self.builder.base_image.to_str()):
+                    logger.debug("do not inspect scratch image")
+                    return {}
                 self._base_image_inspect = self.builder.tasker.inspect_image(
                     self.builder.base_image)
             except docker.errors.NotFound:

--- a/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
+++ b/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
@@ -26,7 +26,7 @@ from atomic_reactor.constants import (PLUGIN_KOJI_IMPORT_PLUGIN_KEY,
                                       PLUGIN_GROUP_MANIFESTS_KEY,
                                       MEDIA_TYPE_DOCKER_V1)
 from atomic_reactor.plugin import ExitPlugin
-from atomic_reactor.util import get_build_json
+from atomic_reactor.util import get_build_json, base_image_is_scratch
 
 
 class StoreMetadataInOSv3Plugin(ExitPlugin):
@@ -205,7 +205,12 @@ class StoreMetadataInOSv3Plugin(ExitPlugin):
             base_image = self.workflow.builder.original_base_image
         else:
             base_image = self.workflow.builder.base_image
-        if base_image is not None:
+
+        if self.workflow.builder.base_image is not None:
+            is_real = not base_image_is_scratch(self.workflow.builder.base_image.to_str())
+        else:
+            is_real = True
+        if base_image is not None and is_real:
             base_image_name = base_image.to_str()
             try:
                 base_image_id = self.workflow.base_image_inspect['Id']

--- a/atomic_reactor/plugins/pre_add_labels_in_df.py
+++ b/atomic_reactor/plugins/pre_add_labels_in_df.py
@@ -59,7 +59,8 @@ from __future__ import unicode_literals
 from atomic_reactor import start_time as atomic_reactor_start_time
 from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.constants import INSPECT_CONFIG
-from atomic_reactor.util import get_docker_architecture, df_parser, LabelFormatter
+from atomic_reactor.util import get_docker_architecture, df_parser, \
+                                LabelFormatter, base_image_is_scratch
 from osbs.utils import Labels
 import json
 import datetime
@@ -245,7 +246,8 @@ class AddLabelsPlugin(PreBuildPlugin):
 
         lines = dockerfile.lines
 
-        if re.match('^koji/image-build(:.*)?$', dockerfile.baseimage):
+        if (re.match('^koji/image-build(:.*)?$', dockerfile.baseimage) or
+                base_image_is_scratch(dockerfile.baseimage)):
             base_image_labels = {}
         else:
             try:

--- a/atomic_reactor/plugins/prepub_squash.py
+++ b/atomic_reactor/plugins/prepub_squash.py
@@ -14,7 +14,8 @@ import os
 from atomic_reactor.constants import EXPORTED_SQUASHED_IMAGE_NAME, IMAGE_TYPE_DOCKER_ARCHIVE
 from atomic_reactor.plugin import PrePublishPlugin
 from atomic_reactor.plugins.exit_remove_built_image import defer_removal
-from atomic_reactor.util import get_exported_image_metadata
+from atomic_reactor.util import get_exported_image_metadata, \
+        base_image_is_scratch
 from docker_squash.squash import Squash
 
 __all__ = ('PrePublishSquashPlugin', )
@@ -72,6 +73,10 @@ class PrePublishSquashPlugin(PrePublishPlugin):
         self.image = self.workflow.builder.image_id
         self.tag = tag or str(self.workflow.builder.image)
         self.from_layer = from_layer
+
+        if base_image_is_scratch(self.workflow.builder.base_image.to_str()):
+            from_base = False
+
         if from_base and from_layer is None:
             try:
                 base_image_id = self.workflow.base_image_inspect['Id']

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -1112,3 +1112,7 @@ def split_module_spec(module):
         'Module specification should be NAME:STREAM or NAME:STREAM:VERSION. ' +
         '(NAME-STREAM and NAME-STREAM-VERSION supported for compatibility.)'
     )
+
+
+def base_image_is_scratch(base_image_name):
+    return re.match('^scratch(:latest)?$', base_image_name)

--- a/tests/plugins/test_koji_promote.py
+++ b/tests/plugins/test_koji_promote.py
@@ -200,7 +200,9 @@ def mock_environment(tmpdir, session=None, name=None,
                      registry_digests=None, blocksize=None,
                      task_states=None, additional_tags=None,
                      has_config=None,
-                     logs_return_bytes=True):
+                     logs_return_bytes=True,
+                     base_image_repo='Fedora',
+                     base_image_tag='22'):
     if session is None:
         session = MockedClientSession('', task_states=None)
     if source is None:
@@ -214,7 +216,7 @@ def mock_environment(tmpdir, session=None, name=None,
     setattr(workflow, '_base_image_inspect', {'Id': base_image_id})
     setattr(workflow, 'builder', X())
     setattr(workflow.builder, 'image_id', '123456imageid')
-    setattr(workflow.builder, 'base_image', ImageName(repo='Fedora', tag='22'))
+    setattr(workflow.builder, 'base_image', ImageName(repo=base_image_repo, tag=base_image_tag))
     setattr(workflow.builder, 'source', X())
     setattr(workflow.builder, 'built_image_info', {'ParentId': base_image_id})
     setattr(workflow.builder.source, 'dockerfile_path', None)
@@ -933,6 +935,26 @@ class TestKojiPromote(object):
         runner = create_runner(tasker, workflow, target=target)
         with pytest.raises(PluginFailedException):
             runner.run()
+
+    def test_koji_promote_scratch_base(self, tmpdir, os_env):
+        session = MockedClientSession('')
+        tasker, workflow = mock_environment(tmpdir,
+                                            name='ns/name',
+                                            version='1.0',
+                                            release='1',
+                                            session=session,
+                                            base_image_repo='scratch',
+                                            base_image_tag='latest')
+        runner = create_runner(tasker, workflow)
+        runner.run()
+
+        data = session.metadata
+        assert 'build' in data
+        build = data['build']
+        assert isinstance(build, dict)
+        assert 'extra' in build
+        extra = build['extra']
+        assert isinstance(extra, dict)
 
     @pytest.mark.parametrize(('task_id', 'expect_success'), [
         (1234, True),

--- a/tests/plugins/test_store_metadata.py
+++ b/tests/plugins/test_store_metadata.py
@@ -486,6 +486,38 @@ CMD blabla"""
     assert int(labels["koji-build-id"]) == koji_build_id
 
 
+def test_store_metadata_scratch_base(tmpdir):
+    workflow = prepare()
+    df_content = """
+FROM scratch
+CMD blabla"""
+    df = df_parser(str(tmpdir))
+    df.content = df_content
+    workflow.builder = X
+    workflow.builder.base_image = ImageName(repo="scratch", tag="latest")
+    workflow.builder.df_path = df.dockerfile_path
+    workflow.builder.df_dir = str(tmpdir)
+
+    runner = ExitPluginsRunner(
+        None,
+        workflow,
+        [{
+            'name': StoreMetadataInOSv3Plugin.key,
+            "args": {
+                "url": "http://example.com/"
+            }
+        }]
+    )
+    output = runner.run()
+    assert 'store_metadata_in_osv3' in output
+    metadata = output['store_metadata_in_osv3']
+    assert 'annotations' in metadata
+    annotations = metadata['annotations']
+    assert 'base-image-id' in annotations
+    base_image_id = annotations['base-image-id']
+    assert base_image_id is ""
+
+
 def test_missing_koji_build_id(tmpdir):
     workflow = prepare()
     workflow.exit_results = {}

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -67,6 +67,21 @@ def test_inspect_base_image(tmpdir, source_params):
 
 @requires_internet
 @with_all_sources
+def test_inspect_scratch_base_image(tmpdir, source_params):
+    if MOCK:
+        mock_docker()
+
+    source_params.update({'tmpdir': str(tmpdir)})
+    s = get_source_instance_for(source_params)
+    b = InsideBuilder(s, '')
+    b.set_base_image("scratch:latest")
+    built_inspect = b.inspect_base_image()
+
+    assert built_inspect == {}
+
+
+@requires_internet
+@with_all_sources
 @pytest.mark.parametrize(('image', 'will_raise'), [
     (
         "buildroot-fedora:latest",


### PR DESCRIPTION
Recognize the special status of scratch image. Adjust plugins to check for this to be able to succesfully utilize plugins even when basing on scratch. Changes included:
- Do not attempt to inspect if using scratch image as this will always fail
- Only perform ID check if we are not building on top of scratch image
- Do not fail on inspection check when building on top of scratch image
- Return empty inspect data when building on top of scratch image
- Set empty parent_id in case the base image was scratch
- Return empty component list for images based on scratch
- Do not include base image in squash when building on top of scratch image

Orignally coded by niko.kortstrom@gmail.com but apparently abandoned.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>