### PR TITLE
input_osv3: validate plugins against a schema

### DIFF
--- a/atomic_reactor/plugins/input_osv3.py
+++ b/atomic_reactor/plugins/input_osv3.py
@@ -32,6 +32,9 @@ class OSv3InputPlugin(InputPlugin):
         from osbs.api import OSBS
         from osbs.conf import Configuration
 
+        # make sure the input json is valid
+        read_yaml(user_params, 'schemas/user_params.json')
+
         osbs_conf = Configuration(build_json_dir=json.loads(user_params).get('build_json_dir'))
         osbs = OSBS(osbs_conf, osbs_conf)
         return osbs.render_plugins_configuration(user_params)

--- a/atomic_reactor/plugins/input_osv3.py
+++ b/atomic_reactor/plugins/input_osv3.py
@@ -167,6 +167,8 @@ class OSv3InputPlugin(InputPlugin):
         self.log.debug("build json: %s", input_json)
 
         self.remove_plugins_without_parameters()
+        # make sure the final json is valid
+        read_yaml(json.dumps(self.plugins_json), 'schemas/plugins.json')
 
         return input_json
 

--- a/atomic_reactor/schemas/plugins.json
+++ b/atomic_reactor/schemas/plugins.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "title": "atomic-reactor plugins configuration",
+
+  "definitions": {
+    "base_plugins_phase": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {"type": "string"},
+          "args": {"type": "object"}
+        },
+        "required": ["name"]
+      }
+    },
+    "general_plugins_phase": {
+      "allOf": [
+        {"$ref": "#/definitions/base_plugins_phase"},
+        {
+          "properties": {
+            "is_allowed_to_fail": {"type": "boolean"},
+            "required": {"type": "boolean"}
+          }
+        }
+      ]
+    }
+  },
+  "type": ["object", "null"],
+  "properties": {
+    "prebuild_plugins": {"$ref": "#/definitions/general_plugins_phase"},
+    "buildstep_plugins": {"$ref": "#/definitions/base_plugins_phase"},
+    "postbuild_plugins": {"$ref": "#/definitions/general_plugins_phase"},
+    "prepublish_plugins": {"$ref": "#/definitions/general_plugins_phase"},
+    "exit_plugins": {"$ref": "#/definitions/general_plugins_phase"}
+  }
+}

--- a/atomic_reactor/schemas/user_params.json
+++ b/atomic_reactor/schemas/user_params.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "title": "atomic-reactor user params",
+
+  "type": ["object", "null"],
+  "properties": {
+    "arrangement_version": {"type": "integer"},
+    "base_image": {"type": "string"},
+    "build_from": {"type": "string"},
+    "build_image": {"type": "string"},
+    "build_imagestream": {"type": "string"},
+    "build_json_dir": {"type": "string"},
+    "build_type": {"enum": ["orchestrator", "worker"]},
+    "component": {"type": "string"},
+    "compose_ids": {
+      "type": "array",
+      "items": {"type": "integer"}
+    },
+    "customize_conf": {"type": "string"},
+    "filesystem_koji_task_id": {"type": "string"},
+    "flatpak": {"type": "boolean"},
+    "flatpak_base_image": {"type": "string"},
+    "git_branch": {"type": "string"},
+    "git_ref": {"type": "string"},
+    "git_uri": {"type": "string"},
+    "image_tag": {"type": "string"},
+    "imagestream_name": {"type": "string"},
+    "isolated": {"type": "boolean"},
+    "koji_parent_build": {"type": "string"},
+    "koji_target": {"type": "string"},
+    "koji_task_id": {"type": "integer"},
+    "koji_upload_dir": {"type": "string"},
+    "name": {"type": "string"},
+    "platform": {"type": "string"},
+    "platforms": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "reactor_config_map": {"type": "string"},
+    "reactor_config_override": {"type": "string"},
+    "release": {"type": "string"},
+    "scratch": {"type": "boolean"},
+    "signing_intent": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "trigger_imagestreamtag": {"type": "string"},
+    "user": {"type": "string"},
+    "yum_repourls": {
+      "type": "array",
+      "items": {"type": "string"}
+    }
+  },
+  "required": ["build_json_dir", "build_type", "git_ref", "git_uri", "user"]
+}

--- a/tests/plugins/test_input_osv3.py
+++ b/tests/plugins/test_input_osv3.py
@@ -92,6 +92,10 @@ def test_plugins_variable(plugins_variable, valid):
         mock_env.update({
             plugins_variable: json.dumps({
                 'build_json_dir': 'inputs',
+                'build_type': 'orchestrator',
+                'git_ref': 'test',
+                'git_uri': 'test',
+                'user': 'user'
             }),
         })
 
@@ -144,6 +148,10 @@ def test_remove_dockerfile_content():
 def test_remove_everything():
     plugins_json = {
         'build_json_dir': 'inputs',
+        'build_type': 'orchestrator',
+        'git_ref': 'test',
+        'git_uri': 'test',
+        'user': 'user',
         'prebuild_plugins': [
             {'name': 'before', },
             {'name': 'bump_release', },
@@ -204,6 +212,10 @@ def test_remove_everything():
 def test_remove_v1_pulp_and_exit_delete():
     plugins_json = {
         'build_json_dir': 'inputs',
+        'build_type': 'orchestrator',
+        'git_ref': 'test',
+        'git_uri': 'test',
+        'user': 'user',
         'postbuild_plugins': [
             {'name': 'before', },
             {'name': 'pulp_push', },
@@ -257,6 +269,10 @@ def test_remove_v1_pulp_and_exit_delete():
 def test_remove_v2_pulp():
     plugins_json = {
         'build_json_dir': 'inputs',
+        'build_type': 'orchestrator',
+        'git_ref': 'test',
+        'git_uri': 'test',
+        'user': 'user',
         'postbuild_plugins': [
             {'name': 'before', },
             {'name': 'pulp_sync', },


### PR DESCRIPTION
add a simple schema for plugins to schema and add a call to input_osv3
to validate the final plugins json against it.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>