### PR TITLE
pre_check_and_set_platforms: pass NO_FALLBACK to get_koji_session

### DIFF
--- a/atomic_reactor/plugins/pre_check_and_set_platforms.py
+++ b/atomic_reactor/plugins/pre_check_and_set_platforms.py
@@ -16,7 +16,7 @@ when koji build tags change.
 
 from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.util import get_platforms_in_limits
-from atomic_reactor.plugins.pre_reactor_config import get_koji_session
+from atomic_reactor.plugins.pre_reactor_config import get_koji_session, NO_FALLBACK
 from atomic_reactor.constants import PLUGIN_CHECK_AND_SET_PLATFORMS_KEY
 
 
@@ -40,7 +40,7 @@ class CheckAndSetPlatformsPlugin(PreBuildPlugin):
         """
         run the plugin
         """
-        koji_session = get_koji_session(self.workflow)
+        koji_session = get_koji_session(self.workflow, NO_FALLBACK)
         self.log.info("Checking koji target for platforms")
         event_id = koji_session.getLastEvent()['id']
         target_info = koji_session.getBuildTarget(self.koji_target, event=event_id)

--- a/tests/plugins/test_check_and_set_platforms.py
+++ b/tests/plugins/test_check_and_set_platforms.py
@@ -11,8 +11,8 @@ import os
 import yaml
 
 from atomic_reactor.constants import PLUGIN_CHECK_AND_SET_PLATFORMS_KEY, REPO_CONTAINER_CONFIG
-from atomic_reactor.plugins.pre_reactor_config import NO_FALLBACK
 import atomic_reactor.plugins.pre_reactor_config as reactor_config
+import atomic_reactor.koji_util as koji_util
 from atomic_reactor.core import DockerTasker
 from atomic_reactor.inner import DockerBuildWorkflow
 from atomic_reactor.plugin import PreBuildPluginsRunner
@@ -111,11 +111,12 @@ def test_check_and_set_platforms(tmpdir, platforms, platform_exclude, platform_o
     tasker, workflow = prepare(tmpdir)
 
     session = mock_session(platforms)
-    flexmock(reactor_config).should_receive('get_koji_session').and_return(session)
-    (flexmock(reactor_config).
-        should_receive('get_value').
-        with_args(workflow, 'koji_target', NO_FALLBACK).
-        and_return(KOJI_TARGET))
+    mock_koji_config = {
+        'auth': {},
+        'hub_url': 'test',
+    }
+    flexmock(reactor_config).should_receive('get_koji').and_return(mock_koji_config)
+    flexmock(koji_util).should_receive('create_koji_session').and_return(session)
 
     runner = PreBuildPluginsRunner(tasker, workflow, [{
         'name': PLUGIN_CHECK_AND_SET_PLATFORMS_KEY,


### PR DESCRIPTION
get_koji_session requires two arguments. pre_check_and_set_platforms does
not have fallback information for the koji session, so pass NO_FALLBACK
and let reactor_config raise the error if the session isn't found.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>