### PR TITLE
Fix test.sh when reusing a running test container

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -82,7 +82,8 @@ fi
 # Install latest osbs-client by installing dependencies from the master branch
 # and running pip install with '--no-deps' to avoid compilation
 # This would also ensure all the deps are specified in the spec
-$RUN rm -rf /tmp/osbs-client && $RUN git clone https://github.com/projectatomic/osbs-client /tmp/osbs-client
+$RUN rm -rf /tmp/osbs-client
+$RUN git clone https://github.com/projectatomic/osbs-client /tmp/osbs-client
 $RUN $BUILDDEP -y /tmp/osbs-client/osbs-client.spec
 $RUN $PIP install --upgrade --no-deps --force-reinstall git+https://github.com/projectatomic/osbs-client
 


### PR DESCRIPTION
Without this fix, reusing a running test container fails like this:
```
[...]
+ [[ 2 == 3 ]]
+ [[ fedora == centos ]]
+ docker exec -ti atomic-reactor-fedora-28-py2 rm -rf /tmp/osbs-client
+ docker exec -ti atomic-reactor-fedora-28-py2 dnf builddep -y /tmp/osbs-client/osbs-client.spec
Last metadata expiration check: 2:34:59 ago on Wed Jun 27 11:39:33 2018.
Failed to open: '/tmp/osbs-client/osbs-client.spec', not a valid spec file: can't parse specfile

Error: Some packages could not be found.
```