### PR TITLE
pull_base_image: fix retry pull w/ library namespace

### DIFF
--- a/atomic_reactor/plugins/pre_pull_base_image.py
+++ b/atomic_reactor/plugins/pre_pull_base_image.py
@@ -100,7 +100,7 @@ class PullBaseImagePlugin(PreBuildPlugin):
                                    insecure=self.parent_registry_insecure)
 
         except RetryGeneratorException as original_exc:
-            if base_image_with_registry.namespace == 'library':
+            if base_image_with_registry.namespace:
                 raise
 
             self.log.info("'%s' not found", base_image_with_registry.to_str())

--- a/tests/plugins/test_pull_base_image.py
+++ b/tests/plugins/test_pull_base_image.py
@@ -190,6 +190,16 @@ def test_pull_base_wrong_registry(reactor_config_map):  # noqa
                                     reactor_config_map=reactor_config_map)
 
 
+# test previous issue https://github.com/projectatomic/atomic-reactor/issues/1008
+def test_pull_base_library(reactor_config_map, caplog):  # noqa
+    with pytest.raises(PluginFailedException) as exc:
+        test_pull_base_image_plugin(
+            LOCALHOST_REGISTRY, "spam/library-only:latest", [], [], reactor_config_map
+        )
+    assert "not found" in str(exc.value)
+    assert "RetryGeneratorException" in str(exc.value)
+    assert "trying" not in caplog.text()  # don't retry with "library/library-only:latest"
+
 def test_pull_base_base_parse(reactor_config_map):  # noqa
     flexmock(ImageName).should_receive('parse').and_raise(AttributeError)
     with pytest.raises(AttributeError):


### PR DESCRIPTION
This retry should only occur for images that have no namespace already.

fix https://github.com/projectatomic/atomic-reactor/issues/1008