### PR TITLE
Resolve module compose test failure 2

### DIFF
--- a/atomic_reactor/plugins/pre_resolve_module_compose.py
+++ b/atomic_reactor/plugins/pre_resolve_module_compose.py
@@ -196,7 +196,7 @@ class ResolveModuleComposePlugin(PreBuildPlugin):
 
         if self.compose_ids:
             if len(self.compose_ids) > 1:
-                self.log.info("Multiple compose_ids, using first compose %d", self.compose_id)
+                self.log.info("Multiple compose_ids, using first compose %d", self.compose_ids[0])
             self.compose_id = self.compose_ids[0]
 
         if self.compose_id is None:

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -1126,9 +1126,17 @@ class SessionWithTimeout(requests.Session):
         return super(SessionWithTimeout, self).request(*args, **kwargs)
 
 
+# This is a hook to mock during tests to temporarily disable retries
+def _http_retries_disabled():
+    return False
+
+
 def get_retrying_requests_session(client_statuses=HTTP_CLIENT_STATUS_RETRY,
                                   times=HTTP_MAX_RETRIES, delay=HTTP_BACKOFF_FACTOR,
                                   method_whitelist=None):
+    if _http_retries_disabled():
+        times = 0
+
     retry = Retry(
         total=int(times),
         backoff_factor=delay,

--- a/test.sh
+++ b/test.sh
@@ -38,8 +38,9 @@ $RUN $PKG install -y $PKG_EXTRA
 $RUN $BUILDDEP -y atomic-reactor.spec
 if [[ $OS == "fedora" ]]; then
   # Remove python-docker-py because docker-squash will pull
-  # in the latest version from PyPI
-  $RUN $PKG remove -y python{,3}-docker{,-py}
+  # in the latest version from PyPI. Don't remove the dependencies
+  # that it pulled in, to avoid having to rebuild them.
+  $RUN $PKG remove -y --noautoremove python{,3}-docker{,-py}
 else
   # Install dependecies for test, as check is disabled for rhel
   $RUN yum install -y python-flexmock python-six \

--- a/tests/retry_mock.py
+++ b/tests/retry_mock.py
@@ -13,13 +13,6 @@ from atomic_reactor import util
 
 
 def mock_get_retry_session():
-
-    def custom_retries(*args, **kwargs):
-        kwargs['times'] = 0
-        return retry_fnc(*args, **kwargs)
-
-    retry_fnc = util.get_retrying_requests_session
-
     (flexmock(util)
-        .should_receive('get_retrying_requests_session')
-        .replace_with(custom_retries))
+        .should_receive('_http_retries_disabled')
+        .and_return(True))


### PR DESCRIPTION
This PR fixes a problem where dependencies were missing during Travis testing causing Flatpak tests not being run because it looked like modulemd or pdc-client was missing, but actually the websockets dependency of docker-client was removed and not built subsequently.

Then two revealed problems are fixed:
 - disabling retries during mocking didn't work in all cases - see the commit message for details
 - A (harmless) backtrace was logged because of a minor logic error
