### PR TITLE
Prevent repo name collision

### DIFF
--- a/atomic_reactor/plugins/pre_add_yum_repo_by_url.py
+++ b/atomic_reactor/plugins/pre_add_yum_repo_by_url.py
@@ -26,6 +26,7 @@ Example configuration to add content of repo file at URL:
 from atomic_reactor.constants import YUM_REPOS_DIR
 from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.util import get_retrying_requests_session
+from hashlib import md5
 import os
 import os.path
 
@@ -50,8 +51,18 @@ class YumRepo(object):
 
     @property
     def filename(self):
+        '''Returns the filename to be used for saving the repo file.
+
+        The filename is derived from the repo url by injecting a suffix
+        after the name and before the file extension. This suffix is a
+        partial md5 checksum of the full repourl. This avoids multiple
+        repos from being written to the same file.
+        '''
         urlpath = unquote(urlsplit(self.repourl, allow_fragments=False).path)
-        return os.path.basename(urlpath)
+        basename = os.path.basename(urlpath)
+        suffix = '-' + md5(self.repourl.encode('utf-8')).hexdigest()[:5]
+        final_name = suffix.join(os.path.splitext(basename))
+        return final_name
 
     @property
     def dst_filename(self):


### PR DESCRIPTION
When adding a yum repository by URL, save it to a unique filename.
Otherwise, the following two repo urls end up on the same file:
- http://yum.example.com/spam/compose.repo
- http://yum.example.com/bacon/compose.repo

NOTE: This PR includes a commit from https://github.com/projectatomic/atomic-reactor/pull/1038 because master is currently broken.