### PR TITLE
Port from modulemd to libmodulemd

### DIFF
--- a/atomic_reactor/plugins/pre_flatpak_create_dockerfile.py
+++ b/atomic_reactor/plugins/pre_flatpak_create_dockerfile.py
@@ -19,7 +19,6 @@ Example configuration:
 """
 
 import os
-import yaml
 
 from atomic_reactor.constants import DOCKERFILE_FILENAME, YUM_REPOS_DIR
 from atomic_reactor.plugin import PreBuildPlugin

--- a/atomic_reactor/plugins/pre_resolve_module_compose.py
+++ b/atomic_reactor/plugins/pre_resolve_module_compose.py
@@ -23,9 +23,6 @@ Example configuration:
 }
 """
 
-import os
-import yaml
-
 import gi
 try:
     gi.require_version('Modulemd', '1.0')

--- a/atomic_reactor/plugins/prepub_flatpak_create_oci.py
+++ b/atomic_reactor/plugins/prepub_flatpak_create_oci.py
@@ -277,7 +277,7 @@ class FlatpakCreateOciPlugin(PrePublishPlugin):
         return parse_rpm_output(lines)
 
     def _filter_app_manifest(self, components):
-        runtime_rpms = self.source.runtime_module.mmd.props.profiles['runtime'].props.rpms
+        runtime_rpms = self.source.runtime_module.mmd.peek_profiles()['runtime'].props.rpms
 
         return [c for c in components if not runtime_rpms.contains(c['name'])]
 

--- a/atomic_reactor/plugins/prepub_flatpak_create_oci.py
+++ b/atomic_reactor/plugins/prepub_flatpak_create_oci.py
@@ -277,9 +277,9 @@ class FlatpakCreateOciPlugin(PrePublishPlugin):
         return parse_rpm_output(lines)
 
     def _filter_app_manifest(self, components):
-        runtime_rpms = self.source.runtime_module.mmd.profiles['runtime'].rpms
+        runtime_rpms = self.source.runtime_module.mmd.props.profiles['runtime'].props.rpms
 
-        return [c for c in components if c['name'] not in runtime_rpms]
+        return [c for c in components if not runtime_rpms.contains(c['name'])]
 
     def _create_runtime_oci(self, tarred_filesystem, outfile):
         info = self.source.flatpak_yaml
@@ -337,9 +337,10 @@ class FlatpakCreateOciPlugin(PrePublishPlugin):
     def _find_runtime_info(self):
         runtime_module = self.source.runtime_module
 
-        runtime_id = runtime_module.mmd.xmd['flatpak']['runtimes']['runtime']['id']
-        sdk_id = runtime_module.mmd.xmd['flatpak']['runtimes']['runtime'].get('sdk', runtime_id)
-        runtime_version = runtime_module.mmd.xmd['flatpak']['branch']
+        flatpak_xmd = runtime_module.mmd.props.xmd['flatpak']
+        runtime_id = flatpak_xmd['runtimes']['runtime']['id']
+        sdk_id = flatpak_xmd['runtimes']['runtime'].get('sdk', runtime_id)
+        runtime_version = flatpak_xmd['branch']
 
         return runtime_id, sdk_id, runtime_version
 

--- a/images/dockerhost-builder/Dockerfile
+++ b/images/dockerhost-builder/Dockerfile
@@ -1,5 +1,5 @@
 FROM fedora:latest
-RUN dnf -y install docker git python-docker-py python-setuptools desktop-file-utils e2fsprogs flatpak koji python-backports-lzma osbs gssproxy && dnf clean all
+RUN dnf -y install docker git python-docker-py python-setuptools desktop-file-utils e2fsprogs flatpak koji libmodulemd ostree python2-gobject-base python-backports-lzma osbs gssproxy && dnf clean all
 ADD ./atomic-reactor.tar.gz /tmp/
 RUN cd /tmp/atomic-reactor-*/ && python setup.py install
 CMD ["atomic-reactor", "--verbose", "inside-build"]

--- a/images/privileged-builder/Dockerfile
+++ b/images/privileged-builder/Dockerfile
@@ -1,5 +1,5 @@
 FROM fedora:latest
