### PR TITLE
create and use pre_check_and_set_platforms

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -84,6 +84,7 @@ PLUGIN_GROUP_MANIFESTS_KEY = 'group_manifests'
 PLUGIN_BUILD_ORCHESTRATE_KEY = 'orchestrate_build'
 PLUGIN_KOJI_PARENT_KEY = 'koji_parent'
 PLUGIN_COMPARE_COMPONENTS_KEY = 'compare_components'
+PLUGIN_CHECK_AND_SET_PLATFORMS_KEY = 'check_and_set_platforms'
 PLUGIN_REMOVE_WORKER_METADATA_KEY = 'remove_worker_metadata'
 PLUGIN_RESOLVE_COMPOSES_KEY = 'resolve_composes'
 

--- a/atomic_reactor/plugins/pre_check_and_set_platforms.py
+++ b/atomic_reactor/plugins/pre_check_and_set_platforms.py
@@ -1,0 +1,55 @@
+"""
+Copyright (c) 2018 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+
+
+Query the koji build target, if any, to find the enabled architectures. Remove any excluded
+architectures, and return the resulting list.
+
+build_orchestrate_build will prefer this list of architectures over the platforms supplied by
+USER_PARAMS, which is necessary to allow autobuilds to build on the correct architectures
+when koji build tags change.
+"""
+
+from atomic_reactor.plugin import PreBuildPlugin
+from atomic_reactor.util import get_platforms_in_limits
+from atomic_reactor.plugins.pre_reactor_config import get_koji_session
+from atomic_reactor.constants import PLUGIN_CHECK_AND_SET_PLATFORMS_KEY
+
+
+class CheckAndSetPlatformsPlugin(PreBuildPlugin):
+    key = PLUGIN_CHECK_AND_SET_PLATFORMS_KEY
+    is_allowed_to_fail = False
+
+    def __init__(self, tasker, workflow, koji_target):
+
+        """
+        constructor
+
+        :param tasker: DockerTasker instance
+        :param workflow: DockerBuildWorkflow instance
+        """
+        # call parent constructor
+        super(CheckAndSetPlatformsPlugin, self).__init__(tasker, workflow)
+        self.koji_target = koji_target
+
+    def run(self):
+        """
+        run the plugin
+        """
+        koji_session = get_koji_session(self.workflow)
+        self.log.info("Checking koji target for platforms")
+        event_id = koji_session.getLastEvent()['id']
+        target_info = koji_session.getBuildTarget(self.koji_target, event=event_id)
+        build_tag = target_info['build_tag']
+        koji_build_conf = koji_session.getBuildConfig(build_tag, event=event_id)
+        koji_platforms = koji_build_conf['arches']
+        if not koji_platforms:
+            self.log.info("No platforms found in koji target")
+            return None
+        platforms = koji_platforms.split()
+
+        return get_platforms_in_limits(self.workflow, platforms)

--- a/atomic_reactor/plugins/pre_resolve_composes.py
+++ b/atomic_reactor/plugins/pre_resolve_composes.py
@@ -14,7 +14,8 @@ from collections import defaultdict
 
 from atomic_reactor.constants import (PLUGIN_KOJI_PARENT_KEY, PLUGIN_RESOLVE_COMPOSES_KEY,
                                       REPO_CONTAINER_CONFIG, REPO_CONTENT_SETS_CONFIG,
-                                      PLUGIN_BUILD_ORCHESTRATE_KEY)
+                                      PLUGIN_BUILD_ORCHESTRATE_KEY,
+                                      PLUGIN_CHECK_AND_SET_PLATFORMS_KEY)
 
 from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.plugins.build_orchestrate_build import override_build_kwarg
@@ -134,7 +135,11 @@ class ResolveComposesPlugin(PreBuildPlugin):
             self.compose_ids = tuple()
 
     def get_arches(self):
-        # This will be replaced by a plugin soon but this will do for now
+        platforms = self.workflow.prebuild_results.get(PLUGIN_CHECK_AND_SET_PLATFORMS_KEY)
+        if platforms:
+            return [platform for platform in platforms]
+
+        # Fallback to build_orchestrate_build args if check_and_set_platforms didn't run
         for plugin in self.workflow.buildstep_plugins_conf:
             if plugin['name'] == PLUGIN_BUILD_ORCHESTRATE_KEY:
                 return plugin['args']['platforms']

