### PR TITLE
plugins/exit_pulp_publish: tolerate missing annotations

### DIFF
--- a/atomic_reactor/plugins/exit_pulp_publish.py
+++ b/atomic_reactor/plugins/exit_pulp_publish.py
@@ -111,7 +111,7 @@ class PulpPublishPlugin(ExitPlugin):
 
         for platform in worker_builds:
             build_info = get_worker_build_info(self.workflow, platform)
-            annotations = build_info.build.get_annotations()
+            annotations = build_info.build.get_annotations() or {}
             v1_image_id = annotations.get('v1-image-id')
             if v1_image_id:
                 image_names = self.workflow.tag_conf.images

--- a/test.sh
+++ b/test.sh
@@ -94,3 +94,6 @@ if [[ $OS != "fedora" ]]; then $RUN $PIP install -U setuptools; fi
 
 # Run tests
 $RUN pytest -vv tests --cov atomic_reactor "$@"
+
+echo "To run tests again:"
+echo "$RUN pytest -vv tests --cov atomic_reactor "

--- a/tests/plugins/test_pulp_publish.py
+++ b/tests/plugins/test_pulp_publish.py
@@ -46,10 +46,12 @@ class X(object):
 
 
 class BuildInfo(object):
-    def __init__(self, v1_image_id=None):
+    def __init__(self, v1_image_id=None, unset_annotations=False):
         annotations = {'meta': 'test'}
         if v1_image_id:
             annotations['v1-image-id'] = v1_image_id
+        if unset_annotations:
+            annotations = None
 
         self.build = BuildResponse({'metadata': {'annotations': annotations}})
 
@@ -115,8 +117,9 @@ def prepare(success=True, v1_image_ids={}):
                 },
                 'metadata_fragment': 'configmap/build-1-ppc64le-md',
                 'metadata_fragment_key': 'metadata.json',
-            }
-        }
+            },
+            'bogus': {},
+        },
     }
 
     if success:
@@ -127,6 +130,7 @@ def prepare(success=True, v1_image_ids={}):
     build_info = {}
     build_info['x86_64'] = BuildInfo()
     build_info['ppc64le'] = BuildInfo()
+    build_info['bogus'] = BuildInfo(unset_annotations=True)  # OSBS-5262
 
     for platform, v1_image_id in v1_image_ids.items():
         build_info[platform] = BuildInfo(v1_image_id)


### PR DESCRIPTION
Fix for OSBS-5262 in which when a worker build disappears or monitoring
otherwise fails for some reason, pulp_publish gives a traceback when
attempting to find annotations from it.