### PR TITLE
support for arch-override in scratch builds

### DIFF
--- a/atomic_reactor/plugins/pre_pull_base_image.py
+++ b/atomic_reactor/plugins/pre_pull_base_image.py
@@ -15,9 +15,9 @@ import docker
 
 from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.util import (get_build_json, get_manifest_list,
-                                 get_config_from_registry, ImageName)
-from atomic_reactor.constants import (PLUGIN_BUILD_ORCHESTRATE_KEY,
-                                      PLUGIN_CHECK_AND_SET_PLATFORMS_KEY)
+                                 get_config_from_registry, ImageName,
+                                 get_orchestrator_platforms)
+from atomic_reactor.constants import PLUGIN_CHECK_AND_SET_PLATFORMS_KEY
 from atomic_reactor.core import RetryGeneratorException
 from atomic_reactor.plugins.pre_reactor_config import (get_source_registry,
                                                        get_platform_to_goarch_mapping)
@@ -217,6 +217,4 @@ class PullBaseImagePlugin(PreBuildPlugin):
         if platforms:
             return platforms
 
-        for plugin in self.workflow.buildstep_plugins_conf or []:
-            if plugin['name'] == PLUGIN_BUILD_ORCHESTRATE_KEY:
-                return plugin['args']['platforms']
+        return get_orchestrator_platforms(self.workflow)

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -40,7 +40,8 @@ from atomic_reactor.constants import (DOCKERFILE_FILENAME, REPO_CONTAINER_CONFIG
                                       HTTP_CLIENT_STATUS_RETRY, HTTP_REQUEST_TIMEOUT,
                                       MEDIA_TYPE_DOCKER_V2_SCHEMA1, MEDIA_TYPE_DOCKER_V2_SCHEMA2,
                                       MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST, MEDIA_TYPE_OCI_V1,
-                                      MEDIA_TYPE_OCI_V1_INDEX, GIT_MAX_RETRIES, GIT_BACKOFF_FACTOR)
+                                      MEDIA_TYPE_OCI_V1_INDEX, GIT_MAX_RETRIES, GIT_BACKOFF_FACTOR,
+                                      PLUGIN_BUILD_ORCHESTRATE_KEY)
 
 from dockerfile_parse import DockerfileParser
 from pkg_resources import resource_stream
@@ -597,6 +598,12 @@ def is_isolated_build():
     except KeyError:
         logger.error('metadata.labels not found in build json')
         raise
+
+
+def get_orchestrator_platforms(workflow):
+    for plugin in workflow.buildstep_plugins_conf or []:
+        if plugin['name'] == PLUGIN_BUILD_ORCHESTRATE_KEY:
+            return plugin['args']['platforms']
 
 
 # copypasted and slightly modified from

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -590,6 +590,15 @@ def is_scratch_build():
         raise
 
 
+def is_isolated_build():
+    build_json = get_build_json()
+    try:
+        return build_json['metadata']['labels'].get('isolated', False)
+    except KeyError:
+        logger.error('metadata.labels not found in build json')
+        raise
+
+
 # copypasted and slightly modified from
 # http://stackoverflow.com/questions/1094841/reusable-library-to-get-human-readable-version-of-file-size/1094933#1094933
 def human_size(num, suffix='B'):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -39,6 +39,7 @@ from atomic_reactor.util import (ImageName, wait_for_command, clone_git_repo,
                                  registry_hostname, Dockercfg, RegistrySession,
                                  get_manifest_digests, ManifestDigest,
                                  get_manifest_list,
+                                 get_build_json, is_scratch_build, is_isolated_build, df_parser,
                                  get_build_json, is_scratch_build, df_parser,
                                  are_plugins_in_order, LabelFormatter,
                                  guess_manifest_media_type,
@@ -825,6 +826,23 @@ def test_is_scratch_build(build_json, scratch):
         assert is_scratch_build() == scratch
 
 
+@pytest.mark.parametrize(('build_json', 'isolated'), [
+    ({'metadata': {'labels': {'isolated': True}}}, True),
+    ({'metadata': {'labels': {'isolated': False}}}, False),
+    ({'metadata': {'labels': {}}}, False),
+    ({'metadata': {}}, None),
+    ({}, None),
+])
+def test_is_isolated_build(build_json, isolated):
+    flexmock(util).should_receive('get_build_json').and_return(build_json)
+    if isolated is None:
+        with pytest.raises(KeyError):
+            is_isolated_build()
+    else:
+        assert is_isolated_build() == isolated
+
+
+@pytest.mark.parametrize(('inputs', 'results'), [
 def test_df_parser(tmpdir):
     tmpdir_path = str(tmpdir.realpath())
     df = df_parser(tmpdir_path)


### PR DESCRIPTION
add support in pre_check_and_set_platforms to detect scratch and isolated builds. For those builds, if
the platform list from user_params is different than the list from koji_target, assume that the user_params list take priority.