### PR TITLE
sendmail: only include logs URL when appropriate (OSBS-5080)

### DIFF
--- a/atomic_reactor/plugins/exit_sendmail.py
+++ b/atomic_reactor/plugins/exit_sendmail.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2015 Red Hat, Inc
+Copyright (c) 2015, 2018 Red Hat, Inc
 All rights reserved.
 
 This software may be modified and distributed under the terms
@@ -193,8 +193,13 @@ class SendMailPlugin(ExitPlugin):
             'Image: %(image)s',
             'Status: %(endstate)s',
             'Submitted by: %(user)s',
-            'Logs: %(logs)s',
         ])
+
+        # Failed autorebuilds include logs as attachments.
+        # Koji integration stores logs in successful Koji Builds.
+        # Don't include logs in these cases.
+        if not ((rebuild and not success) or (self.session and success)):
+            body_template += '\nLogs: %(logs)s'
 
         endstate = None
         if auto_canceled or manual_canceled:

--- a/atomic_reactor/plugins/exit_sendmail.py
+++ b/atomic_reactor/plugins/exit_sendmail.py
@@ -144,13 +144,14 @@ class SendMailPlugin(ExitPlugin):
         else:
             self.log.info("Koji build ID: %s", self.koji_build_id)
 
-        try:
-            self.session = create_koji_session(self.koji_hub, self.koji_auth_info)
-        except Exception:
-            self.log.exception("Failed to connect to koji")
-            self.session = None
-        else:
-            self.log.info("Koji connection established")
+        self.session = None
+        if self.koji_hub:
+            try:
+                self.session = create_koji_session(self.koji_hub, self.koji_auth_info)
+            except Exception:
+                self.log.exception("Failed to connect to koji")
+            else:
+                self.log.info("Koji connection established")
 
     def _fetch_log_files(self):
         try:
@@ -322,7 +323,7 @@ class SendMailPlugin(ExitPlugin):
         receivers_list = [x for x in receivers_list if x]
 
         if not receivers_list:
-            raise RuntimeError("No recepients found")
+            raise RuntimeError("No recipients found")
 
         return receivers_list
 


### PR DESCRIPTION
We should only include the logs URL in certain circumstances.

This PR has three commits:
- clean up one of the sendmail test cases
- adjust the test case for intended change, to show the test case catches failure
- apply the intended change, to make the test case pass again