### PR TITLE
enable multistage builds

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -93,6 +93,14 @@ PLUGIN_CHECK_AND_SET_PLATFORMS_KEY = 'check_and_set_platforms'
 PLUGIN_REMOVE_WORKER_METADATA_KEY = 'remove_worker_metadata'
 PLUGIN_RESOLVE_COMPOSES_KEY = 'resolve_composes'
 
+# some shared dict keys for build metadata that gets recorded with koji.
+# for consistency of metadata in historical builds, these values basically cannot change.
+# however constant names could change to more accurately reflect current semantics.
+BASE_IMAGE_KOJI_BUILD = 'parent-image-koji-build'  # from when the base image was the only parent
+PARENT_IMAGES_KOJI_BUILDS = 'parent-images-koji-builds'
+BASE_IMAGE_BUILD_ID_KEY = 'parent_build_id'  # from when the base image was the only parent
+PARENT_IMAGE_BUILDS_KEY = 'parent_image_builds'
+
 # max retries for docker requests
 DOCKER_MAX_RETRIES = 3
 # how many seconds should wait before another try of docker request

--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -372,6 +372,7 @@ class DockerBuildWorkflow(object):
         self._base_image_inspect = None
         self.default_image_build_method = CONTAINER_DEFAULT_BUILD_METHOD
 
+        # list of images pulled during the build, to be deleted after the build
         self.pulled_base_images = set()
 
         # When an image is exported into tarball, it can then be processed by various plugins.

--- a/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
+++ b/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
@@ -233,6 +233,7 @@ class StoreMetadataInOSv3Plugin(ExitPlugin):
             "base-image-name": base_image_name,
             "image-id": self.workflow.builder.image_id or '',
             "digests": json.dumps(self.get_pullspecs(self.get_digests())),
+            "parent_images": json.dumps(self.workflow.builder.parent_images),
             "plugins-metadata": json.dumps(self.get_plugin_metadata()),
             "filesystem": json.dumps(self.get_filesystem_metadata()),
         }

--- a/atomic_reactor/plugins/pre_change_from_in_df.py
+++ b/atomic_reactor/plugins/pre_change_from_in_df.py
@@ -6,46 +6,95 @@ This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 
 
-Pre build plugin which changes FROM instruction
+Pre-build plugin that changes the parent images used in FROM instructions
+to the more specific names given by the builder.
 """
-import fileinput
-import re
-import sys
 from atomic_reactor.plugin import PreBuildPlugin
-from atomic_reactor.util import ImageName
+from dockerfile_parse import DockerfileParser
+
+
+class BaseImageMismatch(RuntimeError):
+    pass
+
+
+class ParentImageUnresolved(RuntimeError):
+    pass
+
+
+class ParentImageMissing(RuntimeError):
+    pass
+
+
+class NoIdInspection(RuntimeError):
+    pass
 
 
 class ChangeFromPlugin(PreBuildPlugin):
     key = "change_from_in_dockerfile"
 
-    def __init__(self, tasker, workflow, base_image=None):
+    def __init__(self, tasker, workflow):
         """
         constructor
 
         :param tasker: DockerTasker instance
         :param workflow: DockerBuildWorkflow instance