--- a/tests/plugins/test_check_and_set_platforms.py
+++ b/tests/plugins/test_check_and_set_platforms.py
@@ -1,0 +1,130 @@
+"""
+Copyright (c) 2017 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+from __future__ import unicode_literals
+import os
+import yaml
+
+from atomic_reactor.constants import PLUGIN_CHECK_AND_SET_PLATFORMS_KEY, REPO_CONTAINER_CONFIG
+from atomic_reactor.plugins.pre_reactor_config import NO_FALLBACK
+import atomic_reactor.plugins.pre_reactor_config as reactor_config
+from atomic_reactor.core import DockerTasker
+from atomic_reactor.inner import DockerBuildWorkflow
+from atomic_reactor.plugin import PreBuildPluginsRunner
+from atomic_reactor.util import ImageName
+from flexmock import flexmock
+import pytest
+from tests.constants import SOURCE, MOCK
+if MOCK:
+    from tests.docker_mock import mock_docker
+
+
+class X(object):
+    pass
+
+
+KOJI_TARGET = "target"
+
+
+# ClientSession is xmlrpc instance, we need to mock it explicitly
+def mock_session(platforms):
+    last_event_id = 456
+    build_target = {
+        'build_tag': 'build-tag',
+        'name': 'target-name',
+        'dest_tag_name': 'dest-tag'
+    }
+    session = flexmock()
+    (session
+        .should_receive('getLastEvent')
+        .and_return({'id': last_event_id}))
+    (session
+        .should_receive('getBuildTarget')
+        .with_args('target', event=last_event_id)
+        .and_return(build_target))
+    (session
+        .should_receive('getBuildConfig')
+        .with_args('build-tag', event=last_event_id)
+        .and_return({'arches': platforms}))
+
+    return session
+
+
+class MockSource(object):
+    def __init__(self, tmpdir):
+        self.path = str(tmpdir)
+        self.dockerfile_path = str(tmpdir)
+
+    def get_build_file_path(self):
+        return self.path, self.path
+
+
+def prepare(tmpdir):
+    if MOCK:
+        mock_docker()
+    tasker = DockerTasker()
+    workflow = DockerBuildWorkflow(SOURCE, "test-image")
+    setattr(workflow, 'builder', X())
+    source = MockSource(tmpdir)
+
+    setattr(workflow.builder, 'image_id', "asd123")
+    setattr(workflow.builder, 'base_image', ImageName(repo='Fedora', tag='21'))
+    setattr(workflow.builder, 'source', source)
+    setattr(workflow, 'source', source)
+
+    return tasker, workflow
+
+
+@pytest.mark.parametrize(('platforms', 'platform_exclude', 'platform_only', 'result'), [
+    (None, '', 'ppc64le', None),
+    ('x86_64 ppc64le', '', 'ppc64le', ['ppc64le']),
+    ('x86_64 spam bacon toast ppc64le', ['spam', 'bacon', 'eggs', 'toast'], '',
+     ['x86_64', 'ppc64le']),
+    ('ppc64le spam bacon toast', ['spam', 'bacon', 'eggs', 'toast'], 'ppc64le',
+     ['ppc64le']),
+    ('x86_64 bacon toast', 'toast', ['x86_64', 'ppc64le'], ['x86_64']),
+    ('x86_64 toast', 'toast', 'x86_64', ['x86_64']),
+    ('x86_64 spam bacon toast', ['spam', 'bacon', 'eggs', 'toast'], ['x86_64', 'ppc64le'],
+     ['x86_64']),
+    ('x86_64 ppc64le', '', '', ['x86_64', 'ppc64le'])
+])
+def test_check_and_set_platforms(tmpdir, platforms, platform_exclude, platform_only, result):
+    platforms_dict = {}
+    if platform_exclude != '':
+        platforms_dict['platforms'] = {}
+        platforms_dict['platforms']['not'] = platform_exclude
+    if platform_only != '':
+        if 'platforms' not in platforms_dict:
+            platforms_dict['platforms'] = {}
+        platforms_dict['platforms']['only'] = platform_only
+
+    container_path = os.path.join(str(tmpdir), REPO_CONTAINER_CONFIG)
+    with open(container_path, 'w') as f:
+        f.write(yaml.safe_dump(platforms_dict))
+        f.flush()
+
+    tasker, workflow = prepare(tmpdir)
+
+    session = mock_session(platforms)
+    flexmock(reactor_config).should_receive('get_koji_session').and_return(session)
+    (flexmock(reactor_config).
+        should_receive('get_value').
+        with_args(workflow, 'koji_target', NO_FALLBACK).
+        and_return(KOJI_TARGET))
+
+    runner = PreBuildPluginsRunner(tasker, workflow, [{
+        'name': PLUGIN_CHECK_AND_SET_PLATFORMS_KEY,
+        'args': {'koji_target': KOJI_TARGET},
+    }])
+
+    plugin_result = runner.run()
+    if platforms:
+        assert plugin_result[PLUGIN_CHECK_AND_SET_PLATFORMS_KEY]
+        assert plugin_result[PLUGIN_CHECK_AND_SET_PLATFORMS_KEY] == set(result)
+    else:
+        assert plugin_result[PLUGIN_CHECK_AND_SET_PLATFORMS_KEY] is None


### PR DESCRIPTION
 ##add a new plugin that retrieves the koji session information and gets
the platforms from it. The new plugin also checks the repo configuration
file and removes any excluded platforms and limits the result to any only
platforms.

build_orchestrate_build will use the results of the new plugin over the
platforms passed in from USER_PARAMS if available. This will allow
multi-arch autorebuilds to respond to changes in the koji tag.

pre_pull_base_image will also use the results of the new plugin.

Fixes osbs-5230.

requires https://github.com/projectatomic/osbs-client/pull/747 to enable the plugin