### PR TITLE
inner.py: ensure fswatcher updates data once

### DIFF
--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -269,9 +269,11 @@ class FSWatcher(threading.Thread):
 
     def run(self):
         """ Overrides parent method to implement thread's functionality. """
-        while not self._done:
+        while True:  # make sure to run at least once before exiting
             with self._lock:
                 self._update(self._data)
+            if self._done:
+                break
             time.sleep(1)
 
     def get_usage_data(self):


### PR DESCRIPTION
Fix race condition in testing that looked like:
```
_______________________________ test_fs_watcher ________________________________
monkeypatch = <_pytest.monkeypatch.MonkeyPatch instance at 0x7f40f4c75fc8>
    def test_fs_watcher(monkeypatch):
        w = FSWatcher()
        monkeypatch.setattr(time, "sleep", lambda x: x)  # don't waste a second of test time
        w.start()
        w.finish()
        w.join(0.1)  # timeout if thread still running
        assert not w.is_alive()
>       assert "mb_used" in w.get_usage_data()
E       AssertionError: assert 'mb_used' in {}
E        +  where {} = <bound method FSWatcher.get_usage_data of <FSWatcher(Thread-44, stopped daemon 139916973418240)>>()
E        +    where <bound method FSWatcher.get_usage_data of <FSWatcher(Thread-44, stopped daemon 139916973418240)>> = <FSWatcher(Thread-44, stopped daemon 139916973418240)>.get_usage_data
tests/test_inner.py:1383: AssertionError
```