### PR TITLE
add support for include_unpublished_pulp_repos

### DIFF
--- a/atomic_reactor/odcs_util.py
+++ b/atomic_reactor/odcs_util.py
@@ -41,7 +41,8 @@ class ODCSClient(object):
 
         self.session = session
 
-    def start_compose(self, source_type, source, packages=None, sigkeys=None, arches=None):
+    def start_compose(self, source_type, source, packages=None, sigkeys=None, arches=None,
+                      flags=None):
         """Start a new ODCS compose
 
         :param source_type: str, the type of compose to request (tag, module, pulp)
@@ -71,6 +72,9 @@ class ODCSClient(object):
 
         if sigkeys is not None:
             body['source']['sigkeys'] = sigkeys
+
+        if flags is not None:
+            body['flags'] = flags
 
         if arches is not None:
             body['arches'] = arches

--- a/atomic_reactor/plugins/pre_resolve_composes.py
+++ b/atomic_reactor/plugins/pre_resolve_composes.py
@@ -25,6 +25,8 @@ from atomic_reactor.plugins.pre_reactor_config import (get_config,
 
 ODCS_DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 MINIMUM_TIME_TO_EXPIRE = timedelta(hours=2).total_seconds()
+# flag to let ODCS see hidden pulp repos
+UNPUBLISHED_REPOS = 'include_unpublished_pulp_repos'
 
 
 class ResolveComposesPlugin(PreBuildPlugin):
@@ -325,6 +327,9 @@ class ComposeConfig(object):
         self.pulp = {}
         if data.get('pulp_repos'):
             self.pulp = pulp_data or {}
+            self.flags = None
+            if data.get(UNPUBLISHED_REPOS):
+                self.flags = [UNPUBLISHED_REPOS]
         self.koji_tag = koji_tag
         self.odcs_config = odcs_config
         self.arches = arches
@@ -376,6 +381,7 @@ class ComposeConfig(object):
             'source_type': 'pulp',
             'source': ' '.join(self.pulp.get(arch, [])),
             'sigkeys': [],
+            'flags': self.flags,
             'arches': [arch]
         }
 

--- a/tests/test_odcs_util.py
+++ b/tests/test_odcs_util.py
@@ -86,7 +86,12 @@ def compose_json(state, state_name, source_type='module', source=MODULE_NSV,
     ('my-tag', 'tag', ['spam', 'bacon', 'eggs'], ""),
     ('my-tag', 'tag', ['spam', 'bacon', 'eggs'], []),
 ))
-def test_create_compose(odcs_client, source, source_type, packages, sigkeys, arches):
+@pytest.mark.parametrize('flags', (
+    None,
+    ['no_deps'],
+    ['breakfast', 'lunch'],
+))
+def test_create_compose(odcs_client, source, source_type, packages, sigkeys, arches, flags):
 
     def handle_composes_post(request):
         assert_request_token(request, odcs_client.session)
@@ -101,6 +106,7 @@ def test_create_compose(odcs_client, source, source_type, packages, sigkeys, arc
         assert body_json['source']['source'] == source
         assert body_json['source'].get('packages') == packages
         assert body_json['source'].get('sigkeys') == sigkeys
+        assert body_json.get('flags') == flags
         assert body_json.get('arches') == arches
         return (200, {}, compose_json(0, 'wait', source_type=source_type, source=source))
 
@@ -109,7 +115,7 @@ def test_create_compose(odcs_client, source, source_type, packages, sigkeys, arc
                            callback=handle_composes_post)
 
     odcs_client.start_compose(source_type=source_type, source=source, packages=packages,
-                              sigkeys=sigkeys, arches=arches)
+                              sigkeys=sigkeys, arches=arches, flags=flags)
 
 
 @responses.activate


### PR DESCRIPTION
add support in odcs_utils for passing flags to a compose
add support in pre_resolve_composes for retrieving the include_unpublished_pulp_repos when doing a pulp_compose and passing that flag, if set, to odcs_utils