### PR TITLE
Flatpaks: hybrid modularity, container.yaml, package set restriction

### DIFF
--- a/atomic_reactor/build.py
+++ b/atomic_reactor/build.py
@@ -144,8 +144,9 @@ class InsideBuilder(LastLogger, BuilderStateMachine):
         self.df_dir = build_file_dir
         self._df_path = None
 
-        # If the build file isn't a Dockerfile, but say, a flatpak.json then a
-        # plugin needs to create the Dockerfile and set the base image
+        # If the Dockerfile will be entirely generated from the container.yaml
+        # (in the Flatpak case, say), then a plugin needs to create the Dockerfile
+        # and set the base image
         if build_file_path.endswith(DOCKERFILE_FILENAME):
             self.set_df_path(build_file_path)
 

--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -10,7 +10,6 @@ import os
 
 DOCKER_SOCKET_PATH = '/var/run/docker.sock'
 DOCKERFILE_FILENAME = 'Dockerfile'
-FLATPAK_FILENAME = 'flatpak.json'
 BUILD_JSON = 'build.json'
 BUILD_JSON_ENV = 'BUILD_JSON'
 RESULTS_JSON = 'results.json'

--- a/atomic_reactor/plugins/build_orchestrate_build.py
+++ b/atomic_reactor/plugins/build_orchestrate_build.py
@@ -399,7 +399,7 @@ class OrchestrateBuildPlugin(BuildStepPlugin):
         container_path = os.path.join(build_file_dir, REPO_CONTAINER_CONFIG)
         if os.path.exists(container_path):
             with open(container_path) as f:
-                data = yaml.load(f)
+                data = yaml.safe_load(f)
                 if data is None or 'platforms' not in data or data['platforms'] is None:
                     return self.platforms
                 excluded_platforms = set(self.make_list(data['platforms'].get('not', [])))

--- a/atomic_reactor/plugins/pre_flatpak_create_dockerfile.py
+++ b/atomic_reactor/plugins/pre_flatpak_create_dockerfile.py
@@ -35,7 +35,10 @@ LABEL com.redhat.component="{name}"
 LABEL version="{stream}"
 LABEL release="{version}"
 
-RUN dnf -y --nogpgcheck --disablerepo=* --enablerepo=atomic-reactor-module-* \\
+RUN dnf -y --nogpgcheck \\
+    --disablerepo=* \\
+    --enablerepo=atomic-reactor-koji-plugin-* \\
+    --enablerepo=atomic-reactor-module-* \\
     --installroot=/var/tmp/flatpak-build install {packages}
 RUN rpm --root=/var/tmp/flatpak-build {rpm_qf_args} > /var/tmp/flatpak-build.rpm_qf
 COPY cleanup.sh /var/tmp/flatpak-build/tmp/

--- a/atomic_reactor/plugins/pre_resolve_composes.py
+++ b/atomic_reactor/plugins/pre_resolve_composes.py
@@ -141,7 +141,7 @@ class ResolveComposesPlugin(PreBuildPlugin):
         data = None
         if os.path.exists(file_path):
             with open(file_path) as f:
-                data = (yaml.load(f) or {}).get('compose')
+                data = (yaml.safe_load(f) or {}).get('compose')
 
         if not data and not self.compose_ids:
             raise SkipResolveComposesPlugin('"compose" config not set and compose_ids not given')

--- a/atomic_reactor/plugins/pre_resolve_module_compose.py
+++ b/atomic_reactor/plugins/pre_resolve_module_compose.py
@@ -130,7 +130,7 @@ class ResolveModuleComposePlugin(PreBuildPlugin):
         file_path = os.path.join(workdir, REPO_CONTAINER_CONFIG)
         if os.path.exists(file_path):
             with open(file_path) as f:
-                self.data = (yaml.load(f) or {}).get('compose')
+                self.data = (yaml.safe_load(f) or {}).get('compose')
 
         if not self.data:
             raise RuntimeError('"compose" config in container.yaml is required for Flatpaks')

--- a/atomic_reactor/plugins/prepub_flatpak_create_oci.py
+++ b/atomic_reactor/plugins/prepub_flatpak_create_oci.py
@@ -278,7 +278,7 @@ class FlatpakCreateOciPlugin(PrePublishPlugin):
 
     def _check_runtime_manifest(self, components):
         # For a runtime, we want to make sure that the set of RPMs that was installed