-RUN dnf -y install docker git python-docker-py python-setuptools desktop-file-utils e2fsprogs flatpak koji python-backports-lzma osbs gssproxy && dnf clean all
+RUN dnf -y install docker git python-docker-py python-setuptools desktop-file-utils e2fsprogs flatpak koji libmodulemd ostree python2-gobject-base python-backports-lzma osbs gssproxy && dnf clean all
 ADD ./atomic-reactor.tar.gz /tmp/
 RUN cd /tmp/atomic-reactor-*/ && python setup.py install
 ADD ./docker.sh /tmp/docker.sh

--- a/requirements-flatpak.txt
+++ b/requirements-flatpak.txt
@@ -1,4 +1,1 @@
-modulemd
 pdc-client
-# https://pagure.io/modulemd/pull-request/46
-python-dateutil

--- a/test.sh
+++ b/test.sh
@@ -21,7 +21,7 @@ if [[ $OS == "fedora" ]]; then
   PIP_PKG="python$PYTHON_VERSION-pip"
   PIP="pip$PYTHON_VERSION"
   PKG="dnf"
-  PKG_EXTRA="dnf-plugins-core desktop-file-utils flatpak ostree"
+  PKG_EXTRA="dnf-plugins-core desktop-file-utils flatpak libmodulemd ostree python$PYTHON_VERSION-gobject-base"
   BUILDDEP="dnf builddep"
   PYTHON="python$PYTHON_VERSION"
 else

--- a/tests/flatpak.py
+++ b/tests/flatpak.py
@@ -6,14 +6,14 @@ try:
                                                                    set_compose_info)
     from atomic_reactor.plugins.pre_flatpak_create_dockerfile import (FlatpakSourceInfo,
                                                                       set_flatpak_source_info)
-    from modulemd import ModuleMetadata
+    from gi.repository import Modulemd
     MODULEMD_AVAILABLE = True
 except ImportError:
     MODULEMD_AVAILABLE = False
 
 FLATPAK_APP_MODULEMD = """
 document: modulemd
-version: 1
+version: 2
 data:
   name: eog
   stream: f26
@@ -25,8 +25,10 @@ data:
   license:
     module: [MIT]
   dependencies:
-    buildrequires: {flatpak-runtime: f28}
-    requires: {flatpak-runtime: f28}
+  - buildrequires:
+      flatpak-runtime: [f28]
+    requires:
+      flatpak-runtime: [f28]
   profiles:
     default:
       rpms: [eog]
@@ -92,7 +94,7 @@ flatpak:
 
 FLATPAK_RUNTIME_MODULEMD = """
 document: modulemd
-version: 1
+version: 2
 data:
   name: flatpak-runtime
   stream: f28
@@ -108,8 +110,10 @@ data:
       libnotify, adwaita-icon-theme, libgcab1, libxkbcommon, libappstream-glib, python3-cairo,
       gnome-desktop3, libepoxy, hunspell, libgusb, glib2, enchant, at-spi2-atk]
   dependencies:
-    buildrequires: {platform: f28}
-    requires: {platform: f28}
+  - buildrequires:
+      flatpak-runtime: [f28]
+    requires:
+      flatpak-runtime: [f28]
   license:
     module: [MIT]
   profiles:
@@ -257,8 +261,7 @@ def build_flatpak_test_configs(extensions={}):
 def setup_flatpak_compose_info(workflow, config=APP_CONFIG):
     modules = {}
     for name, module_config in config['modules'].items():
