### PR TITLE
Atomic reactor was sending a repo object

### DIFF
--- a/atomic_reactor/pulp_util.py
+++ b/atomic_reactor/pulp_util.py
@@ -137,7 +137,7 @@ class PulpHandler(object):
                         do_update = True
                         break
             if do_update:
-                self.p.updateRepo(repo, {'auto_publish': False})
+                self.p.updateRepo(repo["id"], {'auto_publish': False})
 
     def get_tar_metadata(self, tarfile):
         metadata = dockpulp.imgutils.get_metadata(tarfile)

--- a/tests/test_pulp_util.py
+++ b/tests/test_pulp_util.py
@@ -248,7 +248,7 @@ def test_ensure_repos(auto_publish, unsupported):
 
     (flexmock(dockpulp.Pulp)
      .should_receive('updateRepo')
-     .with_args(data_with_dist[0], {'auto_publish': False})
+     .with_args(data_with_dist[0]["id"], {'auto_publish': False})
      .times(1 if auto_publish and not unsupported else 0))
 
     image_names = [ImageName(repo="myproject-hello-world")]


### PR DESCRIPTION
Atomic reactor was sending a repo object to dockpulp's updateRepo method instead of sending an id.

Signed-off-by: Bret Fontecchio <bfontecc@redhat.com>