### PR TITLE
resolve_composes plugin: create 'pulp' ODCS composes and validate container sets

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -116,3 +116,4 @@ MEDIA_TYPE_OCI_V1 = "application/vnd.oci.image.manifest.v1+json"
 MEDIA_TYPE_OCI_V1_INDEX = "application/vnd.oci.image.index.v1+json"
 
 REPO_CONTAINER_CONFIG = 'container.yaml'
+REPO_CONTENT_SETS_CONFIG = 'content_sets.yaml'


### PR DESCRIPTION
When compose.pulp_repos is true, create 'pulp' ODCS composes for each architecture, using the content sets for each.

please review

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>