-        :param base_image: str, change base image to ID of this image
         """
         # call parent constructor
         super(ChangeFromPlugin, self).__init__(tasker, workflow)
-        self.base_image = ImageName.parse(base_image) if base_image else None
 
     def run(self):
-        """
-        run the plugin
-        """
-        base_image = self.base_image or self.workflow.builder.base_image
-        try:
-            base_image_id = self.workflow.base_image_inspect['Id']
-        except KeyError:
-            self.log.error("Id is missing in inspection: '%s'", self.workflow.base_image_inspect)
-            raise
-        self.log.debug("using base image '%s', id '%s'", base_image, base_image_id)
-        for line in fileinput.input(self.workflow.builder.df_path, inplace=1):
-            re_match = re.match(r"^FROM .+$", line)
-            if re_match:
-                new_from = "FROM %s" % base_image_id
-                sys.stdout.write(new_from + '\n')
-                self.log.info("changed FROM: '%s' -> '%s'", re_match.group(0), new_from)
-            else:
-                sys.stdout.write(line)
+        builder = self.workflow.builder
+        dfp = DockerfileParser(builder.df_path)
+
+        df_base = dfp.baseimage
+        build_base = builder.base_image.to_str()
+
+        # do some sanity checks to defend against bugs and rogue plugins
+
+        if build_base != builder.parent_images[df_base]:
+            # something updated parent_images entry for base without updating
+            # the build's base_image; treat it as an error
+            raise BaseImageMismatch(
+                "Parent image '{}' does not match base_image '{}'"
+                .format(builder.parent_images[df_base], build_base)
+            )
+
+        unresolved = [key for key, val in builder.parent_images.items() if not val]
+        if unresolved:
+            # this would generally mean pull_base_image didn't run and/or
+            # custom plugins modified parent_images; treat it as an error.
+            raise ParentImageUnresolved("Parent image(s) unresolved: {}".format(unresolved))
+
+        missing = [df_img for df_img in dfp.parent_images if df_img not in builder.parent_images]
+        if missing:
+            # this would indicate another plugin modified parent_images out of sync
+            # with the Dockerfile or some other code bug
+            raise ParentImageMissing("Lost parent image(s) from Dockerfile: {}".format(missing))
+
+        # docker inspect all parent images so we can address them by Id
+        parent_image_ids = {}
+        for img, new_img in builder.parent_images.items():
+            inspection = builder.tasker.inspect_image(new_img)
+            try:
+                parent_image_ids[img] = inspection['Id']
+            except KeyError:  # unexpected code bugs or maybe docker weirdness
+                self.log.error(
+                    "Id for image %s is missing in inspection: '%s'",
+                    new_img, inspection)
+                raise NoIdInspection("Could not inspect Id for image " + new_img)
+
+        # update the parents in Dockerfile
+        new_parents = []
+        for parent in dfp.parent_images:
+            pid = parent_image_ids[parent]
+            self.log.info("changed FROM: '%s' -> '%s'", parent, pid)
+            new_parents.append(pid)
+        dfp.parent_images = new_parents
+
+        # update builder's representation of what will be built
+        builder.parent_images = parent_image_ids
+        builder.set_base_image(parent_image_ids[df_base])
+        self.log.debug(
+            "for base image '%s' using local image '%s', id '%s'",
+            df_base, build_base, builder.base_image
+        )

--- a/atomic_reactor/plugins/pre_inject_yum_repo.py
+++ b/atomic_reactor/plugins/pre_inject_yum_repo.py
@@ -29,13 +29,8 @@ def add_yum_repos_to_dockerfile(yumrepos, df, inherited_user):
     structure = df.structure
     for insndesc in structure:
         insn = insndesc['instruction']
-        if insn == 'MAINTAINER':
-            # MAINTAINER line: stop looking
-            preinsert = insndesc['endline'] + 1
-            break
-        elif insn == 'FROM':
-            # FROM line: can use this, but keep looking in case there
-            # is a MAINTAINER line
+        if insn == 'FROM':
+            # FROM line: can use this, but keep looking in case there is another
             preinsert = insndesc['endline'] + 1
 
     if preinsert is None:

--- a/atomic_reactor/plugins/pre_koji_parent.py
+++ b/atomic_reactor/plugins/pre_koji_parent.py
@@ -7,9 +7,10 @@ of the BSD license. See the LICENSE file for details.
 """
 from __future__ import print_function, unicode_literals
 
-from atomic_reactor.constants import INSPECT_CONFIG
 from atomic_reactor.plugin import PreBuildPlugin
-from atomic_reactor.constants import PLUGIN_KOJI_PARENT_KEY
+from atomic_reactor.constants import (
+    INSPECT_CONFIG, PLUGIN_KOJI_PARENT_KEY, BASE_IMAGE_KOJI_BUILD, PARENT_IMAGES_KOJI_BUILDS
+)
 from atomic_reactor.plugins.pre_reactor_config import get_koji_session
 from osbs.utils import Labels
 
@@ -139,7 +140,7 @@ class KojiParentPlugin(PreBuildPlugin):
         """Construct the result dict to be preserved in the build metadata."""
         result = {}
         if self._base_image_build:
-            result['parent-image-koji-build'] = self._base_image_build
+            result[BASE_IMAGE_KOJI_BUILD] = self._base_image_build
         if self._parent_builds:
-            result['parent-images-koji-builds'] = self._parent_builds
+            result[PARENT_IMAGES_KOJI_BUILDS] = self._parent_builds
         return result if result else None

--- a/atomic_reactor/plugins/pre_pull_base_image.py
+++ b/atomic_reactor/plugins/pre_pull_base_image.py
@@ -65,7 +65,7 @@ class PullBaseImagePlugin(PreBuildPlugin):
         Pull parent images and retag them uniquely for this build.
         """
         build_json = get_build_json()
-        base_image_str = str(self.workflow.builder.base_image)
+        base_image_str = str(self.workflow.builder.original_base_image)
         for nonce, parent in enumerate(sorted(self.workflow.builder.parent_images.keys())):
             image = ImageName.parse(parent)
             if parent == base_image_str:
@@ -79,7 +79,6 @@ class PullBaseImagePlugin(PreBuildPlugin):
             self.workflow.builder.parent_images[parent] = str(new_image)
 
             if parent == base_image_str:
-                self.workflow.builder.original_base_image = image.copy()
                 self.workflow.builder.set_base_image(str(new_image))
 
     def _resolve_base_image(self, build_json):
@@ -90,6 +89,7 @@ class PullBaseImagePlugin(PreBuildPlugin):
         except (TypeError, KeyError, IndexError):
             # build not marked for auto-rebuilds; use regular base image
             base_image = self.workflow.builder.base_image
+            self.log.info("using %s as base image.", base_image)
         else:
             # build has auto-rebuilds enabled
             self.log.info("using %s from build spec[triggeredBy] as base image.", image_id)

--- a/atomic_reactor/plugins/pre_pull_base_image.py
+++ b/atomic_reactor/plugins/pre_pull_base_image.py
@@ -6,7 +6,12 @@ This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 
 
-Pull base image to build our layer on.
+Pull parent image(s) the build will use, enforcing that they can only come from
+the specified registry.
+If this build is an auto-rebuild, use the base image from the image change
+trigger instead of what is in the Dockerfile.
+Tag each image to a unique name (the build name plus a nonce) to be used during
+this build so that it isn't removed by other builds doing clean-up.
 """
 
 from __future__ import unicode_literals
