### PR TITLE
Require a platform for GOARCH=amd64 (OSBS-5375)

### DIFF
--- a/atomic_reactor/plugins/pre_check_and_set_platforms.py
+++ b/atomic_reactor/plugins/pre_check_and_set_platforms.py
@@ -16,8 +16,14 @@ when koji build tags change.
 
 from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.util import get_platforms_in_limits
-from atomic_reactor.plugins.pre_reactor_config import get_koji_session, NO_FALLBACK
+from atomic_reactor.plugins.pre_reactor_config import (get_koji_session,
+                                                       get_platform_to_goarch_mapping,
+                                                       NO_FALLBACK)
 from atomic_reactor.constants import PLUGIN_CHECK_AND_SET_PLATFORMS_KEY
+
+
+class MustBuildForAmd64(Exception):
+    """ Platforms must include one for GOARCH amd64 """
 
 
 class CheckAndSetPlatformsPlugin(PreBuildPlugin):
@@ -31,10 +37,33 @@ class CheckAndSetPlatformsPlugin(PreBuildPlugin):
 
         :param tasker: DockerTasker instance
         :param workflow: DockerBuildWorkflow instance
+        :param koji_target: str, Koji build target name
         """
         # call parent constructor
         super(CheckAndSetPlatformsPlugin, self).__init__(tasker, workflow)
         self.koji_target = koji_target
+        try:
+            self.goarch = get_platform_to_goarch_mapping(workflow)
+        except KeyError:
+            self.goarch = None
+
+    def validate_platforms(self, platforms):
+        """
+        Verify that a platform with GOARCH=amd64 is present. If it is not,
+        the tag will not be pullable by clients that do not have
+        support for the 'manifest list' type.
+        """
+        if self.goarch is None:
+            # Don't perform this check without a real reactor_config_map
+            self.log.info("No GOARCH mapping: skipping platform validation")
+            return
+
+        for platform in platforms:
+            goarch = self.goarch.get(platform, platform)
+            if goarch == 'amd64':
+                return
+
+        raise MustBuildForAmd64
 
     def run(self):
         """
@@ -50,6 +79,7 @@ class CheckAndSetPlatformsPlugin(PreBuildPlugin):
         if not koji_platforms:
             self.log.info("No platforms found in koji target")
             return None
-        platforms = koji_platforms.split()
-
-        return get_platforms_in_limits(self.workflow, platforms)
+        platforms = get_platforms_in_limits(self.workflow,
+                                            koji_platforms.split())
+        self.validate_platforms(platforms)
+        return platforms

--- a/atomic_reactor/plugins/pre_pull_base_image.py
+++ b/atomic_reactor/plugins/pre_pull_base_image.py
@@ -14,11 +14,12 @@ from __future__ import unicode_literals
 import docker
 
 from atomic_reactor.plugin import PreBuildPlugin
-from atomic_reactor.util import get_build_json, get_manifest_list, ImageName, DefaultKeyDict
+from atomic_reactor.util import get_build_json, get_manifest_list, ImageName
 from atomic_reactor.constants import (PLUGIN_BUILD_ORCHESTRATE_KEY,
                                       PLUGIN_CHECK_AND_SET_PLATFORMS_KEY)
 from atomic_reactor.core import RetryGeneratorException
-from atomic_reactor.plugins.pre_reactor_config import get_source_registry, get_platform_descriptors
+from atomic_reactor.plugins.pre_reactor_config import (get_source_registry,
+                                                       get_platform_to_goarch_mapping)
 from osbs.utils import RegistryURI
 
 
@@ -163,7 +164,7 @@ class PullBaseImagePlugin(PreBuildPlugin):
             return
 
         try:
-            platform_descriptors = get_platform_descriptors(self.workflow)
+            platform_to_arch = get_platform_to_goarch_mapping(self.workflow)
         except KeyError:
             self.log.info('Cannot validate available platforms for base image '
                           'because platform descriptors are not defined')
@@ -177,10 +178,6 @@ class PullBaseImagePlugin(PreBuildPlugin):
         all_manifests = manifest_list.json()['manifests']
         manifest_list_arches = set(
             manifest['platform']['architecture'] for manifest in all_manifests)
-
-        platform_to_arch = DefaultKeyDict(
-            (descriptor['platform'], descriptor['architecture'])
-            for descriptor in platform_descriptors)
 
         expected_arches = set(
             platform_to_arch[platform] for platform in expected_platforms)

--- a/atomic_reactor/plugins/pre_reactor_config.py
+++ b/atomic_reactor/plugins/pre_reactor_config.py
@@ -8,7 +8,8 @@ of the BSD license. See the LICENSE file for details.
 
 from copy import deepcopy
 from atomic_reactor.plugin import PreBuildPlugin
-from atomic_reactor.util import read_yaml, read_yaml_from_file_path, get_build_json
+from atomic_reactor.util import (read_yaml, read_yaml_from_file_path,
+                                 get_build_json, DefaultKeyDict)
 from osbs.utils import RegistryURI
 
 import os
@@ -304,6 +305,17 @@ def get_clusters(workflow, fallback=NO_FALLBACK):
 def get_clusters_client_config_path(workflow, fallback=NO_FALLBACK):
     client_config_dir = get_value(workflow, 'clusters_client_config_dir', fallback)
     return os.path.join(client_config_dir, 'osbs.conf')
+
+
+def get_platform_to_goarch_mapping(workflow,
+                                   descriptors_fallback=NO_FALLBACK):
+    platform_descriptors = get_platform_descriptors(
+        workflow,
+        fallback=descriptors_fallback,
+    )
+    return DefaultKeyDict(
+        (descriptor['platform'], descriptor['architecture'])
+        for descriptor in platform_descriptors)
 
 
 class ClusterConfig(object):


### PR DESCRIPTION
This is needed because otherwise the resulting tag will not be able to be pulled by clients without support for the 'manifest list' type.

In fact, the pulp_pull plugin will sit waiting forever for an amd64 image manifest to show up.

Signed-off-by: Tim Waugh <twaugh@redhat.com>

**Note**: this adds an additional parameter to the plugin, `goarch`, but I need advice on how to get that value filled in.