### PR TITLE
Make v1 image tagging atomic (OSBS-5820)

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -111,7 +111,10 @@ HTTP_REQUEST_TIMEOUT = 600
 GIT_MAX_RETRIES = 3
 # how many seconds should wait before another try of git clone
 GIT_BACKOFF_FACTOR = 5
-
+# max retries for creating 'lock' repository
+LOCKEDPULPREPOSITORY_RETRIES = 10
+# how many seconds to wait before 1st retry; doubles each retry
+LOCKEDPULPREPOSITORY_BACKOFF = 5
 
 # Media types
 MEDIA_TYPE_DOCKER_V1 = "application/json"

--- a/atomic_reactor/pulp_util.py
+++ b/atomic_reactor/pulp_util.py
@@ -210,7 +210,8 @@ class PulpHandler(object):
         self.p.copy_filters(repo_id, filters=pulp_filter, v1=True, v2=False)
 
     def update_repo(self, repo_id, tag):
-        self.p.updateRepo(repo_id, tag)
+        with LockedPulpRepository(self.p, repo_id):
+            self.p.updateRepo(repo_id, tag)
 
     def remove_image(self, repo_id, image):
         self.p.remove(repo_id, image)

--- a/atomic_reactor/pulp_util.py
+++ b/atomic_reactor/pulp_util.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2017 Red Hat, Inc
+Copyright (c) 2017, 2018 Red Hat, Inc
 All rights reserved.
 
 This software may be modified and distributed under the terms
@@ -8,17 +8,20 @@ of the BSD license. See the LICENSE file for details.
 
 from __future__ import print_function, unicode_literals
 
+import logging
 import os
 import re
+import time
 import warnings
 from collections import namedtuple
 
 try:
     import dockpulp
-
 except (ImportError, SyntaxError):
     dockpulp = None
-    import logging
+
+from atomic_reactor.constants import (LOCKEDPULPREPOSITORY_RETRIES,
+                                      LOCKEDPULPREPOSITORY_BACKOFF)
 
 
 PulpRepo = namedtuple('PulpRepo', ['registry_id', 'tags'])
@@ -27,6 +30,8 @@ PulpRepo = namedtuple('PulpRepo', ['registry_id', 'tags'])
 # which may result in tenths of messages: very annoying
 # with "module", it just prints one warning -- this should balance security and UX
 warnings.filterwarnings("module")
+
+logger = logging.getLogger(__name__)
 
 
 class PulpLogWrapper(object):
@@ -224,3 +229,60 @@ class PulpHandler(object):
 
     def get_pulp_instance(self):
         return self.pulp_instance
+
+
+class LockedPulpRepository(object):
+    """
+    Context manager for Pulp repository operations.
+
+    This context manager creates a 'lock' repository on entry, and
+    deletes the repository on exit.
+
+    Usage:
+
+    with LockedPulpRepository(handler, repo_id) as locked_repo:
+        locked_repo.set_image_tags(v1_image_id, tags)
+    """
+
+    def __init__(self, pulp, repo_id, prefix='lock-'):
+        self.pulp = pulp
+        self.repo_id = repo_id
+        self.prefix = prefix
+
+        self.retry_times = LOCKEDPULPREPOSITORY_RETRIES
+        self.retry_delay = LOCKEDPULPREPOSITORY_BACKOFF
+
+    def __enter__(self):
+        logger.info("creating lock repository %s%s", self.prefix, self.repo_id)
+        registry_id = 'lock/{}'.format(self.repo_id)
+        retry = 0
+        total_attempts = 1 + self.retry_times  # initial attempt plus retries
+        for counter in range(total_attempts):
+            if retry:
+                time.sleep(retry)
+
+            try:
+                self.pulp.createRepo(self.repo_id, None,
+                                     registry_id=registry_id,
+                                     is_origin=True,  # avoid origin-lock-...
+                                     prefix_with=self.prefix)
+                break
+            except dockpulp.errors.DockPulpError as exc:
+                if counter == self.retry_times:
+                    # This was the last chance; go ahead anyway. This
+                    # avoids a stale lock preventing builds.
+                    logging.info("got error, breaking lock: %s", exc)
+                else:
+                    logging.info("got error, will retry in %s: %s", retry, exc)
+                    retry = self.retry_delay * (2 ** counter)
+
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        repo_id = '%s%s' % (self.prefix, self.repo_id)
+        logger.info("deleting lock repository %s", repo_id)
+        try:
+            self.pulp.deleteRepo(repo_id)
+        except dockpulp.errors.DockPulpError as exc:
+            logging.info("ignoring error from lock repository deletion: %s",
+                         exc)

--- a/tests/plugins/test_pulp.py
+++ b/tests/plugins/test_pulp.py
@@ -89,6 +89,8 @@ def prepare(check_repo_retval=0, existing_layers=[],
       ]))
     (flexmock(dockpulp.Pulp)
      .should_receive('createRepo'))
+    (flexmock(dockpulp.Pulp)
+     .should_receive('deleteRepo'))
 
     image_count = len(workflow.tag_conf.images)
     if unsupported:

