### PR TITLE
schema validation fixes

### DIFF
--- a/atomic_reactor/schemas/container.json
+++ b/atomic_reactor/schemas/container.json
@@ -28,6 +28,14 @@
     },
     "image_build_method": {
       "enum": ["docker_api", "imagebuilder"]
+    },
+    "tags": {
+      "type": "array"
+    },
+    "version": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 1
     }
   },
   "additionalProperties": false,

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -1102,12 +1102,10 @@ def read_yaml(yaml_data, schema):
         raise
     except jsonschema.ValidationError:
         for error in validator.iter_errors(data):
-            path = ''
-            for element in error.absolute_path:
-                if isinstance(element, int):
-                    path += '[{}]'.format(element)
-                else:
-                    path += '.{}'.format(element)
+            path = "".join(
+                ('[{}]' if isinstance(element, int) else '.{}').format(element)
+                for element in error.path
+            )
 
             if path.startswith('.'):
                 path = path[1:]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 docker-py
 docker-squash>=1.0.0rc3
 dockerfile-parse>=0.0.5
-jsonschema
+jsonschema==2.3.0  # to match available in RHEL/CentOS 7
 PyYAML
 six

--- a/tests/files/docker-hello-world/container.yaml
+++ b/tests/files/docker-hello-world/container.yaml
@@ -1,2 +1,6 @@
 ---
+version: 1
 image_build_method: imagebuilder
+tags:
+  - spam
+  - eggs

--- a/tests/plugins/test_reactor_config.py
+++ b/tests/plugins/test_reactor_config.py
@@ -267,7 +267,7 @@ class TestReactorConfigPlugin(object):
             "'one' is not of type %r" % u'integer',
 
             "validation error (clusters.foo[3].max_concurrent_builds): "
-            "-1 is less than the minimum of 0",
+            "-1.0 is less than the minimum of 0",
         ]),
 
         ("""\


### PR DESCRIPTION
Now that container.yaml is being validated everywhere we need the validation to be correct. Adding some properties in schema and fixing up the error handling when validation fails (OSBS-5173).