### PR TITLE
fix odcs pulp composes

### DIFF
--- a/atomic_reactor/plugins/pre_reactor_config.py
+++ b/atomic_reactor/plugins/pre_reactor_config.py
@@ -13,7 +13,6 @@ from osbs.utils import RegistryURI
 import os
 import six
 
-
 # Key used to store the config object in the plugin workspace
 WORKSPACE_CONF_KEY = 'reactor_config'
 NO_FALLBACK = object()
@@ -368,8 +367,9 @@ class ODCSConfig(object):
         if isinstance(keys, six.text_type):
             keys = keys.split()
         keys = set(keys)
-        for entry in self.signing_intents:
-            if set(entry['keys']) == keys:
+        for entry in reversed(self.signing_intents):
+            keys_set = set(entry['keys'])
+            if (keys and keys_set >= keys) or keys == keys_set:
                 return entry
 
         raise ValueError('unknown signing intent keys "{}"'.format(keys))


### PR DESCRIPTION
Fix the broken pulp composes in pre_resolve_composes by changing the way that signing intent is determined.

Change ODCSConfig in pre_reactor_config to return the most restrictive signing intent that
includes all the requested keys, without requiring that that the requested keys match all
the keys in the signing intent.

Edit some tests casts in test_resolve_composes to handle pulp composes' signing keys.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>