### PR TITLE
Use catchlog instead of capturelog

### DIFF
--- a/tests/plugins/test_add_dockerfile.py
+++ b/tests/plugins/test_add_dockerfile.py
@@ -183,7 +183,7 @@ CMD blabla"""
         }]
     )
     runner.run()
-    assert "plugin 'add_dockerfile' raised an exception: ValueError" in caplog.text()
+    assert "plugin 'add_dockerfile' raised an exception: ValueError" in caplog.text
 
 
 def test_adddockerfile_final(tmpdir, docker_tasker):  # noqa

--- a/tests/plugins/test_add_filesystem.py
+++ b/tests/plugins/test_add_filesystem.py
@@ -426,7 +426,7 @@ def test_image_task_failure(tmpdir, build_cancel, error_during_cancel, raise_err
         }]
     )
 
-    with caplog.atLevel(logging.INFO), pytest.raises(PluginFailedException) as exc:
+    with caplog.at_level(logging.INFO), pytest.raises(PluginFailedException) as exc:
         runner.run()
 
     assert task_result in str(exc)
@@ -435,16 +435,16 @@ def test_image_task_failure(tmpdir, build_cancel, error_during_cancel, raise_err
 
     if build_cancel:
         msg = "Build was canceled, canceling task %s" % FILESYSTEM_TASK_ID
-        assert msg in [x.message for x in caplog.records()]
+        assert msg in [x.message for x in caplog.records]
 
         if error_during_cancel:
             # We're checking last but one message, as the last one is
             # 'plugin 'add_filesystem' raised an exception'
             assert "Exception while canceling a task (ignored): Exception("\
-                in caplog.records()[-2].message
+                in caplog.records[-3].message
         else:
             msg = "task %s canceled" % FILESYSTEM_TASK_ID
-            assert msg in [x.message for x in caplog.records()]
+            assert msg in [x.message for x in caplog.records]
 
 
 # with a task_id is the new standard, None is legacy-mode support

--- a/tests/plugins/test_add_labels.py
+++ b/tests/plugins/test_add_labels.py
@@ -225,7 +225,7 @@ def test_add_labels_plugin(tmpdir, docker_tasker,
         with pytest.raises(PluginFailedException):
             runner.run()
         assert "plugin 'add_labels_in_dockerfile' raised an exception: RuntimeError" \
-            in caplog.text()
+            in caplog.text
 
     else:
         runner.run()
@@ -446,7 +446,7 @@ def test_add_labels_aliases(tmpdir, docker_tasker, caplog,
     assert result_new == exp_new
 
     if exp_log:
-        assert exp_log in caplog.text()
+        assert exp_log in caplog.text
 
 
 @pytest.mark.parametrize('base_l, df_l, expected, expected_log', [  # noqa
@@ -530,7 +530,7 @@ def test_add_labels_equal_aliases(tmpdir, docker_tasker, caplog,
     assert result_snd == expected[1]
 
     if expected_log:
-        assert expected_log in caplog.text()
+        assert expected_log in caplog.text
 
 
 @pytest.mark.parametrize('base_l, df_l, expected, expected_log', [  # noqa
@@ -620,7 +620,7 @@ def test_add_labels_equal_aliases2(tmpdir, docker_tasker, caplog, base_l,
         assert result_trd == expected[2]
 
         if expected_log:
-            assert expected_log in caplog.text()
+            assert expected_log in caplog.text
 
 
 @pytest.mark.parametrize("parent_scope, docker_scope, result_scope, dont_overwrite", [  # noqa
@@ -831,12 +831,12 @@ def test_add_labels_base_image(tmpdir, docker_tasker, parent, should_fail,
     )
 
     if should_fail:
-        with caplog.atLevel(logging.ERROR):
+        with caplog.at_level(logging.ERROR):
             with pytest.raises(PluginFailedException):
                 runner.run()
 
         msg = "base image was not inspected"
-        assert msg in [x.message for x in caplog.records()]
+        assert msg in [x.message for x in caplog.records]
     else:
         runner.run()
         assert df.labels['release'] == '5'
@@ -914,4 +914,4 @@ def test_release_label(tmpdir, docker_tasker, caplog,
     assert result_new == expected_in_df
 
     if expected_log:
-        assert expected_log in caplog.text()
+        assert expected_log in caplog.text

--- a/tests/plugins/test_assert_labels.py
+++ b/tests/plugins/test_assert_labels.py
@@ -97,4 +97,4 @@ def test_all_missing_required_labels(tmpdir, docker_tasker, caplog, df_content, 
         runner.run()
 
     error_msg = "Dockerfile is missing required labels: {0}".format(req_labels)
-    assert error_msg in caplog.text()
+    assert error_msg in caplog.text

--- a/tests/plugins/test_bump_release.py
+++ b/tests/plugins/test_bump_release.py
@@ -114,7 +114,7 @@ class TestBumpRelease(object):
         plugin = self.prepare(tmpdir, labels={release_label: '1'},
                               reactor_config_map=reactor_config_map)
         plugin.run()
-        assert 'not incrementing' in caplog.text()
+        assert 'not incrementing' in caplog.text
 
     @pytest.mark.parametrize('labels', [
         {'com.redhat.component': 'component'},

--- a/tests/plugins/test_compress.py
+++ b/tests/plugins/test_compress.py
@@ -76,4 +76,4 @@ class TestCompress(object):
         assert metadata['type'] == IMAGE_TYPE_DOCKER_ARCHIVE
         assert 'uncompressed_size' in metadata
         assert isinstance(metadata['uncompressed_size'], integer_types)
-        assert ", ratio: " in caplog.text()
+        assert ", ratio: " in caplog.text

--- a/tests/plugins/test_distribution_scope.py
+++ b/tests/plugins/test_distribution_scope.py
@@ -55,46 +55,48 @@ class TestDistributionScope(object):
                                          {'distribution-scope': parent_scope},
                                          current_scope)
         if allowed:
-            with caplog.atLevel(logging.ERROR):
+            with caplog.at_level(logging.ERROR):
                 plugin.run()
 
             # No errors logged
-            assert not caplog.records()
+            # FIXME: at_level() doesn't seem to work correctly
+            assert all(x.levelno < logging.ERROR for x in caplog.records)
         else:
             with pytest.raises(DisallowedDistributionScope):
                 plugin.run()
 
             # Should log something at ERROR
-            assert caplog.records()
+            assert caplog.records
 
     @pytest.mark.parametrize('current_scope', [None, 'private'])
     def test_imported_parent_distribution_scope(self, tmpdir, caplog, current_scope):
         plugin = self.instantiate_plugin(tmpdir, None, current_scope)
-        with caplog.atLevel(logging.ERROR):
+        with caplog.at_level(logging.ERROR):
             plugin.run()
 
         # No errors logged
-        assert not caplog.records()
+        # FIXME: at_level() doesn't seem to work correctly
+        assert all(x.levelno < logging.ERROR for x in caplog.records)
 
     @pytest.mark.parametrize('current_scope', [None, 'private'])
     def test_invalid_parent_distribution_scope(self, tmpdir, caplog, current_scope):
         plugin = self.instantiate_plugin(tmpdir,
                                          {'distribution-scope': 'invalid-choice'},
                                          current_scope)
-        with caplog.atLevel(logging.WARNING):
+        with caplog.at_level(logging.WARNING):
             plugin.run()
 
             if current_scope:
                 # Warning logged (if we get as far as checking parent scope)
-                assert 'invalid label' in caplog.text()
+                assert 'invalid label' in caplog.text
 
     @pytest.mark.parametrize('parent_scope', [None, 'private'])
     def test_invalid_current_distribution_scope(self, tmpdir, caplog, parent_scope):
         plugin = self.instantiate_plugin(tmpdir,
                                          {'distribution-scope': parent_scope},
                                          'invalid-choice')
-        with caplog.atLevel(logging.WARNING):
+        with caplog.at_level(logging.WARNING):
             plugin.run()
 
             # Warning logged
-            assert 'invalid label' in caplog.text()
+            assert 'invalid label' in caplog.text

--- a/tests/plugins/test_koji_import.py
+++ b/tests/plugins/test_koji_import.py
@@ -732,14 +732,14 @@ class TestKojiImport(object):
         assert isinstance(extra, dict)
 
         if expect_success:
-            assert "Koji Task ID {}".format(koji_task_id) in caplog.text()
+            assert "Koji Task ID {}".format(koji_task_id) in caplog.text
 
             assert 'container_koji_task_id' in extra
             extra_koji_task_id = extra['container_koji_task_id']
             assert isinstance(extra_koji_task_id, int)
             assert extra_koji_task_id == koji_task_id
         else:
-            assert "invalid task ID" in caplog.text()
+            assert "invalid task ID" in caplog.text
             assert 'container_koji_task_id' not in extra
 
     @pytest.mark.parametrize('params', [
@@ -1051,7 +1051,7 @@ class TestKojiImport(object):
         with pytest.raises(PluginFailedException):
             runner.run()
 
-        assert 'metadata:' in caplog.text()
+        assert 'metadata:' in caplog.text
 
     @pytest.mark.parametrize(('parent_id', 'expect_success', 'expect_error'), [
         (1234, True, False),
@@ -1087,7 +1087,7 @@ class TestKojiImport(object):
         assert isinstance(extra, dict)
 
         if expect_error:
-            assert 'invalid koji parent id' in caplog.text()
+            assert 'invalid koji parent id' in caplog.text
         if expect_success:
             image = extra['image']
             assert isinstance(image, dict)
@@ -1132,7 +1132,7 @@ class TestKojiImport(object):
             assert isinstance(filesystem_koji_task_id, int)
             assert filesystem_koji_task_id == task_id
         else:
-            assert 'invalid task ID' in caplog.text()
+            assert 'invalid task ID' in caplog.text
             assert 'filesystem_koji_task_id' not in extra
 
     def test_koji_import_filesystem_koji_task_id_missing(self, tmpdir, os_env, caplog,  # noqa
@@ -1157,7 +1157,7 @@ class TestKojiImport(object):
         extra = build['extra']
         assert isinstance(extra, dict)
         assert 'filesystem_koji_task_id' not in extra
-        assert AddFilesystemPlugin.key in caplog.text()
+        assert AddFilesystemPlugin.key in caplog.text
 
     @pytest.mark.parametrize('blocksize', (None, 1048576))
     @pytest.mark.parametrize(('apis',

--- a/tests/plugins/test_koji_promote.py
+++ b/tests/plugins/test_koji_promote.py
@@ -553,14 +553,14 @@ class TestKojiPromote(object):
         assert isinstance(extra, dict)
 
         if expect_success:
-            assert "Koji Task ID {}".format(koji_task_id) in caplog.text()
+            assert "Koji Task ID {}".format(koji_task_id) in caplog.text
 
             assert 'container_koji_task_id' in extra
             extra_koji_task_id = extra['container_koji_task_id']
             assert isinstance(extra_koji_task_id, int)
             assert extra_koji_task_id == koji_task_id
         else:
-            assert "invalid task ID" in caplog.text()
+            assert "invalid task ID" in caplog.text
             assert 'container_koji_task_id' not in extra
 
     @pytest.mark.parametrize('params', [
@@ -929,7 +929,7 @@ class TestKojiPromote(object):
         with pytest.raises(PluginFailedException):
             runner.run()
 
-        assert 'metadata:' in caplog.text()
+        assert 'metadata:' in caplog.text
 
     @pytest.mark.parametrize('task_states', [
         ['FREE', 'ASSIGNED', 'FAILED'],
@@ -986,7 +986,7 @@ class TestKojiPromote(object):
             assert isinstance(filesystem_koji_task_id, int)
             assert filesystem_koji_task_id == task_id
         else:
-            assert 'invalid task ID' in caplog.text()
+            assert 'invalid task ID' in caplog.text
             assert 'filesystem_koji_task_id' not in extra
 
     def test_koji_promote_filesystem_koji_task_id_missing(self, tmpdir, os_env,
@@ -1011,7 +1011,7 @@ class TestKojiPromote(object):
         extra = build['extra']
         assert isinstance(extra, dict)
         assert 'filesystem_koji_task_id' not in extra
-        assert AddFilesystemPlugin.key in caplog.text()
+        assert AddFilesystemPlugin.key in caplog.text
 
     @pytest.mark.parametrize('additional_tags', [
         None,

--- a/tests/plugins/test_koji_upload.py
+++ b/tests/plugins/test_koji_upload.py
@@ -856,7 +856,7 @@ class TestKojiUpload(object):
         with pytest.raises(PluginFailedException):
             runner.run()
 
-        assert 'metadata:' in caplog.text()
+        assert 'metadata:' in caplog.text
 
     @pytest.mark.parametrize('additional_tags', [
         None,

--- a/tests/plugins/test_orchestrate_build.py
+++ b/tests/plugins/test_orchestrate_build.py
@@ -437,7 +437,7 @@ def test_orchestrate_build(tmpdir, caplog, config_kwargs,
     build_info = get_worker_build_info(workflow, 'x86_64')
     assert build_info.osbs
 
-    for record in caplog.records():
+    for record in caplog.records:
         if not record.name.startswith("atomic_reactor"):
             continue
 
@@ -1342,8 +1342,8 @@ def test_orchestrate_override_content_versions(tmpdir, caplog, enable_v1, conten
     build_result = runner.run()
     if will_fail:
         assert build_result.is_failed()
-        assert 'failed to create worker build' in caplog.text()
-        assert 'content_versions is empty' in caplog.text()
+        assert 'failed to create worker build' in caplog.text
+        assert 'content_versions is empty' in caplog.text
     else:
         assert not build_result.is_failed()
 

--- a/tests/plugins/test_pull_base_image.py
+++ b/tests/plugins/test_pull_base_image.py
@@ -328,7 +328,7 @@ class TestValidateBaseImage(object):
                                     [], [], reactor_config_map=True,
                                     workflow_callback=self.prepare,
                                     check_platforms=True)
-        assert log_message in caplog.text()
+        assert log_message in caplog.text
 
     def test_manifest_list_fallback_to_orchestrate_build_args(self, caplog):
 
@@ -342,7 +342,7 @@ class TestValidateBaseImage(object):
                                     [], [], reactor_config_map=True,
                                     workflow_callback=workflow_callback,
                                     check_platforms=True)
-        assert log_message in caplog.text()
+        assert log_message in caplog.text
 
     def test_expected_platforms_unknown(self, caplog):
 
@@ -357,7 +357,7 @@ class TestValidateBaseImage(object):
                                     [], [], reactor_config_map=True,
                                     workflow_callback=workflow_callback,
                                     check_platforms=True)
-        assert log_message in caplog.text()
+        assert log_message in caplog.text
 
     def test_single_platform_build(self, caplog):
 
@@ -371,7 +371,7 @@ class TestValidateBaseImage(object):
                                     [], [], reactor_config_map=True,
                                     workflow_callback=workflow_callback,
                                     check_platforms=True)
-        assert log_message in caplog.text()
+        assert log_message in caplog.text
 
     def test_registry_undefined(self, caplog):
         def workflow_callback(workflow):
@@ -385,7 +385,7 @@ class TestValidateBaseImage(object):
                                     [], [], reactor_config_map=True,
                                     workflow_callback=workflow_callback,
                                     check_platforms=True)
-        assert log_message in caplog.text()
+        assert log_message in caplog.text
 
     def test_platform_descriptors_undefined(self, caplog):
         def workflow_callback(workflow):
@@ -399,7 +399,7 @@ class TestValidateBaseImage(object):
                                     [], [], reactor_config_map=True,
                                     workflow_callback=workflow_callback,
                                     check_platforms=True)
-        assert log_message in caplog.text()
+        assert log_message in caplog.text
 
     def test_manifest_list_with_no_response(self, caplog):
         def workflow_callback(workflow):

--- a/tests/plugins/test_pulp.py
+++ b/tests/plugins/test_pulp.py
@@ -334,6 +334,6 @@ def test_pulp_publish_only_without_sync(before_name, after_name, publish,
     plugin.run()
 
     if should_publish:
-        assert 'to be published' in caplog.text()
+        assert 'to be published' in caplog.text
     else:
-        assert 'publishing deferred' in caplog.text()
+        assert 'publishing deferred' in caplog.text

--- a/tests/plugins/test_pulp_publish.py
+++ b/tests/plugins/test_pulp_publish.py
@@ -168,7 +168,7 @@ def test_pulp_publish_success(caplog, reactor_config_map):
 
     crane_images = plugin.run()
 
-    assert 'to be published' in caplog.text()
+    assert 'to be published' in caplog.text
     images = [i.to_str() for i in crane_images]
     assert "registry.example.com/image-name1:latest" in images
     assert "registry.example.com/image-name1:2" in images
@@ -208,6 +208,6 @@ def test_pulp_publish_delete(worker_builds_created, v1_image_ids,
 
     assert crane_images == []
     if expected and worker_builds_created:
-        assert msg in caplog.text()
+        assert msg in caplog.text
     else:
-        assert msg not in caplog.text()
+        assert msg not in caplog.text

--- a/tests/plugins/test_pulp_sync.py
+++ b/tests/plugins/test_pulp_sync.py
@@ -526,7 +526,7 @@ class TestPostPulpSync(object):
                                 dockpulp_loglevel=loglevel)
         plugin.run()
 
-        errors = [record.getMessage() for record in caplog.records()
+        errors = [record.getMessage() for record in caplog.records
                   if record.levelname == 'ERROR']
 
         if fail:
@@ -624,7 +624,7 @@ class TestPostPulpSync(object):
                                 delete_from_registry=True)
         plugin.run()
 
-        errors = [record.getMessage() for record in caplog.records()
+        errors = [record.getMessage() for record in caplog.records
                   if record.levelname == 'ERROR']
 
         assert [message for message in errors
@@ -762,7 +762,7 @@ class TestPostPulpSync(object):
                                 workflow=workflow,
                                 **kwargs)
         plugin.run()
-        log_messages = [l.getMessage() for l in caplog.records()]
+        log_messages = [l.getMessage() for l in caplog.records]
 
         for image in workflow.tag_conf.images:
             expected_log = 'image available at %s' % image.to_str()

--- a/tests/plugins/test_pulp_tag.py
+++ b/tests/plugins/test_pulp_tag.py
@@ -198,9 +198,9 @@ def test_pulp_tag_basic(tmpdir, monkeypatch, v1_image_ids, should_raise, caplog,
 
     results = runner.run()
     if msg:
-        assert msg in caplog.text()
+        assert msg in caplog.text
     else:
-        assert "tagging v1-image-id" not in caplog.text()
+        assert "tagging v1-image-id" not in caplog.text
     assert results['pulp_tag'] == expected_results
 
 
@@ -234,7 +234,7 @@ def test_pulp_tag_source_secret(tmpdir, monkeypatch, caplog, reactor_config_map)
                                                   'auth': {'ssl_certs_dir': str(tmpdir)}}})
 
     results = runner.run()
-    assert msg in caplog.text()
+    assert msg in caplog.text
     assert results['pulp_tag'] == expected_results
 
 
@@ -270,5 +270,5 @@ def test_pulp_tag_service_account_secret(tmpdir, monkeypatch, caplog, reactor_co
                                     'auth': {'ssl_certs_dir': str(tmpdir)}}})
 
     results = runner.run()
-    assert msg in caplog.text()
+    assert msg in caplog.text
     assert results['pulp_tag'] == expected_results

--- a/tests/plugins/test_reactor_config.py
+++ b/tests/plugins/test_reactor_config.py
@@ -182,10 +182,10 @@ class TestReactorConfigPlugin(object):
 
         tasker, workflow = self.prepare()
         plugin = ReactorConfigPlugin(tasker, workflow, config_path=str(tmpdir))
-        with caplog.atLevel(logging.ERROR), pytest.raises(Exception):
+        with caplog.at_level(logging.ERROR), pytest.raises(Exception):
             plugin.run()
 
-        captured_errs = [x.message for x in caplog.records()]
+        captured_errs = [x.message for x in caplog.records]
         assert "unable to extract JSON schema, cannot validate" in captured_errs
 
     @pytest.mark.parametrize('schema', [
@@ -212,10 +212,10 @@ class TestReactorConfigPlugin(object):
 
         tasker, workflow = self.prepare()
         plugin = ReactorConfigPlugin(tasker, workflow, config_path=str(tmpdir))
-        with caplog.atLevel(logging.ERROR), pytest.raises(Exception):
+        with caplog.at_level(logging.ERROR), pytest.raises(Exception):
             plugin.run()
 
-        captured_errs = [x.message for x in caplog.records()]
+        captured_errs = [x.message for x in caplog.records]
         assert any("cannot validate" in x for x in captured_errs)
 
     @pytest.mark.parametrize(('config', 'errors'), [  # noqa:F811
@@ -315,11 +315,11 @@ class TestReactorConfigPlugin(object):
         tasker, workflow = self.prepare()
         plugin = ReactorConfigPlugin(tasker, workflow, config_path=str(tmpdir))
 
-        with caplog.atLevel(logging.ERROR), pytest.raises(ValidationError):
+        with caplog.at_level(logging.ERROR), pytest.raises(ValidationError):
             plugin.run()
 
         os.environ.pop('REACTOR_CONFIG', None)
-        captured_errs = [x.message for x in caplog.records()]
+        captured_errs = [x.message for x in caplog.records]
         for error in errors:
             try:
                 # Match regexp

--- a/tests/plugins/test_remove_worker_metadata.py
+++ b/tests/plugins/test_remove_worker_metadata.py
@@ -126,6 +126,6 @@ def test_remove_worker_plugin(tmpdir, caplog, names, fragment_key):
 
     for name in names:
         if name:
-            assert "ConfigMap {} deleted".format(name) in caplog.text()
+            assert "ConfigMap {} deleted".format(name) in caplog.text
         else:
-            assert "Failed to delete ConfigMap None" in caplog.text()
+            assert "Failed to delete ConfigMap None" in caplog.text

--- a/tests/plugins/test_resolve_composes.py
+++ b/tests/plugins/test_resolve_composes.py
@@ -773,22 +773,22 @@ class TestResolveComposes(object):
     def test_abort_when_odcs_config_missing(self, tmpdir, caplog, workflow, reactor_config_map):  # noqa:F811
         # Clear out default reactor config
         mock_reactor_config(workflow, tmpdir, data='')
-        with caplog.atLevel(logging.INFO):
+        with caplog.at_level(logging.INFO):
             self.run_plugin_with_args(workflow, reactor_config_map=reactor_config_map)
 
         msg = 'Aborting plugin execution: ODCS config not found'
-        assert msg in (x.message for x in caplog.records())
+        assert msg in (x.message for x in caplog.records)
 
     def test_abort_when_compose_config_missing(self, caplog, workflow, reactor_config_map):  # noqa:F811
         # Clear out default git repo config
         mock_repo_config(workflow._tmpdir, '')
         # Ensure no compose_ids are passed to plugin
         plugin_args = {'compose_ids': tuple()}
-        with caplog.atLevel(logging.INFO):
+        with caplog.at_level(logging.INFO):
             self.run_plugin_with_args(workflow, plugin_args, reactor_config_map=reactor_config_map)
 
         msg = 'Aborting plugin execution: "compose" config not set and compose_ids not given'
-        assert msg in (x.message for x in caplog.records())
+        assert msg in (x.message for x in caplog.records)
 
     def test_invalid_koji_build_target(self, workflow, reactor_config_map):  # noqa:F811
         plugin_args = {
@@ -809,11 +809,11 @@ class TestResolveComposes(object):
     def test_parameters_ignored_for_autorebuild(self, caplog, workflow, plugin_args, msg,
                                                 reactor_config_map):
         flexmock(pre_check_and_set_rebuild).should_receive('is_rebuild').and_return(True)
-        with caplog.atLevel(logging.INFO):
+        with caplog.at_level(logging.INFO):
             self.run_plugin_with_args(workflow, plugin_args,
                                       reactor_config_map=reactor_config_map)
 
-        assert msg in (x.message for x in caplog.records())
+        assert msg in (x.message for x in caplog.records)
 
     def run_plugin_with_args(self, workflow, plugin_args=None,  # noqa:F811
                              expect_error=None, reactor_config_map=False,

--- a/tests/plugins/test_stop_autorebuild_if_disabled.py
+++ b/tests/plugins/test_stop_autorebuild_if_disabled.py
@@ -63,7 +63,7 @@ class TestStopAutorebuildIfDisabledPlugin(object):
     }]
 
     def assert_message_logged(self, msg, cplog):
-        assert any([msg in l.getMessage() for l in cplog.records()])
+        assert any([msg in l.message for l in cplog.records])
 
     def setup_method(self, method):
         if MOCK:

--- a/tests/plugins/test_store_metadata.py
+++ b/tests/plugins/test_store_metadata.py
@@ -592,7 +592,7 @@ CMD blabla"""
         .and_raise(OsbsResponseException('/', 'failed', 0)))
     with pytest.raises(PluginFailedException):
         runner.run()