-        # into the filesystem is *exactly* the set that is listed in the 'runtime'
+        # into the filesystem is *exactly* the set that is listed in the runtime
         # profile. Requiring the full listed set of RPMs to be listed makes it
         # easier to catch unintentional changes in the package list that might break
         # applications depending on the runtime. It also simplifies the checking we
@@ -288,7 +288,7 @@ class FlatpakCreateOciPlugin(PrePublishPlugin):
         base_module = self.source.compose.base_module
 
         component_names = {c['name'] for c in components}
-        expected_component_names = set(base_module.mmd.profiles['runtime'].rpms)
+        expected_component_names = set(base_module.mmd.profiles[self.source.profile].rpms)
 
         if component_names != expected_component_names:
             missing = expected_component_names - component_names

--- a/atomic_reactor/plugins/prepub_flatpak_create_oci.py
+++ b/atomic_reactor/plugins/prepub_flatpak_create_oci.py
@@ -39,7 +39,7 @@ def get_arch():
 # since our build step is just unpacking the filesystem we've already
 # created. This is a stub implementation of 'flatpak build-init' that
 # doesn't check for the SDK or use it to set up the build filesystem.
-def build_init(directory, appname, sdk, runtime, runtime_branch):
+def build_init(directory, appname, sdk, runtime, runtime_branch, tags=[]):
     if not os.path.isdir(directory):
         os.mkdir(directory)
     with open(os.path.join(directory, "metadata"), "w") as f:
@@ -53,6 +53,8 @@ def build_init(directory, appname, sdk, runtime, runtime_branch):
                                   runtime=runtime,
                                   runtime_branch=runtime_branch,
                                   arch=get_arch())))
+        if tags:
+            f.write("tags=" + ";".join(tags) + "\n")
     os.mkdir(os.path.join(directory, "files"))
 
 
@@ -435,7 +437,7 @@ class FlatpakCreateOciPlugin(PrePublishPlugin):
         # See comment for build_init() for why we can't use 'flatpak build-init'
         # subprocess.check_call(['flatpak', 'build-init',
         #                        builddir, app_id, runtime_id, runtime_id, runtime_version])
-        build_init(builddir, app_id, runtime_id, runtime_id, runtime_version)
+        build_init(builddir, app_id, runtime_id, runtime_id, runtime_version, tags=info.get('tags', []))
 
         # with gzip'ed tarball, tar is several seconds faster than tarfile.extractall
         subprocess.check_call(['tar', 'xCfz', builddir, tarred_filesystem])

--- a/atomic_reactor/plugins/prepub_flatpak_create_oci.py
+++ b/atomic_reactor/plugins/prepub_flatpak_create_oci.py
@@ -448,6 +448,8 @@ class FlatpakCreateOciPlugin(PrePublishPlugin):
         if 'finish-args' in info:
             # shlex.split(None) reads from standard input, so avoid that
             finish_args = shlex.split(info['finish-args'] or '')
+        if 'command' in info:
+            finish_args = ['--command', info['command']] + finish_args
 
         subprocess.check_call(['flatpak', 'build-finish'] + finish_args + [builddir])
         subprocess.check_call(['flatpak', 'build-export', repo, builddir])

