### PR TITLE
Add support for registry cert authentication.

### DIFF
--- a/atomic_reactor/plugins/post_pulp_sync.py
+++ b/atomic_reactor/plugins/post_pulp_sync.py
@@ -182,7 +182,7 @@ class PulpSyncPlugin(PostBuildPlugin):
         if not self.registry_secret_path:
             return {}
 
-        dockercfg = Dockercfg(self.registry_secret_path)
+        dockercfg = Dockercfg(self.registry_secret_path, dockercfg_required=True)
 
         if dockercfg.json_secret_path is None:
             return {}

--- a/atomic_reactor/plugins/post_pulp_sync.py
+++ b/atomic_reactor/plugins/post_pulp_sync.py
@@ -183,6 +183,10 @@ class PulpSyncPlugin(PostBuildPlugin):
             return {}
 
         dockercfg = Dockercfg(self.registry_secret_path)
+
+        if dockercfg.json_secret_path is None:
+            return {}
+
         registry_creds = dockercfg.get_credentials(docker_registry)
         if 'username' not in registry_creds:
             return {}

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -611,7 +611,7 @@ def registry_hostname(registry):
 
 
 class Dockercfg(object):
-    def __init__(self, secret_path):
+    def __init__(self, secret_path, dockercfg_required=False):
         """
         Create a new Dockercfg object from a .dockercfg file whose
         containing directory is secret_path.
@@ -620,6 +620,11 @@ class Dockercfg(object):
         """
         self.json_secret_path = os.path.join(secret_path, '.dockercfg')
         if not os.path.exists(self.json_secret_path):
+            if dockercfg_required:
+                msg = "dockercfg secret file does not exists"
+                logger.error(msg, exc_info=True)
+                raise RuntimeError(msg)
+
             self.json_secret_path = None
             self.json_secret = {}
         else:

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -617,13 +617,13 @@ class Dockercfg(object):
         containing directory is secret_path.
 
         :param secret_path: str, dirname of .dockercfg location
+        :param dockercfg_required: boolean, when True raise a RuntimeError
+                                   execption if .dockercfg file is missing.
         """
         self.json_secret_path = os.path.join(secret_path, '.dockercfg')
         if not os.path.exists(self.json_secret_path):
             if dockercfg_required:
-                msg = "dockercfg secret file does not exists"
-                logger.error(msg, exc_info=True)
-                raise RuntimeError(msg)
+                raise RuntimeError("dockercfg secret file does not exists")
 
             self.json_secret_path = None
             self.json_secret = {}
@@ -674,13 +674,11 @@ class RegistrySession(object):
             else:
                 # Use the registry certificates to authenticate instead of
                 # instead of username/password.
-                self.cert_path = os.path.join(dockercfg_path, 'registry.cert')
-                self.key_path = os.path.join(dockercfg_path, 'registry.key')
+                self.cert_path = os.path.join(dockercfg_path, 'client.cert')
+                self.key_path = os.path.join(dockercfg_path, 'client.key')
 
                 if not os.path.exists(self.cert_path) or not os.path.exists(self.key_path):
-                    msg = "failed to read registry certs secret"
-                    logger.error(msg, exc_info=True)
-                    raise RuntimeError(msg)
+                    raise RuntimeError("failed to read registry certs secret")
 
         self._fallback = None
         if re.match('http(s)?://', self.registry):


### PR DESCRIPTION
Open this for early review, before I start working on some tests

----

This commit allows to use the registry certificates to
authenticate. It makes use of the registry secret to either
store a .dockercfg file with username/password or
a registry.crt and registry.key files that will be used
by the requests session.

Signed-off-by: Clement Verna <cverna@tutanota.com>