-        mmd = ModuleMetadata()
-        mmd.loads(module_config['metadata'])
+        mmd = Modulemd.Module.new_from_string(module_config['metadata'])
         modules[name] = ModuleInfo(name,
                                    module_config['stream'],
                                    module_config['version'],

--- a/tests/plugins/test_flatpak_create_dockerfile.py
+++ b/tests/plugins/test_flatpak_create_dockerfile.py
@@ -26,6 +26,9 @@ from tests.constants import (MOCK_SOURCE, FLATPAK_GIT, FLATPAK_SHA1)
 from tests.fixtures import docker_tasker  # noqa
 from tests.flatpak import MODULEMD_AVAILABLE, build_flatpak_test_configs, setup_flatpak_compose_info
 
+if MODULEMD_AVAILABLE:
+    from gi.repository import GLib
+
 
 class MockSource(object):
     def __init__(self, tmpdir):
@@ -76,7 +79,7 @@ CONFIGS = build_flatpak_test_configs()
 
 @responses.activate  # noqa - docker_tasker fixture
 @pytest.mark.skipif(not MODULEMD_AVAILABLE,
-                    reason='modulemd not available')
+                    reason='libmodulemd not available')
 @pytest.mark.parametrize('config_name,breakage', [
     ('app', None),
     ('runtime', None),
@@ -90,7 +93,21 @@ def test_flatpak_create_dockerfile(tmpdir, docker_tasker, config_name, breakage)
     compose = setup_flatpak_compose_info(workflow, config)
 
     if breakage == 'branch_mismatch':
-        compose.base_module.mmd.xmd['flatpak']['branch'] = 'MISMATCH'
+        xmd = compose.base_module.mmd.props.xmd
+
+        # Modifying the xmd from Python requires creating a new GVariant
+        flatpak_xmd = xmd['flatpak']
+
+        new_flatpak_xmd = {}
+        for i in range(flatpak_xmd.n_children()):
+            v = flatpak_xmd.get_child_value(i)
+            new_flatpak_xmd[v.get_child_value(0).unpack()] = v.get_child_value(1)
+
+        new_flatpak_xmd['branch'] = GLib.Variant('s', 'MISMATCH')
+
+        xmd['flatpak'] = GLib.Variant('a{sv}', new_flatpak_xmd)
+        compose.base_module.mmd.props.xmd = xmd
+
         expected_exception = "Mismatch for 'branch'"
     else:
         assert breakage is None

--- a/tests/plugins/test_koji_import.py
+++ b/tests/plugins/test_koji_import.py
@@ -1475,7 +1475,7 @@ class TestKojiImport(object):
             assert 'help' not in image.keys()
 
     @pytest.mark.skipif(not MODULEMD_AVAILABLE,
-                        reason="modulemd not available")
+                        reason="libmodulemd not available")
     def test_koji_import_flatpak(self, tmpdir, os_env, reactor_config_map):
         session = MockedClientSession('')
         tasker, workflow = mock_environment(tmpdir,

--- a/tests/plugins/test_koji_promote.py
+++ b/tests/plugins/test_koji_promote.py
@@ -1426,7 +1426,7 @@ class TestKojiPromote(object):
             assert 'help' not in image.keys()
 
     @pytest.mark.skipif(not MODULEMD_AVAILABLE,
-                        reason="modulemd not available")
+                        reason="libmodulemd not available")
     def test_koji_promote_flatpak(self, tmpdir, os_env, reactor_config_map):  # noqa
         session = MockedClientSession('')
         tasker, workflow = mock_environment(tmpdir,

--- a/tests/plugins/test_resolve_module_compose.py
+++ b/tests/plugins/test_resolve_module_compose.py
@@ -187,7 +187,6 @@ def test_resolve_module_compose(tmpdir, docker_tasker, compose_ids, modules,  # 
                            callback=handle_unreleasedvariants)
 
     args = {
-        'base_image': "registry.fedoraproject.org/fedora:latest",
         'odcs_url': ODCS_URL,
         'odcs_openidc_secret_path': secrets_path,
         'pdc_url': PDC_URL,

--- a/tests/plugins/test_resolve_module_compose.py
+++ b/tests/plugins/test_resolve_module_compose.py
@@ -110,7 +110,7 @@ def compose_json(state, state_name):
 
 @responses.activate  # noqa - docker_tasker fixture
 @pytest.mark.skipif(not MODULEMD_AVAILABLE,
-                    reason="modulemd not available")
+                    reason="libmodulemd not available")
 @pytest.mark.parametrize('compose_ids', (None, [], [84], [84, 2]))
 @pytest.mark.parametrize('modules', (
     None,
@@ -228,4 +228,4 @@ def test_resolve_module_compose(tmpdir, docker_tasker, compose_ids, modules,  # 
         assert compose_info.base_module.name == MODULE_NAME
         assert compose_info.base_module.stream == MODULE_STREAM
         assert compose_info.base_module.version == MODULE_VERSION
-        assert compose_info.base_module.mmd.summary == 'Eye of GNOME Application Module'
+        assert compose_info.base_module.mmd.props.summary == 'Eye of GNOME Application Module'


### PR DESCRIPTION
The Python modulemd library has been deprecated. The replacement is
accessing the libmodulemd file through gobject-introspection bindings.
    
Porting to libmodulemd enables support for version 2 of the modulemd
specification, which is being moved to for all modules.

[ Includes two small cleanups as separate commits ]
