### PR TITLE
input_osv3: fix for user_params schema

### DIFF
--- a/atomic_reactor/plugins/input_osv3.py
+++ b/atomic_reactor/plugins/input_osv3.py
@@ -34,6 +34,9 @@ class OSv3InputPlugin(InputPlugin):
 
         # make sure the input json is valid
         read_yaml(user_params, 'schemas/user_params.json')
+        reactor_config_override = json.loads(user_params).get('reactor_config_override')
+        if reactor_config_override:
+            read_yaml(json.dumps(reactor_config_override), 'schemas/config.json')
 
         osbs_conf = Configuration(build_json_dir=json.loads(user_params).get('build_json_dir'))
         osbs = OSBS(osbs_conf, osbs_conf)

--- a/atomic_reactor/schemas/user_params.json
+++ b/atomic_reactor/schemas/user_params.json
@@ -38,7 +38,7 @@
       "items": {"type": "string"}
     },
     "reactor_config_map": {"type": "string"},
-    "reactor_config_override": {"type": "string"},
+    "reactor_config_override": {"type": "object"},
     "release": {"type": "string"},
     "scratch": {"type": "boolean"},
     "signing_intent": {


### PR DESCRIPTION
worker build pass the entire json of the new reactor config in the
reactor_config_override, and the schema broke on that.

Rewrite the schema so that it expects reactor_config_override to be
a string if the buildtype is orchestrator, and an object if the
buildtype is worker.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>