### PR TITLE
Add clusters_client_config_dir to reactor-config

### DIFF
--- a/atomic_reactor/plugins/build_orchestrate_build.py
+++ b/atomic_reactor/plugins/build_orchestrate_build.py
@@ -34,7 +34,8 @@ from atomic_reactor.plugins.pre_reactor_config import (get_config,
                                                        get_artifacts_allowed_domains,
                                                        get_yum_proxy, get_image_equal_labels,
                                                        get_content_versions, get_openshift_session,
-                                                       get_platform_descriptors)
+                                                       get_platform_descriptors,
+                                                       get_clusters_client_config_path)
 from atomic_reactor.plugins.pre_check_and_set_rebuild import is_rebuild
 from atomic_reactor.util import df_parser, get_build_json, get_manifest_list, ImageName
 from atomic_reactor.constants import (PLUGIN_ADD_FILESYSTEM_KEY, PLUGIN_BUILD_ORCHESTRATE_KEY,
@@ -281,7 +282,7 @@ class OrchestrateBuildPlugin(BuildStepPlugin):
         super(OrchestrateBuildPlugin, self).__init__(tasker, workflow)
         self.platforms = set(platforms)
         self.build_kwargs = build_kwargs
-        self.osbs_client_config = osbs_client_config
+        self.osbs_client_config_fallback = osbs_client_config
         self.config_kwargs = config_kwargs or {}
 
         self.adjust_build_kwargs()
@@ -447,8 +448,8 @@ class OrchestrateBuildPlugin(BuildStepPlugin):
     def get_cluster_info(self, cluster, platform):
         kwargs = deepcopy(self.config_kwargs)
         kwargs['conf_section'] = cluster.name
-        if self.osbs_client_config:
-            kwargs['conf_file'] = os.path.join(self.osbs_client_config, 'osbs.conf')
+        kwargs['conf_file'] = get_clusters_client_config_path(self.workflow,
+                                                              self.osbs_client_config_fallback)
 
         if platform in self.build_image_digests:
             kwargs['build_image'] = self.build_image_digests[platform]

--- a/atomic_reactor/plugins/pre_reactor_config.py
+++ b/atomic_reactor/plugins/pre_reactor_config.py
@@ -266,6 +266,11 @@ def get_clusters(workflow, fallback=NO_FALLBACK):
     return get_value(workflow, 'clusters', fallback)
 
 
+def get_clusters_client_config_path(workflow, fallback=NO_FALLBACK):
+    client_config_dir = get_value(workflow, 'clusters_client_config_dir', fallback)
+    return os.path.join(client_config_dir, 'osbs.conf')
+
+
 class ClusterConfig(object):
     """
     Configuration relating to a particular cluster

--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -40,6 +40,10 @@
       },
       "additionalProperties": false
     },
+    "clusters_client_config_dir": {
+      "description": "Path to directory with osbs.conf for communicating with workers",
+      "type": "string"
+    },
     "koji": {
         "description": "Koji instance",
         "type": "object",

--- a/tests/plugins/test_orchestrate_build.py
+++ b/tests/plugins/test_orchestrate_build.py
@@ -340,6 +340,9 @@ def test_orchestrate_build(tmpdir, caplog, config_kwargs,
         reactor_dict['content_versions'] = ['v2']
         expected_kwargs['registry_api_versions'] = 'v2'
 
+        # Move client config from plugin args to reactor config
+        reactor_dict['clusters_client_config_dir'] = plugin_args.pop('osbs_client_config')
+
         if config_kwargs and 'equal_labels' in config_kwargs:
             expected_kwargs['equal_labels'] = config_kwargs['equal_labels']
 


### PR DESCRIPTION
This new config is used to determine the location of osbs.conf file to
be used when communicating with worker clusters.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>