### PR TITLE
Only remove pulp_push if v1 content is not on

### DIFF
--- a/atomic_reactor/plugins/input_osv3.py
+++ b/atomic_reactor/plugins/input_osv3.py
@@ -82,18 +82,18 @@ class OSv3InputPlugin(InputPlugin):
             docker_registry = None
             all_registries = self.get_value('registries', {})
 
-            versions = []
+            versions = self.get_value('content_versions', ['v1', 'v2'])
 
             for registry in all_registries:
                 reguri = RegistryURI(registry.get('url'))
-                versions.append(reguri.version)
-                if not docker_registry and reguri.version == 'v2':
+                if reguri.version == 'v2':
                     # First specified v2 registry is the one we'll tell pulp
                     # to sync from. Keep the http prefix -- pulp wants it.
                     docker_registry = registry
+                    break
 
             if 'v1' not in versions:
-                self.remove_plugin('postbuild_plugins', 'pulp_push', 'only V2 registries')
+                self.remove_plugin('postbuild_plugins', 'pulp_push', 'v1 content not enabled')
 
             if docker_registry:
                 source_registry_str = self.get_value('source_registry', {}).get('url')

--- a/tests/plugins/test_input_osv3.py
+++ b/tests/plugins/test_input_osv3.py
@@ -222,6 +222,8 @@ def test_remove_v1_pulp_and_exit_delete():
             auth:
                 password: testpasswd
                 username: testuser
+        content_versions:
+        - v2
         registries:
         - url: https://container-registry.example.com/v2
         auth:


### PR DESCRIPTION
The plugin pulp_push is meant to push v1 content to pulp repository. Use
the content_versions value from reactor config to determine whether or
not plugin should be removed.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>