### PR TITLE
Add helper for creating koji.PathInfo object

### DIFF
--- a/atomic_reactor/plugins/pre_fetch_maven_artifacts.py
+++ b/atomic_reactor/plugins/pre_fetch_maven_artifacts.py
@@ -16,6 +16,7 @@ from atomic_reactor import util
 from atomic_reactor.constants import DEFAULT_DOWNLOAD_BLOCK_SIZE
 from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.plugins.pre_reactor_config import (get_koji_session, get_koji,
+                                                       get_koji_path_info,
                                                        get_artifacts_allowed_domains)
 from collections import namedtuple
 
@@ -102,8 +103,7 @@ class FetchMavenArtifactsPlugin(PreBuildPlugin):
                 'krb_keytab_path': str(koji_krb_keytab)
             }
         }
-        self.path_info =\
-            koji.PathInfo(topdir=get_koji(self.workflow, self.koji_fallback)['root_url'])
+        self.path_info = get_koji_path_info(self.workflow, self.koji_fallback)
 
         all_allowed_domains = get_artifacts_allowed_domains(self.workflow, allowed_domains or [])
         self.allowed_domains = set(domain.lower() for domain in all_allowed_domains or [])

--- a/atomic_reactor/plugins/pre_koji.py
+++ b/atomic_reactor/plugins/pre_koji.py
@@ -9,11 +9,11 @@ of the BSD license. See the LICENSE file for details.
 Pre build plugin for koji build system
 """
 import os
-import koji
 from atomic_reactor.constants import YUM_REPOS_DIR
 from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.util import render_yum_repo
-from atomic_reactor.plugins.pre_reactor_config import get_koji_session, get_yum_proxy
+from atomic_reactor.plugins.pre_reactor_config import (get_koji_session, get_yum_proxy,
+                                                       get_koji_path_info)
 
 
 class KojiPlugin(PreBuildPlugin):
@@ -40,13 +40,14 @@ class KojiPlugin(PreBuildPlugin):
 
         self.koji_fallback = {
             'hub_url': hub,
+            'root_url': root,
             'auth': {
                 'ssl_certs_dir': koji_ssl_certs_dir
             }
         }
 
         self.xmlrpc = get_koji_session(self.workflow, self.koji_fallback)
-        self.pathinfo = koji.PathInfo(topdir=root)
+        self.pathinfo = get_koji_path_info(self.workflow, self.koji_fallback)
         self.proxy = get_yum_proxy(self.workflow, proxy)
 
     def run(self):

--- a/atomic_reactor/plugins/pre_reactor_config.py
+++ b/atomic_reactor/plugins/pre_reactor_config.py
@@ -76,6 +76,16 @@ def get_koji_session(workflow, fallback):
     return create_koji_session(config['hub_url'], auth_info)
 
 
+def get_koji_path_info(workflow, fallback):
+    config = get_koji(workflow, fallback)
+    from koji import PathInfo
+
+    # Make sure koji root_url doesn't end with a slash since the url
+    # is used to construct resource urls (e.g. log links)
+    root_url = config['root_url'].rstrip('/')
+    return PathInfo(topdir=root_url)
+
+
 def get_pulp(workflow, fallback=NO_FALLBACK):
     return get_value(workflow, 'pulp', fallback)
 

--- a/tests/plugins/test_koji.py
+++ b/tests/plugins/test_koji.py
@@ -192,15 +192,10 @@ class TestKoji(object):
                          tmpdir, root, koji_ssl_certs,
                          expected_string, expected_file, proxy, reactor_config_map):
         tasker, workflow = prepare()
-        args = {
-            'target': target,
-            'hub': '',
-            'root': root,
-            'proxy': proxy,
-        }
+
+        args = {'target': target}
 
         if koji_ssl_certs:
-            args['koji_ssl_certs_dir'] = str(tmpdir)
             tmpdir.join('cert').write('cert')
             tmpdir.join('serverca').write('serverca')
 
@@ -216,6 +211,16 @@ class TestKoji(object):
                 ReactorConfig({'version': 1,
                                'koji': koji_map,
                                'yum_proxy': proxy})
+
+        else:
+            args.update({
+                'hub': '',
+                'root': root,
+                'proxy': proxy,
+            })
+
+            if koji_ssl_certs:
+                args['koji_ssl_certs_dir'] = str(tmpdir)
 
         runner = PreBuildPluginsRunner(tasker, workflow, [{
             'name': KojiPlugin.key,


### PR DESCRIPTION
Also ensures that pre_koji plugin reads koji root url from reactor
config when available.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>