@@ -38,6 +43,7 @@ class PullBaseImagePlugin(PreBuildPlugin):
         :param workflow: DockerBuildWorkflow instance
         :param parent_registry: registry to enforce pulling from
         :param parent_registry_insecure: allow connecting to the registry over plain http
+        :param check_platforms: validate parent images provide all platforms expected for the build
         """
         # call parent constructor
         super(PullBaseImagePlugin, self).__init__(tasker, workflow)
@@ -54,7 +60,23 @@ class PullBaseImagePlugin(PreBuildPlugin):
             self.parent_registry = None
             self.parent_registry_insecure = False
 
-    def resolve_base_image(self, build_json):
+    def run(self):
+        """
+        Pull parent images and retag them uniquely for this build.
+        """
+        build_json = get_build_json()
+        base_image = self._resolve_base_image(build_json)
+        base_image_with_registry = self._ensure_image_registry(base_image)
+
+        if self.check_platforms:
+            self._validate_platforms_in_image(base_image_with_registry)
+
+        new_image = self._pull_and_tag_image(base_image_with_registry, build_json)
+        self.workflow.builder.original_base_image = base_image.copy()
+        self.workflow.builder.set_base_image(str(new_image))
+
+    def _resolve_base_image(self, build_json):
+        """If this is an auto-rebuild, adjust the base image to use the triggering build"""
         spec = build_json.get("spec")
         try:
             image_id = spec['triggeredBy'][0]['imageChangeBuild']['imageID']
@@ -65,92 +87,86 @@ class PullBaseImagePlugin(PreBuildPlugin):
 
         return base_image
 
-    def run(self):
-        """
-        pull base image
-        """
-        build_json = get_build_json()
-
-        base_image = self.resolve_base_image(build_json)
-
-        base_image_with_registry = base_image.copy()
-
+    def _ensure_image_registry(self, image):
+        """If plugin configured with a parent registry, ensure the image uses it"""
+        image_with_registry = image.copy()
         if self.parent_registry:
-            self.log.info("pulling base image '%s' from registry '%s'",
-                          base_image, self.parent_registry)
-            # registry in dockerfile doesn't match provided source registry
-            if base_image.registry and base_image.registry != self.parent_registry:
-                self.log.error("registry in dockerfile doesn't match provided source registry, "
-                               "dockerfile = '%s', provided = '%s'",
-                               base_image.registry, self.parent_registry)
-                raise RuntimeError(
-                    "Registry specified in dockerfile doesn't match provided one. "
-                    "Dockerfile: '%s', Provided: '%s'"
-                    % (base_image.registry, self.parent_registry))
+            # if registry specified in Dockerfile image, ensure it's the one allowed by config
+            if image.registry and image.registry != self.parent_registry:
+                error = (
+                    "Registry specified in dockerfile image doesn't match configured one. "
+                    "Dockerfile: '%s'; expected registry: '%s'"
+                    % (image, self.parent_registry))
+                self.log.error("%s", error)
+                raise RuntimeError(error)
 
-            base_image_with_registry.registry = self.parent_registry
+            self.log.info(
+                "pulling parent image '%s' from registry '%s'",
+                image, self.parent_registry
+            )
+            image_with_registry.registry = self.parent_registry
         else:
-            self.log.info("pulling base image '%s'", base_image)
+            self.log.info("pulling parent image '%s'", image)
 
-        if self.check_platforms:
-            self.validate_platforms_in_base_image(base_image_with_registry)
+        return image_with_registry
 
-        try:
-            self.tasker.pull_image(base_image_with_registry,
-                                   insecure=self.parent_registry_insecure)
-
-        except RetryGeneratorException as original_exc:
-            if base_image_with_registry.namespace:
-                raise
-
-            self.log.info("'%s' not found", base_image_with_registry.to_str())
-            base_image_with_registry.namespace = 'library'
-            self.log.info("trying '%s'", base_image_with_registry.to_str())
-
-            try:
-                self.tasker.pull_image(base_image_with_registry,
-                                       insecure=self.parent_registry_insecure)
-
-            except RetryGeneratorException:
-                raise original_exc
-
-        pulled_base = base_image_with_registry.to_str()
-        self.workflow.pulled_base_images.add(pulled_base)
-
-        # Attempt to tag it using a unique ID. We might have to retry
-        # if another build with the same parent image is finishing up
-        # and removing images it pulled.
-
-        # Use the OpenShift build name as the unique ID
-        unique_id = build_json['metadata']['name']
-        original_base_image = base_image.copy()
-        base_image = ImageName(repo=unique_id)
-
+    def _pull_and_tag_image(self, image, build_json):
+        """Docker pull the image and tag it uniquely for use by this build"""
+        image = image.copy()
+        first_library_exc = None
         for _ in range(20):
+            # retry until pull and tag is successful or definitively fails.
+            # should never require 20 retries but there's a race condition at work.
+            # just in case something goes wildly wrong, limit to 20 so it terminates.
+            try:
+                self.tasker.pull_image(image, insecure=self.parent_registry_insecure)
+                self.workflow.pulled_base_images.add(image.to_str())
+            except RetryGeneratorException as exc:
+                # getting here means the pull itself failed. we may want to retry if the
+                # image being pulled lacks a namespace, like e.g. "rhel7". we cannot count
+                # on the registry mapping this into the docker standard "library/rhel7" so
+                # need to retry with that.
+                if first_library_exc:
+                    # we already tried and failed; report the first failure.
+                    raise first_library_exc
+                if image.namespace:
+                    # already namespaced, do not retry with "library/", just fail.
+                    raise
+
+                self.log.info("'%s' not found", image.to_str())
+                image.namespace = 'library'
+                self.log.info("trying '%s'", image.to_str())
+                first_library_exc = exc  # report first failure if retry also fails
+                continue
+
+            # Attempt to tag it using a unique ID. We might have to retry
+            # if another build with the same parent image is finishing up
+            # and removing images it pulled.
+
+            # Use the OpenShift build name as the unique ID
+            unique_id = build_json['metadata']['name']
+            new_image = ImageName(repo=unique_id)
+
             try:
                 self.log.info("tagging pulled image")
-                response = self.tasker.tag_image(base_image_with_registry,
-                                                 base_image)
+                response = self.tasker.tag_image(image, new_image)
                 self.workflow.pulled_base_images.add(response)
-                break
+                self.log.debug("image '%s' is available as '%s'", image, new_image)
+                return new_image
             except docker.errors.NotFound:
                 # If we get here, some other build raced us to remove
                 # the parent image, and that build won.
                 # Retry the pull immediately.
                 self.log.info("re-pulling removed image")
-                self.tasker.pull_image(base_image_with_registry,
-                                       insecure=self.parent_registry_insecure)
-        else:
-            # Failed to tag it
-            self.log.error("giving up trying to pull image")
-            raise RuntimeError("too many attempts to pull and tag image")
+                continue
 
-        self.workflow.builder.set_base_image(base_image.to_str())
-        self.workflow.builder.original_base_image = ImageName.parse(original_base_image.to_str())
-        self.log.debug("image '%s' is available", pulled_base)
+        # Failed to tag it after 20 tries
+        self.log.error("giving up trying to pull image")
+        raise RuntimeError("too many attempts to pull and tag image")
 
-    def validate_platforms_in_base_image(self, base_image):
-        expected_platforms = self.get_expected_platforms()
+    def _validate_platforms_in_image(self, image):
+        """Ensure that the image provides all platforms expected for the build."""
+        expected_platforms = self._get_expected_platforms()
         if not expected_platforms:
             self.log.info('Skipping validation of available platforms '
                           'because expected platforms are unknown')
@@ -160,7 +176,7 @@ class PullBaseImagePlugin(PreBuildPlugin):
                           'because this is a single platform build')
             return
 
-        if not base_image.registry:
+        if not image.registry:
             self.log.info('Cannot validate available platforms for base image '
                           'because base image registry is not defined')
             return
@@ -172,27 +188,26 @@ class PullBaseImagePlugin(PreBuildPlugin):
                           'because platform descriptors are not defined')
             return
 
-        manifest_list = get_manifest_list(base_image, base_image.registry,
+        manifest_list = get_manifest_list(image, image.registry,
                                           insecure=self.parent_registry_insecure)
-        if '@sha256:' in str(base_image) and not manifest_list:
+        if '@sha256:' in str(image) and not manifest_list:
             # we want to adjust the tag only for manifest list fetching
-            base_image = base_image.copy()
+            image = image.copy()
 
             try:
-                config_blob = get_config_from_registry(base_image, base_image.registry,
-                                                       base_image.tag,
+                config_blob = get_config_from_registry(image, image.registry, image.tag,
                                                        insecure=self.parent_registry_insecure)
             except (HTTPError, RetryError, Timeout) as ex:
                 self.log.warning('Unable to fetch config for %s, got error %s',
-                                 base_image, ex.response.status_code)
+                                 image, ex.response.status_code)
                 raise RuntimeError('Unable to fetch config for base image')
 
             release = config_blob['config']['Labels']['release']
             version = config_blob['config']['Labels']['version']
             docker_tag = "%s-%s" % (version, release)
-            base_image.tag = docker_tag
+            image.tag = docker_tag
 
-            manifest_list = get_manifest_list(base_image, base_image.registry,
+            manifest_list = get_manifest_list(image, image.registry,
                                               insecure=self.parent_registry_insecure)
 
         if not manifest_list:
@@ -212,7 +227,8 @@ class PullBaseImagePlugin(PreBuildPlugin):
 
         self.log.info('Base image is a manifest list for all required platforms')
 
-    def get_expected_platforms(self):
+    def _get_expected_platforms(self):
+        """retrieve expected platforms configured for this build"""
         platforms = self.workflow.prebuild_results.get(PLUGIN_CHECK_AND_SET_PLATFORMS_KEY)
         if platforms:
             return platforms

--- a/atomic_reactor/plugins/pre_resolve_composes.py
+++ b/atomic_reactor/plugins/pre_resolve_composes.py
@@ -14,7 +14,7 @@ from collections import defaultdict
 
 from atomic_reactor.constants import (PLUGIN_KOJI_PARENT_KEY, PLUGIN_RESOLVE_COMPOSES_KEY,
                                       REPO_CONTENT_SETS_CONFIG, PLUGIN_BUILD_ORCHESTRATE_KEY,
-                                      PLUGIN_CHECK_AND_SET_PLATFORMS_KEY)
+                                      PLUGIN_CHECK_AND_SET_PLATFORMS_KEY, BASE_IMAGE_KOJI_BUILD)
 
 from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.plugins.build_orchestrate_build import override_build_kwarg
@@ -180,7 +180,7 @@ class ResolveComposesPlugin(PreBuildPlugin):
                            PLUGIN_KOJI_PARENT_KEY)
             return
 
-        build_info = plugin_result['parent-image-koji-build']
+        build_info = plugin_result[BASE_IMAGE_KOJI_BUILD]
 
         try:
             parent_signing_intent_name = build_info['extra']['image']['odcs']['signing_intent']

--- a/docs/koji.md
+++ b/docs/koji.md
@@ -46,6 +46,7 @@ Data which is placed here includes:
 - `build.extra.filesystem_koji_task_id` (int): Koji task ID which atomic-reactor created in order to generate the initial layer of the image (for "FROM koji/image-build" images) -- note that this location is technically incorrect but remains as-is for compatibility with existing software
 - `build.extra.image.media_types` (str list): Container image media types for which this image is available, where "application/json" is for a Docker Registry HTTP API V1 image; currently this key is only set when Pulp integration is enabled
 - `build.extra.image.parent_build_id` (int): Koji build id of the parent image, if found
+- `build.extra.image.parent_image_builds` (map of maps): With each parent image given in the Dockerfile as a key, its value being a map representing the Koji build (if found) for that image, with keys `id` (int) and `nvr` (str).
 - `build.extra.image.index` (map): information about the manifest list
 - `build.extra.image.flatpak` (boolean): true if this image is a Flatpak
 - `build.extra.image.modules` (boolean): the [modules](https://docs.pagure.org/modularity/) that provide the packages for this image, resolved to `NAME-STREAM-VERSION`. This will include the resolved versions of the modules in `source_modules`, and the dependencies of those modules. (Currently only for Flatpaks)

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -22,6 +22,7 @@ DOCKERFILE_FILENAME = 'Dockerfile'
 DOCKERFILE_GIT = "https://github.com/TomasTomecek/docker-hello-world.git"
 DOCKERFILE_SHA1 = "6e592f1420efcd331cd28b360a7e02f669caf540"
 DOCKERFILE_OK_PATH = os.path.join(FILES, 'docker-hello-world')
+DOCKERFILE_MULTISTAGE_PATH = os.path.join(FILES, 'docker-hello-world-multistage')
 DOCKERFILE_ERROR_BUILD_PATH = os.path.join(FILES, 'docker-hello-world-error-build')
 SOURCE_CONFIG_ERROR_PATH = os.path.join(FILES, 'docker-hello-world-error-config')
 DOCKERFILE_SUBDIR_PATH = os.path.join(FILES, 'df-in-subdir')

--- a/tests/docker_mock.py
+++ b/tests/docker_mock.py
@@ -246,12 +246,12 @@ def _mock_inspect(img, **kwargs):
     raise _docker_exception()
 
 
-def _mock_tag(src_img, dest_repo, dest_tag='latest', **kwargs):
+def _mock_tag(src_img, dest_repo, tag='latest', **kwargs):
     i = _find_image(src_img)
     if i is None:
         raise _docker_exception()
 
-    dst_img = "%s:%s" % (dest_repo, dest_tag)
+    dst_img = "%s:%s" % (dest_repo, tag)
     i = _find_image(dst_img)
     if i is None:
         new_image = mock_image.copy()

--- a/tests/files/docker-hello-world-multistage/Dockerfile
+++ b/tests/files/docker-hello-world-multistage/Dockerfile
@@ -1,0 +1,5 @@
+FROM fedora:latest as builder
+RUN uname -a && env
+
+FROM fedora
+COPY --from=builder /etc/fedora-release /opt/release

--- a/tests/files/docker-hello-world-multistage/container.yaml
+++ b/tests/files/docker-hello-world-multistage/container.yaml
@@ -1,0 +1,5 @@
+---
+image_build_method: imagebuilder
+tags:
+  - spam
+  - eggs

--- a/tests/plugins/test_change_from_in_df.py
+++ b/tests/plugins/test_change_from_in_df.py
@@ -1,0 +1,180 @@
+"""
+Copyright (c) 2018 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+from __future__ import print_function, unicode_literals
+
+import pytest
+from flexmock import flexmock
+
+from atomic_reactor.inner import DockerBuildWorkflow
+from atomic_reactor.plugin import PreBuildPluginsRunner
+from atomic_reactor.plugins.pre_change_from_in_df import (
+    NoIdInspection, BaseImageMismatch, ParentImageUnresolved, ChangeFromPlugin, ParentImageMissing
+)
+from atomic_reactor.util import ImageName, df_parser
+from tests.fixtures import docker_tasker
+from tests.constants import SOURCE
+from tests.stubs import StubInsideBuilder
+from textwrap import dedent
+
+
+def mock_workflow():
+    """
+    Provide just enough structure that workflow can be used to run the plugin.
+    Defaults below are solely to enable that purpose; tests where those values
+    matter should provide their own.
+    """
+
+    workflow = DockerBuildWorkflow(SOURCE, "mock:default_built")
+    builder = StubInsideBuilder().for_workflow(workflow)
+    builder.set_df_path('/mock-path')
+    builder.parent_images["mock:base"] = "mock:tag"
+    builder.base_image = ImageName.parse("mock:tag")
+    builder.tasker = flexmock()
+    workflow.builder = flexmock(builder)
+
+    return workflow
+
+
+def run_plugin(workflow, allow_failure=False):
+    result = PreBuildPluginsRunner(
+       docker_tasker(), workflow,
+       [{
+          'name': ChangeFromPlugin.key,
+          'args': {},
+       }]
+    ).run()
+
+    if not allow_failure:  # exceptions are captured in plugin result
+        assert result[ChangeFromPlugin.key] is None, "Plugin threw exception, check logs"
+
+    return result[ChangeFromPlugin.key]
+
+
+def test_update_base_image(tmpdir):
+    df_content = dedent("""\
+        FROM {}
+        LABEL horses=coconuts
+        CMD whoah
+    """)
+    dfp = df_parser(str(tmpdir))
+    dfp.content = df_content.format("base:image")
+
+    workflow = mock_workflow()
+    workflow.builder.set_df_path(dfp.dockerfile_path)
+    workflow.builder.parent_images = {"base:image": "base@sha256:1234"}
+    workflow.builder.base_image = ImageName.parse("base@sha256:1234")
+    workflow.builder.tasker.inspect_image = lambda *_: dict(Id="base@sha256:1234")
+
+    run_plugin(workflow)
+    expected_df = df_content.format("base@sha256:1234")
+    assert dfp.content == expected_df
+
+
+def test_update_base_image_inspect_broken(tmpdir, caplog):
+    """exercise code branch where the base image inspect comes back without an Id"""
+    df_content = "FROM base:image"
+    dfp = df_parser(str(tmpdir))
+    dfp.content = df_content
+
+    workflow = mock_workflow()
+    workflow.builder.set_df_path(dfp.dockerfile_path)
+    workflow.builder.parent_images = {"base:image": "base@sha256:1234"}
+    workflow.builder.base_image = ImageName.parse("base@sha256:1234")
+    workflow.builder.tasker.inspect_image = lambda img: dict(no_id="here")
+
+    with pytest.raises(NoIdInspection):
+        ChangeFromPlugin(docker_tasker(), workflow).run()
+    assert dfp.content == df_content  # nothing changed
+    assert "missing in inspection" in caplog.text()
+
+
+def test_update_parent_images(tmpdir):
+    """test the happy path for updating multiple parents"""
+    df_content = dedent("""\
+        FROM first:parent AS builder1
+        CMD build /spam/eggs
+        FROM second:parent AS builder2
+        CMD build /vikings
+        FROM monty
+        COPY --from=builder1 /spam/eggs /bin/eggs
+        COPY --from=builder2 /vikings /bin/vikings
+    """)
+    dfp = df_parser(str(tmpdir))
+    dfp.content = df_content
+
+    # maps from dockerfile image to unique tag and then to ID
+    pimgs = {
+        "first:parent": 'build-name:1',
+        "second:parent": 'build-name:2',
+        "monty": 'build-name:3',
+    }
+    img_ids = {
+        'build-name:1': 'id:1',
+        'build-name:2': 'id:2',
+        'build-name:3': 'id:3',
+    }
+
+    workflow = mock_workflow()
+    workflow.builder.set_df_path(dfp.dockerfile_path)
+    workflow.builder.base_image = ImageName.parse(pimgs['monty'])
+    workflow.builder.parent_images = pimgs
+    workflow.builder.tasker.inspect_image = lambda img: dict(Id=img_ids[img])
+
+    run_plugin(workflow)
+    expected_df_content = df_content
+    for image, rename in pimgs.items():
+        expected_df_content = expected_df_content.replace(image, img_ids[rename])
+    assert dfp.content == expected_df_content
+
+
+def test_parent_images_unresolved(tmpdir):
+    """test when parent_images hasn't been filled in with unique tags."""
+    dfp = df_parser(str(tmpdir))
+    dfp.content = "FROM spam"
+
+    workflow = mock_workflow()
+    workflow.builder.set_df_path(dfp.dockerfile_path)
+    workflow.builder.base_image = ImageName.parse('eggs')
+
+    # we want to fail because some img besides base was not resolved
+    workflow.builder.parent_images = {'spam': 'eggs', 'extra:image': None}
+
+    with pytest.raises(ParentImageUnresolved):
+        ChangeFromPlugin(docker_tasker(), workflow).run()
+
+
+def test_parent_images_missing(tmpdir):
+    """test when parent_images has been mangled and lacks parents compared to dockerfile."""
+    dfp = df_parser(str(tmpdir))
+    dfp.content = dedent("""\
+        FROM first:parent AS builder1
+        FROM second:parent AS builder2
+        FROM monty
+    """)
+
+    workflow = mock_workflow()
+    workflow.builder.set_df_path(dfp.dockerfile_path)
+    workflow.builder.parent_images = {"monty": "build-name:3"}
+    workflow.builder.base_image = ImageName.parse("build-name:3")
+
+    with pytest.raises(ParentImageMissing):
+        ChangeFromPlugin(docker_tasker(), workflow).run()
+
+
+def test_parent_images_mismatch_base_image(tmpdir):
+    """test when base_image has been updated differently from parent_images."""
+    dfp = df_parser(str(tmpdir))
+    dfp.content = "FROM base:image"
+    workflow = mock_workflow()
+    workflow.builder.set_df_path(dfp.dockerfile_path)
+    workflow.builder.base_image = ImageName.parse("base:image")
+    workflow.builder.parent_images = {"base:image": "different-parent-tag"}
+
+    with pytest.raises(BaseImageMismatch):
+        ChangeFromPlugin(docker_tasker(), workflow).run()

