### PR TITLE
Make 'unknown signing intent' message more helpful

### DIFF
--- a/atomic_reactor/plugins/pre_reactor_config.py
+++ b/atomic_reactor/plugins/pre_reactor_config.py
@@ -438,11 +438,16 @@ class ODCSConfig(object):
         self.get_signing_intent_by_name(self.default_signing_intent)
 
     def get_signing_intent_by_name(self, name):
+        valid = []
         for entry in self.signing_intents:
-            if entry['name'] == name:
+            this_name = entry['name']
+            if this_name == name:
                 return entry
 
-        raise ValueError('unknown signing intent name "{}"'.format(name))
+            valid.append(this_name)
+
+        raise ValueError('unknown signing intent name "{}", valid names: {}'
+                         .format(name, ', '.join(valid)))
 
     def get_signing_intent_by_keys(self, keys):
         if isinstance(keys, six.text_type):

--- a/tests/plugins/test_reactor_config.py
+++ b/tests/plugins/test_reactor_config.py
@@ -507,7 +507,10 @@ class TestReactorConfigPlugin(object):
 
         with pytest.raises(ValueError) as exc_info:
             get_config(workflow).get_odcs_config()
-        assert 'unknown signing intent' in str(exc_info.value)
+        message = str(exc_info.value)
+        assert message == dedent("""\
+            unknown signing intent name "spam", valid names: unsigned, beta, release
+            """.rstrip())
 
     @pytest.mark.parametrize('fallback', (True, False, None))
     @pytest.mark.parametrize('method', [


### PR DESCRIPTION
Include valid names in the error message.

Signed-off-by: Tim Waugh <twaugh@redhat.com>