-    assert 'annotations:' in caplog.text()
+    assert 'annotations:' in caplog.text
 
 
 @pytest.mark.parametrize('koji_plugin', (PLUGIN_KOJI_IMPORT_PLUGIN_KEY,
@@ -619,7 +619,7 @@ def test_store_metadata_fail_update_labels(tmpdir, caplog, koji_plugin, reactor_
         .and_raise(OsbsResponseException('/', 'failed', 0)))
     with pytest.raises(PluginFailedException):
         runner.run()
-    assert 'labels:' in caplog.text()
+    assert 'labels:' in caplog.text
 
 
 @pytest.mark.parametrize(('pulp_registries', 'docker_registries', 'prefixes'), [

--- a/tests/plugins/test_tag_and_push.py
+++ b/tests/plugins/test_tag_and_push.py
@@ -507,14 +507,14 @@ def test_tag_and_push_plugin_oci(
         }]
     )
 
-    with caplog.atLevel(logging.DEBUG):
+    with caplog.at_level(logging.DEBUG):
         if fail_push:
             with pytest.raises(PluginFailedException):
                 output = runner.run()
         else:
             output = runner.run()
 
-    for r in caplog.records():
+    for r in caplog.records:
         assert 'mypassword' not in r.getMessage()
 
     if not fail_push:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,5 +2,5 @@ flexmock
 ordereddict
 responses
 pytest==3.2.5
-pytest-capturelog==0.7
+pytest-catchlog
 pytest-cov==2.5.1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -192,12 +192,12 @@ class TestCLISuite(object):
             "--verbose",
             "inside-build",
         ]
-        with caplog.atLevel(logging.INFO):
+        with caplog.at_level(logging.INFO):
             with pytest.raises(RuntimeError):
                 self.exec_cli(command)
 
         # first message should be 'log encoding: <encoding>'
-        match = caplog.records()[0].message.split(':')
+        match = caplog.records[0].message.split(':')
         if not match:
             raise RuntimeError
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -189,7 +189,7 @@ def test_buildstep_phase_build_plugin(caplog, tmpdir, docker_tasker, success1, s
     else:
         runner.run()
         expected_log_message = "stopping further execution of plugins after first successful plugin"
-        assert expected_log_message in [l.getMessage() for l in caplog.records()]
+        assert expected_log_message in [l.getMessage() for l in caplog.records]
 
 
 @pytest.mark.parametrize('success1', [True, False])  # noqa
@@ -222,7 +222,7 @@ def test_buildstep_phase_build_plugin_failing_exception(tmpdir, caplog, docker_t
     else:
         runner.run()
         expected_log_message = "stopping further execution of plugins after first successful plugin"
-        assert expected_log_message in [l.getMessage() for l in caplog.records()]
+        assert expected_log_message in [l.getMessage() for l in caplog.records]
 
 
 def test_non_buildstep_phase_raises_InappropriateBuildStepError(caplog, tmpdir, docker_tasker):  # noqa

--- a/tests/test_pulp_util.py
+++ b/tests/test_pulp_util.py
@@ -294,10 +294,11 @@ def test_upload(unsupported, caplog):
          .and_return(False)
          .once())
 
-    handler.upload(upload_file, repo_id)
+    with caplog.at_level(logging.DEBUG):
+        handler.upload(upload_file, repo_id)
 
-    assert "Uploading %s to %s" % (upload_file, repo_id) in caplog.text()
+    assert "Uploading %s to %s" % (upload_file, repo_id) in caplog.text
 
     if unsupported:
         assert "Falling back to uploading %s to redhat-everything repo" %\
-               upload_file in caplog.text()
+               upload_file in caplog.text

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -865,7 +865,7 @@ def test_df_parser_parent_env_wf(tmpdir, caplog, env_arg):
 
     if isinstance(env_arg, list) and ('=' not in env_arg[0]):
         expected_log_message = "Unable to parse all of Parent Config ENV"
-        assert expected_log_message in [l.getMessage() for l in caplog.records()]
+        assert expected_log_message in [l.getMessage() for l in caplog.records]
     elif isinstance(env_arg, dict):
         assert df.labels.get('label') == ('foobar ' + env_arg['test_env'])
     else:
@@ -1206,7 +1206,7 @@ def test_get_platforms_in_limits(tmpdir, platforms, platform_exclude, platform_o
         workflow = MockWorkflow(str(tmpdir))
         final_platforms = get_platforms_in_limits(workflow, platforms)
         if platform_exclude and platform_exclude == platform_only:
-            assert 'only and not platforms are the same' in caplog.text()
+            assert 'only and not platforms are the same' in caplog.text
         assert final_platforms == set(result)
     elif valid:
         workflow = MockWorkflow(str(tmpdir))


### PR DESCRIPTION
In pytest-3.3, included in Fedora 28, the 'caplog' fixture is built-in, merged from the pytest-catchlog package. This has a different interface to pytest-capturelog:
http://blog.pytest.org/2017/whats-new-in-pytest-33/

Use this new interface, with pytest-catchlog installed to handle versions of pytest prior to the merge.

Signed-off-by: Tim Waugh <twaugh@redhat.com>