--- a/tests/plugins/test_koji_parent.py
+++ b/tests/plugins/test_koji_parent.py
@@ -26,7 +26,9 @@ except ImportError:
     del koji
     import koji as koji
 
-from atomic_reactor.constants import INSPECT_CONFIG
+from atomic_reactor.constants import (
+    INSPECT_CONFIG, BASE_IMAGE_KOJI_BUILD, PARENT_IMAGES_KOJI_BUILDS
+)
 from atomic_reactor.build import InsideBuilder
 from atomic_reactor.inner import DockerBuildWorkflow
 from atomic_reactor.plugin import PreBuildPluginsRunner, PluginFailedException
@@ -216,8 +218,8 @@ class TestKojiParent(object):
         workflow.base_image_inspect.update(image_inspects['base'])
 
         expected = {
-            'parent-image-koji-build': koji_builds['base'],
-            'parent-images-koji-builds': koji_builds,
+            BASE_IMAGE_KOJI_BUILD: koji_builds['base'],
+            PARENT_IMAGES_KOJI_BUILDS: koji_builds,
         }
         self.run_plugin_with_args(
             workflow, expect_result=expected, reactor_config_map=reactor_config_map
@@ -251,7 +253,7 @@ class TestKojiParent(object):
 
         result = runner.run()
         if expect_result is True:
-            expected_result = {'parent-image-koji-build': KOJI_BUILD}
+            expected_result = {BASE_IMAGE_KOJI_BUILD: KOJI_BUILD}
         elif expect_result is False:
             expected_result = None
         else:  # param provided the expected result

--- a/tests/plugins/test_pull_base_image.py
+++ b/tests/plugins/test_pull_base_image.py
@@ -50,6 +50,7 @@ class MockBuilder(object):
     image_id = "xxx"
     source = MockSource()
     base_image = None
+    parent_images = {UNIQUE_ID: None}
 
     def set_base_image(self, base_image):
         self.base_image = base_image

--- a/tests/plugins/test_pull_base_image.py
+++ b/tests/plugins/test_pull_base_image.py
@@ -50,10 +50,12 @@ class MockBuilder(object):
     image_id = "xxx"
     source = MockSource()
     base_image = None
+    original_base_image = None
     parent_images = {UNIQUE_ID: None}
 
     def set_base_image(self, base_image):
         self.base_image = ImageName.parse(base_image)
+        self.original_base_image = self.original_base_image or self.base_image
         assert base_image.startswith(UNIQUE_ID + ":")
 
 
@@ -132,9 +134,9 @@ def test_pull_base_image_plugin(parent_registry, df_base, expected, not_expected
     }]
     parent_images = parent_images or {df_base: None}
     workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image', buildstep_plugins=buildstep_plugin,)