--- a/tests/plugins/test_pulp_tag.py
+++ b/tests/plugins/test_pulp_tag.py
@@ -96,6 +96,8 @@ def prepare(v1_image_ids={}):
     (flexmock(dockpulp.Pulp)
      .should_receive('createRepo'))
     (flexmock(dockpulp.Pulp)
+     .should_receive('deleteRepo'))
+    (flexmock(dockpulp.Pulp)
      .should_receive('upload')
      .with_args(unicode)).at_most().once()
     (flexmock(dockpulp.Pulp)

--- a/tests/stubs.py
+++ b/tests/stubs.py
@@ -19,6 +19,17 @@ class StubSource(object):
     path = ''
 
 
+class StubTagConf(object):
+    def __init__(self):
+        self.primary_images = []
+        self.unique_images = []
+        self.images = []
+
+    def set_images(self, images):
+        self.images = images
+        return self
+
+
 class StubInsideBuilder(object):
     """
     A test data builder for the InsideBuilder class.
@@ -41,6 +52,7 @@ class StubInsideBuilder(object):
         self.image = None
         self.image_id = None
         self.source = StubSource()
+        self.tag_conf = StubTagConf()
 
         self._inspection_data = None
 

--- a/tests/test_pulp_util.py
+++ b/tests/test_pulp_util.py
@@ -19,7 +19,8 @@ from atomic_reactor.util import ImageName
 import pytest
 import copy
 from flexmock import flexmock
-from tests.constants import INPUT_IMAGE, SOURCE, MOCK
+from tests.constants import SOURCE, MOCK
+from tests.stubs import StubInsideBuilder, StubTagConf
 if MOCK:
     from tests.docker_mock import mock_docker
 
@@ -37,27 +38,19 @@ except (ImportError):
 PulpRepo = namedtuple('PulpRepo', ['registry_id', 'tags'])
 
 
-class X(object):
-    image_id = INPUT_IMAGE
-    git_dockerfile_path = None
-    git_path = None
-    base_image = ImageName(repo="qwe", tag="asd")
-
-
 def prepare(testfile="test-image", check_repo_retval=0):
     if MOCK:
         mock_docker()
     tasker = DockerTasker()
     workflow = DockerBuildWorkflow(SOURCE, testfile)
-    setattr(workflow, 'builder', X())
-    setattr(workflow.builder, 'source', X())
-    setattr(workflow.builder.source, 'dockerfile_path', None)
-    setattr(workflow.builder.source, 'path', None)
-    setattr(workflow, 'tag_conf', X())
-    setattr(workflow.tag_conf, 'images', [ImageName(repo="image-name1"),
-                                          ImageName(namespace="prefix",
-                                                    repo="image-name2"),
-                                          ImageName(repo="image-name3", tag="asd")])
+    workflow.builder = StubInsideBuilder()
+    workflow.tag_conf = StubTagConf().set_images([
+        ImageName(repo="image-name1"),
+        ImageName(namespace="prefix",
+                  repo="image-name2"),
+        ImageName(repo="image-name3",
+                  tag="asd"),
+    ])
 
     # Mock dockpulp and docker
     dockpulp.Pulp = flexmock(dockpulp.Pulp)

--- a/tests/test_pulp_util.py
+++ b/tests/test_pulp_util.py
@@ -13,11 +13,13 @@ from collections import namedtuple
 
 from atomic_reactor.core import DockerTasker
 from atomic_reactor.inner import DockerBuildWorkflow
-from atomic_reactor.pulp_util import PulpHandler
+from atomic_reactor.pulp_util import PulpHandler, LockedPulpRepository
 from atomic_reactor.util import ImageName
+from atomic_reactor.constants import LOCKEDPULPREPOSITORY_RETRIES
 
 import pytest
 import copy
+import time
 from flexmock import flexmock
 from tests.constants import SOURCE, MOCK
 from tests.stubs import StubInsideBuilder, StubTagConf
@@ -294,3 +296,161 @@ def test_upload(unsupported, caplog):
     if unsupported:
         assert "Falling back to uploading %s to redhat-everything repo" %\
                upload_file in caplog.text()
+
+
+class TestLockedPulpRepository(object):
+    def test_lock_bad_params(self):
+        """
+        Should fail if 'prefix' is not a string
+        """
+        pulp = flexmock()
+        pulp.should_receive('createRepo').never()
+        pulp.should_receive('deleteRepo').never()
+        with pytest.raises(Exception):
+            with LockedPulpRepository(pulp, 'redhat-repo', prefix=None):
+                pass
+
+    @pytest.mark.parametrize(('repo_id', 'kwargs', 'expected_repo_id'), [
+        ('redhat-repo', {}, 'lock-redhat-repo'),
+        ('redhat-repo', {'prefix': 'locked-'}, 'locked-redhat-repo'),
+    ])
+    def test_lock_no_errors(self, repo_id, kwargs, expected_repo_id):
+        pulp = flexmock()
+
+        # First it should call createRepo()
+        createRepo_kwargs = {
+            'registry_id': object,  # don't care what this is
+            'is_origin': True,
+            'prefix_with': kwargs.get('prefix', 'lock-'),
+        }
+
+        (pulp
+         .should_receive('createRepo')
+         .with_args(repo_id, object, **createRepo_kwargs)
+         .once()
+         .ordered())
+
+        with LockedPulpRepository(pulp, repo_id, **kwargs) as lock:
+            assert isinstance(lock, LockedPulpRepository)
+
+            # Next, deleteRepo() -- but with the full repository id.
+            # Yes, dockpulp really works like this.
+            (pulp
+             .should_receive('deleteRepo')
+             .with_args(expected_repo_id)
+             .once()
+             .ordered())
+
+    @pytest.mark.skipif(dockpulp is None,
+                        reason='dockpulp module not available')
+    def test_lock_exception_create(self):
+        pulp = flexmock()
+        pulp.should_receive('createRepo').and_raise(RuntimeError).once()
+
+        with pytest.raises(RuntimeError):
+            with LockedPulpRepository(pulp, 'redhat-repo'):
+                assert False, "Should not get here"
+
+    @pytest.mark.skipif(dockpulp is None,
+                        reason='dockpulp module not available')
+    def test_lock_exception_delete_ignored(self):
+        """
+        dockpulp.errors.DockPulpError should be ignored when exiting the
+        context manager.
+        """
+        pulp = flexmock()
+        pulp.should_receive('createRepo').once().ordered()
+        (pulp
+         .should_receive('deleteRepo')
+         .and_raise(dockpulp.errors.DockPulpError('error deleting'))
+         .once()
+         .ordered())
+
+        with LockedPulpRepository(pulp, 'redhat-repo'):
+            pass
+
+    @pytest.mark.skipif(dockpulp is None,
+                        reason='dockpulp module not available')
+    def test_lock_exception_delete_raise(self):
+        """
+        Other exceptions from deleting should be propagated when exiting
+        the context manager.
+        """
+        pulp = flexmock()
+        pulp.should_receive('createRepo').once().ordered()
+        (pulp
+         .should_receive('deleteRepo')
+         .and_raise(RuntimeError)
+         .once()
+         .ordered())
+
+        entered = False
+        with pytest.raises(RuntimeError):
+            with LockedPulpRepository(pulp, 'redhat-repo'):
+                entered = True
+
+        assert entered
+
+    @pytest.mark.skipif(dockpulp is None,
+                        reason='dockpulp module not available')
+    def test_lock_exception_delete_propagate(self):
+        """
+        dockpulp.errors.DockPulpError raised within the context should be
+        propagated up the call stack.
+        """
+        pulp = flexmock()
+        pulp.should_receive('createRepo').once().ordered()
+        pulp.should_receive('deleteRepo').once().ordered()
+        entered = False
+        with pytest.raises(dockpulp.errors.DockPulpError):
+            with LockedPulpRepository(pulp, 'redhat-repo'):
+                entered = True
+                raise dockpulp.errors.DockPulpError('random error')
+
+        assert entered
+
+    @pytest.mark.skipif(dockpulp is None,
+                        reason='dockpulp module not available')
+    @pytest.mark.parametrize('failures', [2, 9])
+    def test_lock_retry(self, failures):
+        # Don't actually wait when retrying
+        flexmock(time).should_receive('sleep')
+
+        pulp = flexmock()
+        expectation = pulp.should_receive('createRepo').times(failures + 1)
+        exc = dockpulp.errors.DockPulpError('error creating')
+        for i in range(failures):
+            expectation = expectation.and_raise(exc).ordered()
+
+        expectation.and_return(None).ordered
+
+        pulp.should_receive('deleteRepo').once().ordered()
+
+        with LockedPulpRepository(pulp, 'redhat-repo'):
+            pass
+
+    @pytest.mark.skipif(dockpulp is None,
+                        reason='dockpulp module not available')
+    def test_lock_break(self):
+        class Elapsed(object):
+            def __init__(self):
+                self.seconds = 0
+
+            def sleep(self, s):
+                self.seconds += s
+
+        # Don't actually wait when retrying, just measure time
+        elapsed = Elapsed()
+        flexmock(time).should_receive('sleep').replace_with(elapsed.sleep)
+
+        pulp = flexmock()
+        (pulp
+         .should_receive('createRepo')
+         .times(LOCKEDPULPREPOSITORY_RETRIES + 1)
+         .and_raise(dockpulp.errors.DockPulpError('error creating')))
+
+        pulp.should_receive('deleteRepo').once().ordered()
+
+        with LockedPulpRepository(pulp, 'redhat-repo'):
+            # Should wait at least an hour before breaking the lock
+            assert elapsed.seconds > 60 * 60


### PR DESCRIPTION
This change introduces a new context manager, LockedPulpRepository, which locks operations on a Pulp repository by creating another repository, similar to the way a lock file works.

Signed-off-by: Tim Waugh <twaugh@redhat.com>