### PR TITLE
post_push_to_pulp: export image if not exported

### DIFF
--- a/atomic_reactor/plugins/post_push_to_pulp.py
+++ b/atomic_reactor/plugins/post_push_to_pulp.py
@@ -209,9 +209,7 @@ class PulpPushPlugin(PostBuildPlugin):
             self.log.info("extending image names: %s", self.image_names)
             image_names += [ImageName.parse(x) for x in self.image_names]
 
-        if self.load_exported_image:
-            if len(self.workflow.exported_image_sequence) == 0:
-                raise RuntimeError('no exported image to push to pulp')
+        if self.load_exported_image and len(self.workflow.exported_image_sequence) > 0:
             export_path = self.workflow.exported_image_sequence[-1].get("path")
             top_layer, crane_repos = self.push_tar(export_path, image_names)
         else:

--- a/tests/plugins/test_imagebuilder.py
+++ b/tests/plugins/test_imagebuilder.py
@@ -29,6 +29,9 @@ class MockDocker(object):
     def history(self, name):
         return []
 
+    def get_image(self, image_id):
+        return flexmock(data="image data")
+
 
 class MockDockerTasker(object):
     def __init__(self):
@@ -97,6 +100,7 @@ def test_popen_cmd(image_id):
     assert workflow.build_result.image_id.startswith('sha256:')
     assert workflow.build_result.image_id.count(':') == 1
     assert workflow.build_result.skip_layer_squash
+    assert len(workflow.exported_image_sequence) == 1
     assert cmd_output in workflow.build_result.logs
 
 

--- a/tests/plugins/test_pulp.py
+++ b/tests/plugins/test_pulp.py
@@ -150,7 +150,7 @@ def prepare(check_repo_retval=0, existing_layers=[],
     return tasker, workflow
 
 
-@pytest.mark.skipif(dockpulp is None,
+@pytest.mark.skipif(dockpulp is None,  # noqa: F811; redefinition of 'reactor_config_map'
                     reason='dockpulp module not available')
 @pytest.mark.parametrize(("unsupported"), [
     (True),
@@ -204,7 +204,7 @@ def test_pulp_dedup_layers(unsupported, unlink_exc, tmpdir, existing_layers, sho
     assert top_layer == 'foo'
 
 
-@pytest.mark.skipif(dockpulp is None,
+@pytest.mark.skipif(dockpulp is None,  # noqa: F811; redefinition of 'reactor_config_map'
                     reason='dockpulp module not available')
 @pytest.mark.parametrize(("check_repo_retval", "should_raise"), [
     (3, True),
@@ -248,7 +248,7 @@ def test_pulp_source_secret(tmpdir, check_repo_retval, should_raise, monkeypatch
     assert "registry.example.com/image-name3:asd" in images
 
 
-@pytest.mark.skipif(dockpulp is None,
+@pytest.mark.skipif(dockpulp is None,  # noqa: F811; redefinition of 'reactor_config_map'
                     reason='dockpulp module not available')
 def test_pulp_service_account_secret(tmpdir, monkeypatch, reactor_config_map):
     tasker, workflow = prepare()
@@ -280,7 +280,7 @@ def test_pulp_service_account_secret(tmpdir, monkeypatch, reactor_config_map):
     assert "registry.example.com/image-name3:asd" in images
 
 
-@pytest.mark.skipif(dockpulp is None,
+@pytest.mark.skipif(dockpulp is None,  # noqa: F811; redefinition of 'reactor_config_map'
                     reason='dockpulp module not available')
 @pytest.mark.parametrize(('before_name', 'after_name', 'publish', 'should_publish'), [
     ('foo', 'foo', True, True),
@@ -337,3 +337,24 @@ def test_pulp_publish_only_without_sync(before_name, after_name, publish,
         assert 'to be published' in caplog.text()
     else:
         assert 'publishing deferred' in caplog.text()
+
+
+@pytest.mark.skipif(dockpulp is None,
+                    reason='dockpulp module not available')
+def test_load_exported_image():
+    # low-level case to exercise the logic for using exported image
+    tasker, workflow = prepare()
+    workflow.exported_image_sequence = [dict(path='/some/dir')]
+    plugin = flexmock(PulpPushPlugin(
+        tasker, workflow,
+        publish=False,
+        load_exported_image=True,
+    ))
+    (
+        plugin
+        .should_receive('push_tar')
+        .with_args('/some/dir', workflow.tag_conf.images)
+        .and_return((None, None))
+        .once()
+    )
+    plugin.run()


### PR DESCRIPTION
With an imagebuilder build, the squash plugin is not invoked, thus the image is not exported from Docker. With the `pulp_push` plugin in sequence before `compress`, it finds no image to load and fails. So, this is an update, like the one made to `compress`, to export the image first in that case.

A more correct fix to work with more varied plugin sequences would be to have the imagebuilder plugin export the image itself. However I ran into problems trying to get this plugin to accept that exported image and thought this fix could stand on its own (it addressed the issue when tested in stage) until I figure that out.