-    workflow.builder = MockBuilder()
-    workflow.builder.base_image = ImageName.parse(df_base)
-    workflow.builder.parent_images = parent_images
+    builder = workflow.builder = MockBuilder()
+    builder.base_image = builder.original_base_image = ImageName.parse(df_base)
+    builder.parent_images = parent_images
 
     expected = set(expected)
     for nonce in range(len(parent_images)):

--- a/tests/plugins/test_resolve_composes.py
+++ b/tests/plugins/test_resolve_composes.py
@@ -27,7 +27,11 @@ except ImportError:
     del koji
     import koji as koji
 
-from atomic_reactor.constants import PLUGIN_KOJI_PARENT_KEY, PLUGIN_CHECK_AND_SET_PLATFORMS_KEY
+from atomic_reactor.constants import (
+    PLUGIN_KOJI_PARENT_KEY,
+    PLUGIN_CHECK_AND_SET_PLATFORMS_KEY,
+    BASE_IMAGE_KOJI_BUILD
+)
 from atomic_reactor.core import DockerTasker
 from atomic_reactor.inner import DockerBuildWorkflow
 from atomic_reactor.source import SourceConfig
@@ -589,7 +593,7 @@ class TestResolveComposes(object):
             parent_build_info['extra']['image'] = {'odcs': {'signing_intent': parent_si}}
 
         workflow.prebuild_results[PLUGIN_KOJI_PARENT_KEY] = {
-            'parent-image-koji-build': parent_build_info,
+            BASE_IMAGE_KOJI_BUILD: parent_build_info,
         }
 
         plugin_args = {}