--- a/docs/flatpak.md
+++ b/docs/flatpak.md
@@ -66,45 +66,46 @@ These are mock'ed for 'make test' - 'make test' only requires binaries that are 
 
 Modules build in Fedora koji are currently not built into yum repositories, though this is [planned](https://pagure.io/odcs). To build a Flatpak against a module thus requires you to manually build a yum repository ([flatpak-module-tools] (https://pagure.io/flatpak-module-tools) contains `flatpak-module compose`), put it somewhere publically accessible by HTTP, and provide it as the `compose_url` argument to the `flatpak_create_dockerfile` plugin.
 
-### flatpak.json
+### container.yaml
 
-The flatpak.json file is inspired by the JSON manifest input to [flatpak builder](http://docs.flatpak.org/en/latest/flatpak-builder.html), but
-without the actual build instructions. The flaptak.json for a runtime and for a application are somewhat different.
+Building a flatpak requires additional information to be added to the container.yaml file. The necessary additions for a runtime and for a application are somewhat different.
 
 Runtime:
 
-```json
-{
-        "runtime": "org.fedoraproject.Platform",
-        "runtime-version": "26",
-        "sdk": "org.fedoraproject.Sdk",
-        "cleanup-commands": [ "touch -d @0 /usr/share/fonts",
-                              "touch -d @0 /usr/share/fonts/*",
-                              "fc-cache -fs"
-                            ]
-}
-
+```yaml
+compose:
+    modules:
+    - flatpak-runtime:f28
+flatpak:
+    runtime: org.fedoraproject.Platform
+    runtime-version: f28
+    sdk: org.fedoraproject.Sdk
+    cleanup-commands: >
+        touch -d @0 /usr/share/fonts
+        touch -d @0 /usr/share/fonts/*
+        fc-cache -fs
 ```
 
 Application:
 
-```json
-{
-        "id": "org.gnome.eog",
-        "version": "3.20.0-2.fc26",
-        "runtime": "org.fedoraproject.Platform",
-        "runtime-version": "26",
-        "sdk": "org.fedoraproject.Sdk",
-        "command": "eog",
-        "tags": ["Viewer"],
-        "finish-args": ["--filesystem=host",
-                        "--share=ipc",
-                        "--socket=x11",
-                        "--socket=wayland",
-                        "--socket=session-bus",
-                        "--filesystem=~/.config/dconf:ro",
-                        "--filesystem=xdg-run/dconf",
-                        "--talk-name=ca.desrt.dconf",
-                        "--env=DCONF_USER_CONFIG_DIR=.config/dconf"]
-}
+```yaml
+compose:
+    modules:
+    - eog:f28
+flatpak:
+    id: org.gnome.eog
+    runtime: org.fedoraproject.Platform
+    runtime-version: 28
+    command: eog
+    tags: ["Viewer"]
+    finish-args: >
+        --filesystem=host
+        --share=ipc
+        --socket=x11
+        --socket=wayland
+        --socket=session-bus
+        --filesystem=~/.config/dconf:ro
+        --filesystem=xdg-run/dconf
+        --talk-name=ca.desrt.dconf
+        --env=DCONF_USER_CONFIG_DIR=.config/dconf
 ```

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -26,7 +26,7 @@ DOCKERFILE_ERROR_BUILD_PATH = os.path.join(FILES, 'docker-hello-world-error-buil
 DOCKERFILE_SUBDIR_PATH = os.path.join(FILES, 'df-in-subdir')
 
 FLATPAK_GIT = "git://pkgs.fedoraproject.org/modules/eog.git"
-FLATPAK_SHA1 = "dfb36e55a983d9957a32571f61deff0b1f06f86c"
+FLATPAK_SHA1 = "603bb298c8fb60936590e159b7a6387d6e090a09"
 
 SOURCE = {
     'provider': 'git',

--- a/tests/flatpak.py
+++ b/tests/flatpak.py
@@ -83,8 +83,7 @@ compose:
     - eog:f28
 flatpak:
     id: org.gnome.eog
-    runtime: org.fedoraproject.Platform
-    runtime-version: 28
+    branch: stable
     # Test overriding the automatic "first executable in /usr/bin'
     command: eog2
     tags: ["Viewer"]
@@ -96,7 +95,7 @@ document: modulemd
 version: 1
 data:
   name: flatpak-runtime
-  stream: f26
+  stream: f28
   version: 20170701152209
   summary: Flatpak Runtime
   description: Libraries and data files shared between applications
@@ -109,8 +108,8 @@ data:
       libnotify, adwaita-icon-theme, libgcab1, libxkbcommon, libappstream-glib, python3-cairo,
       gnome-desktop3, libepoxy, hunspell, libgusb, glib2, enchant, at-spi2-atk]
   dependencies:
-    buildrequires: {bootstrap: f26, shared-userspace: f26}
-    requires: {base-runtime: f26, shared-userspace: f26}
+    buildrequires: {platform: f28}
+    requires: {platform: f28}
   license:
     module: [MIT]
   profiles:
@@ -151,6 +150,17 @@ data:
   components:
     rpms: {}
   xmd:
+    flatpak:
+      # This gives information about how to map this module into Flatpak terms
+      # this is used when building application modules against this module.
+      branch: f28
+      runtimes: # Keys are profile names
+        runtime:
+          id: org.fedoraproject.Platform
+          sdk: org.fedoraproject.Sdk
+        sdk:
+          id: org.fedoraproject.Sdk
+          runtime: org.fedoraproject.Platform
     mbs: OMITTED
 """  # noqa
 
@@ -159,8 +169,8 @@ compose:
     modules:
     - flatpak-runtime:f28
 flatpak:
-    runtime: org.fedoraproject.Platform
-    runtime-version: f28
+    id: org.fedoraproject.Platform
+    branch: f28
     sdk: org.fedoraproject.Sdk
     cleanup-commands: >
         touch -d @0 /usr/share/fonts

--- a/tests/flatpak.py
+++ b/tests/flatpak.py
@@ -147,6 +147,8 @@ data:
         libutempter, adwaita-icon-theme, ncurses-libs, libidn2, system-python-libs,
         libffi, libXdamage, libglvnd-egl, libXft, cups-libs, ustr, libcom_err, libappstream-glib,
         gnome-desktop3, gdk-pixbuf2-modules, libsepol, filesystem, gzip, mpfr]
+    sdk:
+      rpms: [gcc]
   components:
     rpms: {}
   xmd:
@@ -172,6 +174,20 @@ flatpak:
     id: org.fedoraproject.Platform
     branch: f28
     sdk: org.fedoraproject.Sdk
+    cleanup-commands: >
+        touch -d @0 /usr/share/fonts
+        touch -d @0 /usr/share/fonts/*
+        fc-cache -fs
+"""
+
+FLATPAK_SDK_CONTAINER_YAML = """
+compose:
+    modules:
+    - flatpak-runtime:f28/sdk
+flatpak:
+    id: org.fedoraproject.Sdk
+    branch: f28
+    runtime: org.fedoraproject.Platform
     cleanup-commands: >
         touch -d @0 /usr/share/fonts
         touch -d @0 /usr/share/fonts/*
@@ -210,11 +226,26 @@ RUNTIME_CONFIG = {
     'container_yaml': FLATPAK_RUNTIME_CONTAINER_YAML,
 }
 
+SDK_CONFIG = {
+    'base_module': 'flatpak-runtime',
+    'profile': 'sdk',
+    'modules': {
+        'flatpak-runtime': {
+            'stream': 'f26',
+            'version': '20170629185228',
+            'metadata': FLATPAK_RUNTIME_MODULEMD,
+            'rpms': [],  # We don't use this currently
+        },
+    },
+    'container_yaml': FLATPAK_SDK_CONTAINER_YAML,
+}
+
 
 def build_flatpak_test_configs(extensions={}):
     configs = {
         'app': APP_CONFIG,
         'runtime': RUNTIME_CONFIG,
+        'sdk': SDK_CONFIG,
     }
 
     for key, config in extensions.items():

--- a/tests/flatpak.py
+++ b/tests/flatpak.py
@@ -12,9 +12,8 @@ data:
   license:
     module: [MIT]
   dependencies:
-    buildrequires: {base-runtime: f26, common-build-dependencies: f26, flatpak-runtime: f26,
-      perl: f26, shared-userspace: f26}
-    requires: {flatpak-runtime: f26}
+    buildrequires: {flatpak-runtime: f28}
+    requires: {flatpak-runtime: f28}
   profiles:
     default:
       rpms: [eog]
@@ -65,16 +64,18 @@ FLATPAK_APP_FINISH_ARGS = [
     "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
 ]
 
-FLATPAK_APP_JSON = {
-    "id": "org.gnome.eog",
-    "version": "3.20.0-2.fc26",
-    "runtime": "org.fedoraproject.Platform",
-    "runtime-version": "26",
-    "sdk": "org.fedoraproject.Sdk",
-    "command": "eog",
-    "tags": ["Viewer"],
-    "finish-args": FLATPAK_APP_FINISH_ARGS
-}
+FLATPAK_APP_CONTAINER_YAML = """
+compose:
+    modules:
+    - eog:f28
+flatpak:
+    id: org.gnome.eog
+    runtime: org.fedoraproject.Platform
+    runtime-version: 28
+    command: eog
+    tags: ["Viewer"]
+    finish-args: >
+""" + "".join("        {}\n".format(a) for a in FLATPAK_APP_FINISH_ARGS)
 
 FLATPAK_RUNTIME_MODULEMD = """
 document: modulemd
@@ -139,11 +140,16 @@ data:
     mbs: OMITTED
 """  # noqa
 
-FLATPAK_RUNTIME_JSON = {
-    "runtime": "org.fedoraproject.Platform",
-    "runtime-version": "26",
-    "sdk": "org.fedoraproject.Sdk",
-    "cleanup-commands": ["touch -d @0 /usr/share/fonts",
-                         "touch -d @0 /usr/share/fonts/*",
-                         "fc-cache -fs"]
-}
+FLATPAK_RUNTIME_CONTAINER_YAML = """
+compose:
+    modules:
+    - flatpak-runtime:f28
+flatpak:
+    runtime: org.fedoraproject.Platform
+    runtime-version: f28
+    sdk: org.fedoraproject.Sdk
+    cleanup-commands: >
+        touch -d @0 /usr/share/fonts
+        touch -d @0 /usr/share/fonts/*
+        fc-cache -fs
+"""

--- a/tests/flatpak.py
+++ b/tests/flatpak.py
@@ -72,7 +72,8 @@ flatpak:
     id: org.gnome.eog
     runtime: org.fedoraproject.Platform
     runtime-version: 28
-    command: eog
+    # Test overriding the automatic "first executable in /usr/bin'
+    command: eog2
     tags: ["Viewer"]
     finish-args: >
 """ + "".join("        {}\n".format(a) for a in FLATPAK_APP_FINISH_ARGS)

--- a/tests/plugins/test_flatpak_create_dockerfile.py
+++ b/tests/plugins/test_flatpak_create_dockerfile.py
@@ -114,4 +114,13 @@ def test_flatpak_create_dockerfile(tmpdir, docker_tasker, config_name, breakage)
         runner.run()
 
         assert os.path.exists(workflow.builder.df_path)
+
+        includepkgs_path = os.path.join(workflow.builder.df_dir, 'atomic-reactor-includepkgs')
+        assert os.path.exists(includepkgs_path)
+        with open(includepkgs_path) as f:
+            includepkgs = f.read()
+            assert 'librsvg2' in includepkgs
+            if config_name == 'app':
+                assert 'eog-0:3.24.1-1.module_7b96ed10.x86_64' in includepkgs
+
         assert os.path.exists(os.path.join(workflow.builder.df_dir, 'cleanup.sh'))

--- a/tests/plugins/test_flatpak_create_dockerfile.py
+++ b/tests/plugins/test_flatpak_create_dockerfile.py
@@ -8,7 +8,6 @@ of the BSD license. See the LICENSE file for details.
 
 from flexmock import flexmock
 
-import json
 import responses
 import os
 import pytest
@@ -30,7 +29,7 @@ from atomic_reactor.util import ImageName
 
 from tests.constants import (MOCK_SOURCE, FLATPAK_GIT, FLATPAK_SHA1)
 from tests.fixtures import docker_tasker  # noqa
-from tests.flatpak import FLATPAK_APP_JSON, FLATPAK_APP_MODULEMD, FLATPAK_APP_RPMS
+from tests.flatpak import FLATPAK_APP_CONTAINER_YAML, FLATPAK_APP_MODULEMD, FLATPAK_APP_RPMS
 
 
 class MockSource(object):
@@ -39,10 +38,10 @@ class MockSource(object):
         self.dockerfile_path = "./"
         self.path = tmpdir
 
-        self.flatpak_json_path = os.path.join(tmpdir, 'flatpak.json')
+        self.container_yaml_path = os.path.join(tmpdir, 'container.yaml')
 
     def get_build_file_path(self):
-        return self.flatpak_json_path, self.path
+        return self.container_yaml_path, self.path
 
     def get_vcs_info(self):
         return VcsInfo('git', FLATPAK_GIT, FLATPAK_SHA1)
@@ -67,8 +66,8 @@ def mock_workflow(tmpdir):
     workflow.builder.source = mock_source
     flexmock(workflow, source=mock_source)
 
-    with open(mock_source.flatpak_json_path, "w") as f:
-        f.write(json.dumps(FLATPAK_APP_JSON))
+    with open(mock_source.container_yaml_path, "w") as f:
+        f.write(FLATPAK_APP_CONTAINER_YAML)
 
     setattr(workflow.builder, 'df_dir', str(tmpdir))
 

--- a/tests/plugins/test_flatpak_create_oci.py
+++ b/tests/plugins/test_flatpak_create_oci.py
@@ -823,6 +823,8 @@ def test_flatpak_create_oci(tmpdir, docker_tasker, config_name, breakage, mock_f
             output = inspector.cat_file('/export/share/applications/org.gnome.eog.desktop')
             lines = output.split('\n')
             assert 'Icon=org.gnome.eog' in lines
+            metadata_lines = inspector.cat_file('/metadata').split('\n')
+            assert 'tags=Viewer' in metadata_lines
         else:  # runtime
             # Check that permissions have been normalized
             assert inspector.get_file_perms('/files/etc/shadow') == '-00644'

--- a/tests/plugins/test_flatpak_create_oci.py
+++ b/tests/plugins/test_flatpak_create_oci.py
@@ -447,8 +447,9 @@ class MockFlatpak:
         os.mkdir(os.path.join(directory, "files"))
 
     @staticmethod
-    def build_finish(directory):
-        pass
+    def build_finish(directory, command):
+        with open(os.path.join(directory, "metadata"), "a") as f:
+            f.write("command=" + command + "\n")
 
     @staticmethod
     def build_export(repo, directory):
@@ -485,7 +486,8 @@ COMMAND_PATTERNS = [
      MockFlatpak.build_bundle),
     (['flatpak', 'build-export', '@repo', '@directory'],
      MockFlatpak.build_export),
-    (['flatpak', 'build-finish'] + FLATPAK_APP_FINISH_ARGS + ['@directory'],
+    (['flatpak', 'build-finish', '--command', '@command'] +
+     FLATPAK_APP_FINISH_ARGS + ['@directory'],
      MockFlatpak.build_finish),
     (['flatpak', 'build-init', '@directory', '@appname', '@sdk', '@runtime', '@runtime_branch'],
      MockFlatpak.build_init),
@@ -825,6 +827,7 @@ def test_flatpak_create_oci(tmpdir, docker_tasker, config_name, breakage, mock_f
             assert 'Icon=org.gnome.eog' in lines
             metadata_lines = inspector.cat_file('/metadata').split('\n')
             assert 'tags=Viewer' in metadata_lines
+            assert 'command=eog2' in metadata_lines
         else:  # runtime
             # Check that permissions have been normalized
             assert inspector.get_file_perms('/files/etc/shadow') == '-00644'

--- a/tests/plugins/test_flatpak_create_oci.py
+++ b/tests/plugins/test_flatpak_create_oci.py
@@ -633,11 +633,8 @@ class MockInspector(object):
                     reason="modulemd not available")
 @pytest.mark.parametrize('config_name, breakage', [
     ('app', None),
-    ('app', 'stray_component'),
     ('app', 'no_runtime'),
     ('runtime', None),
-    ('runtime', 'stray_component'),
-    ('runtime', 'missing_component'),
     ('sdk', None)
 ])
 @pytest.mark.parametrize('mock_flatpak', (False, True))
@@ -697,20 +694,7 @@ def test_flatpak_create_oci(tmpdir, docker_tasker, config_name, breakage, mock_f
         if mode is not None:
             os.chmod(fullpath, int(mode, 8))
 
-    if breakage == 'stray_component':
-        fullpath = os.path.join(filesystem_dir, 'var/tmp/flatpak-build.rpm_qf')
-        with open(fullpath, 'a') as f:
-            f.write("bad-rpm;1.2.3;1.fc26;x86_64;0;42;sigmd5;0;42;1491914281;sigpgp;siggpg\n")
-        expected_exception = 'bad-rpm'
-    elif breakage == 'missing_component':
-        fullpath = os.path.join(filesystem_dir, 'var/tmp/flatpak-build.rpm_qf')
-        with open(fullpath, 'r') as f:
-            with open(fullpath + '.tmp', 'w') as g:
-                f.readline()
-                g.write(f.read())
-        os.rename(fullpath + '.tmp', fullpath)
-        expected_exception = 'Installed set of packages does not match runtime profile'
-    elif breakage == 'no_runtime':
+    if breakage == 'no_runtime':
         mmd = ModuleMetadata()
 
         # Copy the parts of the config we are going to change

--- a/tests/plugins/test_flatpak_create_oci.py
+++ b/tests/plugins/test_flatpak_create_oci.py
@@ -16,6 +16,7 @@ import shutil
 import subprocess
 import tarfile
 from textwrap import dedent
+import yaml
 
 
 from atomic_reactor.constants import IMAGE_TYPE_OCI, IMAGE_TYPE_OCI_TAR
@@ -39,8 +40,8 @@ from atomic_reactor.util import ImageName
 from tests.constants import TEST_IMAGE
 from tests.fixtures import docker_tasker  # noqa
 from tests.flatpak import (
-    FLATPAK_APP_JSON, FLATPAK_APP_MODULEMD, FLATPAK_APP_RPMS, FLATPAK_APP_FINISH_ARGS,
-    FLATPAK_RUNTIME_JSON, FLATPAK_RUNTIME_MODULEMD
+    FLATPAK_APP_CONTAINER_YAML, FLATPAK_APP_MODULEMD, FLATPAK_APP_RPMS, FLATPAK_APP_FINISH_ARGS,
+    FLATPAK_RUNTIME_CONTAINER_YAML, FLATPAK_RUNTIME_MODULEMD
 )
 
 TEST_ARCH = 'x86_64'
@@ -108,7 +109,7 @@ APP_CONFIG = {
             'rpms': [],  # We don't use this currently
         },
     },
-    'flatpak_json': FLATPAK_APP_JSON,
+    'container_yaml': FLATPAK_APP_CONTAINER_YAML,
     'filesystem_contents': APP_FILESYSTEM_CONTENTS,
     'expected_contents': EXPECTED_APP_FLATPAK_CONTENTS,
     'expected_components': ['eog'],
@@ -351,7 +352,7 @@ RUNTIME_CONFIG = {
             'rpms': [],  # We don't use this currently
         },
     },
-    'flatpak_json': FLATPAK_RUNTIME_JSON,
+    'container_yaml': FLATPAK_RUNTIME_CONTAINER_YAML,
     'filesystem_contents': RUNTIME_FILESYSTEM_CONTENTS,
     'expected_contents': EXPECTED_RUNTIME_FLATPAK_CONTENTS,
     'expected_components': ['abattis-cantarell-fonts'],
@@ -775,7 +776,7 @@ def test_flatpak_create_oci(tmpdir, docker_tasker, config_name, breakage, mock_f
                                repo_url)
     set_compose_info(workflow, compose_info)
 
-    source = FlatpakSourceInfo(FLATPAK_APP_JSON,
+    source = FlatpakSourceInfo(yaml.safe_load(config['container_yaml'])['flatpak'],
                                compose_info)
     set_flatpak_source_info(workflow, source)
 

--- a/tests/plugins/test_koji_import.py
+++ b/tests/plugins/test_koji_import.py
@@ -1513,7 +1513,7 @@ class TestKojiImport(object):
                                    modules,
                                    repo_url)
 
-        source = FlatpakSourceInfo(flatpak_json={}, compose=compose_info)
+        source = FlatpakSourceInfo(flatpak_yaml={}, compose=compose_info)
         set_flatpak_source_info(workflow, source)
 
         runner = create_runner(tasker, workflow, reactor_config_map=reactor_config_map)

--- a/tests/plugins/test_koji_promote.py
+++ b/tests/plugins/test_koji_promote.py
@@ -48,6 +48,7 @@ from atomic_reactor.build import BuildResult
 from tests.constants import SOURCE, MOCK
 from tests.util import mocked_reactorconfig
 from tests.fixtures import reactor_config_map  # noqa
+from tests.flatpak import MODULEMD_AVAILABLE, setup_flatpak_source_info
 
 try:
     import atomic_reactor.plugins.post_pulp_sync  # noqa:F401
@@ -55,15 +56,6 @@ try:
 except ImportError:
     PULP_SYNC_AVAILABLE = False
 
-try:
-    from atomic_reactor.plugins.pre_flatpak_create_dockerfile import (FlatpakSourceInfo,
-                                                                      set_flatpak_source_info)
-    from atomic_reactor.plugins.pre_resolve_module_compose import (ModuleInfo,
-                                                                   ComposeInfo)
-    from modulemd import ModuleMetadata
-    MODULEMD_AVAILABLE = True
-except ImportError:
-    MODULEMD_AVAILABLE = False
 
 from flexmock import flexmock
 import pytest
@@ -1439,28 +1431,7 @@ class TestKojiPromote(object):
                                             release='1',
                                             session=session)
 
-        modules = {
-            'eog': ModuleInfo(name='eog',
-                              stream='f26',
-                              version='20170629213428',
-                              mmd=ModuleMetadata(),
-                              rpms=[]),
-            'flatpak-runtime': ModuleInfo(name='flatpak-runtime',
-                                          stream='f26',
-                                          version='20170701152209',
-                                          mmd=ModuleMetadata(),
-                                          rpms=[]),
-        }
-        base_module = modules['eog']
-
-        repo_url = 'http://odcs.example/composes/latest-odcs-42-1/compose/Temporary/$basearch/os/'
-        compose_info = ComposeInfo(base_module.name + '-' + base_module.stream,
-                                   42, base_module,
-                                   modules,
-                                   repo_url)
-
-        source = FlatpakSourceInfo(flatpak_yaml={}, compose=compose_info)
-        set_flatpak_source_info(workflow, source)
+        setup_flatpak_source_info(workflow)
 
         runner = create_runner(tasker, workflow, reactor_config_map=reactor_config_map)
         runner.run()
@@ -1479,7 +1450,7 @@ class TestKojiPromote(object):
         assert image.get('flatpak') is True
         assert image.get('modules') == ['eog-f26-20170629213428',
                                         'flatpak-runtime-f26-20170701152209']
-        assert image.get('source_modules') == ['eog-f26']
+        assert image.get('source_modules') == ['eog:f26']
 
     @pytest.mark.parametrize('logs_return_bytes', [
         True,

--- a/tests/plugins/test_koji_promote.py
+++ b/tests/plugins/test_koji_promote.py
@@ -1459,7 +1459,7 @@ class TestKojiPromote(object):
                                    modules,
                                    repo_url)
 
-        source = FlatpakSourceInfo(flatpak_json={}, compose=compose_info)
+        source = FlatpakSourceInfo(flatpak_yaml={}, compose=compose_info)
         set_flatpak_source_info(workflow, source)
 
         runner = create_runner(tasker, workflow, reactor_config_map=reactor_config_map)

--- a/tests/plugins/test_resolve_module_compose.py
+++ b/tests/plugins/test_resolve_module_compose.py
@@ -33,7 +33,7 @@ from atomic_reactor.constants import REPO_CONTAINER_CONFIG
 from tests.constants import (MOCK_SOURCE, FLATPAK_GIT, FLATPAK_SHA1)
 from tests.util import mocked_reactorconfig
 from tests.fixtures import docker_tasker, reactor_config_map  # noqa
-from tests.flatpak import FLATPAK_APP_JSON, FLATPAK_APP_MODULEMD, FLATPAK_APP_RPMS
+from tests.flatpak import FLATPAK_APP_MODULEMD, FLATPAK_APP_RPMS
 from tests.retry_mock import mock_get_retry_session
 
 
@@ -43,10 +43,10 @@ class MockSource(object):
         self.dockerfile_path = "./"
         self.path = tmpdir
 
-        self.flatpak_json_path = os.path.join(tmpdir, 'flatpak.json')
+        self.container_yaml_path = os.path.join(tmpdir, 'container.yaml')
 
     def get_build_file_path(self):
-        return self.flatpak_json_path, self.path
+        return self.container_yaml_path, self.path
 
     def get_vcs_info(self):
         return VcsInfo('git', FLATPAK_GIT, FLATPAK_SHA1)
@@ -70,9 +70,6 @@ def mock_workflow(tmpdir):
     setattr(workflow, 'builder', MockBuilder())
     workflow.builder.source = mock_source
     flexmock(workflow, source=mock_source)
-
-    with open(mock_source.flatpak_json_path, "w") as f:
-        f.write(json.dumps(FLATPAK_APP_JSON))
 
     setattr(workflow.builder, 'df_dir', str(tmpdir))
 

--- a/tests/plugins/test_resolve_module_compose.py
+++ b/tests/plugins/test_resolve_module_compose.py
@@ -27,7 +27,7 @@ from atomic_reactor.plugin import PreBuildPluginsRunner, PluginFailedException
 from atomic_reactor.plugins.pre_reactor_config import (ReactorConfigPlugin,
                                                        WORKSPACE_CONF_KEY)
 from atomic_reactor.source import VcsInfo
-from atomic_reactor.util import ImageName, split_module_spec
+from atomic_reactor.util import ImageName
 from atomic_reactor.constants import REPO_CONTAINER_CONFIG
 
 from tests.constants import (MOCK_SOURCE, FLATPAK_GIT, FLATPAK_SHA1)
@@ -130,7 +130,6 @@ def test_resolve_module_compose(tmpdir, docker_tasker, compose_ids, modules,  # 
     module = None
     if modules:
         module = modules[0]
-        mod_name, mod_stream, mod_version = split_module_spec(module)
 
     workflow = mock_workflow(tmpdir)
     mock_get_retry_session()


### PR DESCRIPTION
This PR has three main groups of changes:

 * Support hybrid modularity by including the repository for the 'koji' plugin in the package set that we install in the Flatpak Dockerfile. (Also requires a osbs-client change)
 * Merge flatpak.json into container.yaml, and actually implement some tags from flatpak.json that were in the examples, but never hooked up.
 * Restrict the set of packages that are available to installation upfront using the dnf includepkgs option instead of checking after the fact that nothing extra was installed.

It would be hard to do three independent pull requests, but if it is preferred I can do serial pull requests for the three topics filing each one after the previous is merged. (The patches are cleanly split up, it's only the PR that is for everything together.) I've only done end-to-end testing with real content on all three sets of changes together. 
