### PR TITLE
orchestrate_build plugin: override_build_kwarg() 'platform' parameter

### DIFF
--- a/tests/plugins/test_orchestrate_build.py
+++ b/tests/plugins/test_orchestrate_build.py
@@ -1092,7 +1092,12 @@ def test_orchestrate_build_worker_build_kwargs(tmpdir, caplog, is_auto):
     assert not build_result.is_failed()
 
 
-def test_orchestrate_override_build_kwarg(tmpdir):
+@pytest.mark.parametrize('overrides', [
+    {None: '4242'},
+    {'x86_64': '4242'},
+    {'x86_64': '4242', None: '1111'},
+])
+def test_orchestrate_override_build_kwarg(tmpdir, overrides):
     workflow = mock_workflow(tmpdir)
     expected_kwargs = {
         'git_uri': SOURCE['uri'],
@@ -1114,7 +1119,8 @@ def test_orchestrate_override_build_kwarg(tmpdir):
         'osbs_client_config': str(tmpdir),
     }
 
-    override_build_kwarg(workflow, 'release', '4242')
+    for platform, value in overrides.items():
+        override_build_kwarg(workflow, 'release', value, platform)
 
     runner = BuildStepPluginsRunner(
         workflow.builder.tasker,

--- a/tests/plugins/test_resolve_composes.py
+++ b/tests/plugins/test_resolve_composes.py
@@ -671,4 +671,5 @@ class TestResolveComposes(object):
         return (workflow.plugin_workspace
                 .get(OrchestrateBuildPlugin.key, {})
                 .get(WORKSPACE_KEY_OVERRIDE_KWARGS, {})
+                .get(None, {})
                 .get('yum_repourls'))


### PR DESCRIPTION
allow overrride_build_kwarg to take an optional platform parameter. When
it is supplied, the parameter key-value is assigned to a new platform
dictionary in the override dictionary. If it is not assigned, the key-value
pair is assigned to a 'None' dictionary instead.

When override parameters are processed, the 'None' dictionary updates the
kwargs first, then the platform dictionary for the platform, if either
exist.

please review.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>