--- a/tests/plugins/test_store_metadata.py
+++ b/tests/plugins/test_store_metadata.py
@@ -56,6 +56,7 @@ class X(object):
     source.dockerfile_path = None
     source.path = None
     base_image = ImageName(repo="qwe", tag="asd")
+    parent_images = {base_image.to_str(): "sha256:spamneggs"}
     original_base_image = base_image.copy()
     # image = ImageName.parse("test-image:unique_tag_123")
 
@@ -66,6 +67,7 @@ class XBeforeDockerfile(object):
     source.dockerfile_path = None
     source.path = None
     base_image = None
+    parent_images = {}
 
     @property
     def df_path(self):
@@ -267,6 +269,9 @@ CMD blabla"""
     assert "base-image-name" in annotations
     assert annotations["base-image-name"] == workflow.builder.original_base_image.to_str()
     assert is_string_type(annotations['base-image-name'])
+    assert "parent_images" in annotations
+    assert is_string_type(annotations['parent_images'])
+    assert workflow.builder.original_base_image.to_str() in annotations['parent_images']
     assert "image-id" in annotations
     assert is_string_type(annotations['image-id'])
     assert "filesystem" in annotations

--- a/tests/plugins/test_yum_inject.py
+++ b/tests/plugins/test_yum_inject.py
@@ -133,9 +133,9 @@ Dockerfile = namedtuple('Dockerfile', ['inherited_user',
 
 
 DOCKERFILES = {
-    "no maintainer":
+    "simple":
         Dockerfile('',
-                   ["# Simple example with no MAINTAINER line\n",
+                   ["# Simple example\n",
                     "FROM base\n"],
                    # add goes here
                    [" RUN yum -y update\n"],
@@ -143,18 +143,14 @@ DOCKERFILES = {
 
     "no yum":
         Dockerfile('',
-                   ["FROM base\n",
-                    "# This time there is a MAINTAINER line\n",
-                    "# but it's the last last there is\n",
-                    "MAINTAINER Example <example@example.com>\n"],
+                   ["FROM base\n"],
                    # add goes here
-                   [],
+                   ["MAINTAINER Example <example@example.com>\n"],
                    ["RUN rm ...\n"]),
 
     "user":
         Dockerfile('',
-                   [" From base\n",
-                    " Maintainer Example <example@example.com\n"],
+                   [" From base\n"],
                    # add goes here
                    [" Run yum update -y\n",
                     " Env asd qwe\n",
@@ -168,8 +164,7 @@ DOCKERFILES = {
 
     "root":
         Dockerfile('',
-                   ["FROM nonroot-base\n",
-                    "MAINTAINER example@example.com\n"],
+                   ["FROM nonroot-base\n"],
                    # add goes here
                    ["USER root\n",
                     "RUN yum -y update\n",

--- a/tests/stubs.py
+++ b/tests/stubs.py
@@ -45,6 +45,7 @@ class StubInsideBuilder(object):
 
     def __init__(self):
         self.base_image = None
+        self.parent_images = {}
         self.df_path = None
         self.df_dir = None
         self.git_dockerfile_path = None
@@ -80,3 +81,7 @@ class StubInsideBuilder(object):
 
     def inspect_base_image(self):
         return self._inspection_data
+
+    def set_base_image(self, image):
+        # likely run as side effect; ignore. tests that want stateful results must mock.
+        pass


### PR DESCRIPTION
Enhance atomic-reactor to correctly manage multi-stage build inputs and metadata.

Implementation of OSBS-5663. The commits are intended to be individually coherent for easier reviews.