### PR TITLE
OSBS-3053: threaded filesystem poll

### DIFF
--- a/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
+++ b/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
@@ -153,6 +153,16 @@ class StoreMetadataInOSv3Plugin(ExitPlugin):
             "durations": self.workflow.plugins_durations,
         }
 
+    def get_filesystem_metadata(self):
+        data = {}
+        try:
+            data = self.workflow.fs_watcher.get_usage_data()
+            self.log.debug("filesystem metadata: %s", data)
+        except Exception:
+            self.log.exception("Error getting filesystem stats")
+
+        return data
+
     def make_labels(self):
         labels = {}
 
@@ -223,7 +233,8 @@ class StoreMetadataInOSv3Plugin(ExitPlugin):
             "base-image-name": base_image_name,
             "image-id": self.workflow.builder.image_id or '',
             "digests": json.dumps(self.get_pullspecs(self.get_digests())),
-            "plugins-metadata": json.dumps(self.get_plugin_metadata())
+            "plugins-metadata": json.dumps(self.get_plugin_metadata()),
+            "filesystem": json.dumps(self.get_filesystem_metadata()),
         }
 
         help_result = self.workflow.prebuild_results.get(AddHelpPlugin.key)

--- a/tests/plugins/test_store_metadata.py
+++ b/tests/plugins/test_store_metadata.py
@@ -217,6 +217,7 @@ CMD blabla"""
     workflow.exit_results = {
         PulpPullPlugin.key: pulp_pull_results,
     }
+    workflow.fs_watcher._data = dict(fs_data=None)
 
     if br_annotations or br_labels:
         workflow.build_result = BuildResult(
@@ -268,6 +269,8 @@ CMD blabla"""
     assert is_string_type(annotations['base-image-name'])
     assert "image-id" in annotations
     assert is_string_type(annotations['image-id'])
+    assert "filesystem" in annotations
+    assert "fs_data" in annotations['filesystem']
 
     if koji:
         assert "metadata_fragment" in annotations


### PR DESCRIPTION
Have DBW use a background thread to track filesystem usage over time so it can be recorded in the build metadata.