### PR TITLE
Clean up platform handling and restrict platforms by enabled clusters

### DIFF
--- a/atomic_reactor/plugins/post_pulp_pull.py
+++ b/atomic_reactor/plugins/post_pulp_pull.py
@@ -17,14 +17,13 @@ from __future__ import unicode_literals
 
 from atomic_reactor.constants import (PLUGIN_PULP_PUSH_KEY, PLUGIN_PULP_SYNC_KEY,
                                       PLUGIN_GROUP_MANIFESTS_KEY,
-                                      PLUGIN_CHECK_AND_SET_PLATFORMS_KEY,
                                       MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_SCHEMA1,
                                       MEDIA_TYPE_DOCKER_V2_SCHEMA2,
                                       MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST)
 
 from atomic_reactor.plugin import PostBuildPlugin, ExitPlugin
 from atomic_reactor.plugins.exit_remove_built_image import defer_removal
-from atomic_reactor.util import get_manifest_digests
+from atomic_reactor.util import get_manifest_digests, get_platforms
 from atomic_reactor.plugins.pre_reactor_config import (get_prefer_schema1_digest,
                                                        get_platform_to_goarch_mapping)
 import requests
@@ -189,10 +188,10 @@ class PulpPullPlugin(ExitPlugin, PostBuildPlugin):
         if self.workflow.postbuild_results.get(PLUGIN_GROUP_MANIFESTS_KEY):
             self.expect_v2schema2list = True
 
-            platforms = self.workflow.prebuild_results.get(PLUGIN_CHECK_AND_SET_PLATFORMS_KEY)
+            platforms = get_platforms(self.workflow)
             if not platforms:
                 self.log.debug('Cannot check if only manifest list digest should be checked '
-                               'because %s plugin did not run', PLUGIN_CHECK_AND_SET_PLATFORMS_KEY)
+                               'because we have no platforms list')
                 return
 
             try:

--- a/atomic_reactor/plugins/pre_check_and_set_platforms.py
+++ b/atomic_reactor/plugins/pre_check_and_set_platforms.py
@@ -56,7 +56,7 @@ class CheckAndSetPlatformsPlugin(PreBuildPlugin):
 
         if is_scratch_build() or is_isolated_build():
             override_platforms = get_orchestrator_platforms(self.workflow)
-            if override_platforms and set(override_platforms) != koji_platforms:
+            if override_platforms and set(override_platforms) != set(platforms):
                 # platforms from user params do not match platforms from koji target
                 # that almost certainly means they were overridden and should be used
                 return set(override_platforms)

--- a/atomic_reactor/plugins/pre_check_and_set_platforms.py
+++ b/atomic_reactor/plugins/pre_check_and_set_platforms.py
@@ -25,7 +25,7 @@ class CheckAndSetPlatformsPlugin(PreBuildPlugin):
     key = PLUGIN_CHECK_AND_SET_PLATFORMS_KEY
     is_allowed_to_fail = False
 
-    def __init__(self, tasker, workflow, koji_target):
+    def __init__(self, tasker, workflow, koji_target=None):
 
         """
         constructor
@@ -42,23 +42,26 @@ class CheckAndSetPlatformsPlugin(PreBuildPlugin):
         """
         run the plugin
         """
-        koji_session = get_koji_session(self.workflow, NO_FALLBACK)
-        self.log.info("Checking koji target for platforms")
-        event_id = koji_session.getLastEvent()['id']
-        target_info = koji_session.getBuildTarget(self.koji_target, event=event_id)
-        build_tag = target_info['build_tag']
-        koji_build_conf = koji_session.getBuildConfig(build_tag, event=event_id)
-        koji_platforms = koji_build_conf['arches']
-        if not koji_platforms:
-            self.log.info("No platforms found in koji target")
-            return None
-        platforms = koji_platforms.split()
+        if self.koji_target:
+            koji_session = get_koji_session(self.workflow, NO_FALLBACK)
+            self.log.info("Checking koji target for platforms")
+            event_id = koji_session.getLastEvent()['id']
+            target_info = koji_session.getBuildTarget(self.koji_target, event=event_id)
+            build_tag = target_info['build_tag']
+            koji_build_conf = koji_session.getBuildConfig(build_tag, event=event_id)
+            koji_platforms = koji_build_conf['arches']
+            if not koji_platforms:
+                self.log.info("No platforms found in koji target")
+                return None
+            platforms = koji_platforms.split()
 
-        if is_scratch_build() or is_isolated_build():
-            override_platforms = get_orchestrator_platforms(self.workflow)
-            if override_platforms and set(override_platforms) != set(platforms):
-                # platforms from user params do not match platforms from koji target
-                # that almost certainly means they were overridden and should be used
-                return set(override_platforms)
+            if is_scratch_build() or is_isolated_build():
+                override_platforms = get_orchestrator_platforms(self.workflow)
+                if override_platforms and set(override_platforms) != set(platforms):
+                    # platforms from user params do not match platforms from koji target
+                    # that almost certainly means they were overridden and should be used
+                    return set(override_platforms)
+        else:
+            platforms = get_orchestrator_platforms(self.workflow)
 
         return get_platforms_in_limits(self.workflow, platforms)

--- a/atomic_reactor/plugins/pre_pull_base_image.py
+++ b/atomic_reactor/plugins/pre_pull_base_image.py
@@ -22,8 +22,7 @@ import platform
 from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.util import (get_build_json, get_manifest_list,
                                  get_config_from_registry, ImageName,
-                                 get_orchestrator_platforms)
-from atomic_reactor.constants import PLUGIN_CHECK_AND_SET_PLATFORMS_KEY
+                                 get_platforms)
 from atomic_reactor.core import RetryGeneratorException
 from atomic_reactor.plugins.pre_reactor_config import (get_source_registry,
                                                        get_platform_to_goarch_mapping,
@@ -235,7 +234,7 @@ class PullBaseImagePlugin(PreBuildPlugin):
 
     def _validate_platforms_in_image(self, image):
         """Ensure that the image provides all platforms expected for the build."""
-        expected_platforms = self._get_expected_platforms()
+        expected_platforms = get_platforms(self.workflow)
         if not expected_platforms:
             self.log.info('Skipping validation of available platforms '
                           'because expected platforms are unknown')
@@ -275,11 +274,3 @@ class PullBaseImagePlugin(PreBuildPlugin):
             'Missing arches in manifest list for base image'
 
         self.log.info('Base image is a manifest list for all required platforms')
-
-    def _get_expected_platforms(self):
-        """retrieve expected platforms configured for this build"""
-        platforms = self.workflow.prebuild_results.get(PLUGIN_CHECK_AND_SET_PLATFORMS_KEY)
-        if platforms:
-            return platforms
-
-        return get_orchestrator_platforms(self.workflow)

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -615,9 +615,8 @@ def get_platforms(workflow):
     if koji_platforms:
         return koji_platforms
 
-    # if check_and_set_platforms didn't run, or didn't get any platforms from koji
-    # determine platforms from USER_PARAMS platforms parameter
-    return get_platforms_in_limits(self.workflow, get_orchestrator_platforms())
+    # Not an orchestrator build
+    return None
 
 
 # copypasted and slightly modified from

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -41,7 +41,9 @@ from atomic_reactor.constants import (DOCKERFILE_FILENAME, REPO_CONTAINER_CONFIG
                                       MEDIA_TYPE_DOCKER_V2_SCHEMA1, MEDIA_TYPE_DOCKER_V2_SCHEMA2,
                                       MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST, MEDIA_TYPE_OCI_V1,
                                       MEDIA_TYPE_OCI_V1_INDEX, GIT_MAX_RETRIES, GIT_BACKOFF_FACTOR,
-                                      PLUGIN_BUILD_ORCHESTRATE_KEY, PLUGIN_KOJI_PARENT_KEY,
+                                      PLUGIN_BUILD_ORCHESTRATE_KEY,
+                                      PLUGIN_CHECK_AND_SET_PLATFORMS_KEY,
+                                      PLUGIN_KOJI_PARENT_KEY,
                                       PARENT_IMAGE_BUILDS_KEY, PARENT_IMAGES_KOJI_BUILDS,
                                       BASE_IMAGE_KOJI_BUILD, BASE_IMAGE_BUILD_ID_KEY)
 
@@ -606,6 +608,16 @@ def get_orchestrator_platforms(workflow):
     for plugin in workflow.buildstep_plugins_conf or []:
         if plugin['name'] == PLUGIN_BUILD_ORCHESTRATE_KEY:
             return plugin['args']['platforms']
+
+
+def get_platforms(workflow):
+    koji_platforms = workflow.prebuild_results.get(PLUGIN_CHECK_AND_SET_PLATFORMS_KEY)
+    if koji_platforms:
+        return koji_platforms
+
+    # if check_and_set_platforms didn't run, or didn't get any platforms from koji
+    # determine platforms from USER_PARAMS platforms parameter
+    return get_platforms_in_limits(self.workflow, get_orchestrator_platforms())
 
 
 # copypasted and slightly modified from

--- a/tests/plugins/test_check_and_set_platforms.py
+++ b/tests/plugins/test_check_and_set_platforms.py
@@ -66,6 +66,24 @@ class MockSource(object):
         return self.path, self.path
 
 
+class MockClusterConfig(object):
+    enabled = True
+
+
+class MockConfig(object):
+    def __init__(self, platforms):
+        if platforms:
+            self.platforms = set(platforms.split())
+        else:
+            self.platforms = ['x86_64']
+
+    def get_enabled_clusters_for_platform(self, platform):
+        if platform in self.platforms:
+            return MockClusterConfig
+        else:
+            return []
+
+
 def write_container_yaml(tmpdir, platform_exclude='', platform_only=''):
     platforms_dict = {}
     if platform_exclude != '':
@@ -132,6 +150,9 @@ def test_check_and_set_platforms(tmpdir, platforms, platform_exclude, platform_o
     flexmock(reactor_config).should_receive('get_koji').and_return(mock_koji_config)
     flexmock(koji_util).should_receive('create_koji_session').and_return(session)
 
+    mock_config = MockConfig(platforms)
+    flexmock(reactor_config).should_receive('get_config').and_return(mock_config)
+
     runner = PreBuildPluginsRunner(tasker, workflow, [{
         'name': PLUGIN_CHECK_AND_SET_PLATFORMS_KEY,
         'args': {'koji_target': KOJI_TARGET},
@@ -177,6 +198,9 @@ def test_check_isolated_or_scratch(tmpdir, labels, platforms,
     flexmock(reactor_config).should_receive('get_koji').and_return(mock_koji_config)
     flexmock(koji_util).should_receive('create_koji_session').and_return(session)
 
+    mock_config = MockConfig(platforms)
+    flexmock(reactor_config).should_receive('get_config').and_return(mock_config)
+
     runner = PreBuildPluginsRunner(tasker, workflow, [{
         'name': PLUGIN_CHECK_AND_SET_PLATFORMS_KEY,
         'args': {'koji_target': KOJI_TARGET},
@@ -205,6 +229,42 @@ def test_check_and_set_platforms_no_koji(tmpdir, platforms, platform_only, resul
 
     build_json = {'metadata': {'labels': {}}}
     flexmock(util).should_receive('get_build_json').and_return(build_json)
+
+    mock_config = MockConfig(platforms)
+    flexmock(reactor_config).should_receive('get_config').and_return(mock_config)
+
+    runner = PreBuildPluginsRunner(tasker, workflow, [{
+        'name': PLUGIN_CHECK_AND_SET_PLATFORMS_KEY,
+    }])
+
+    if platforms:
+        plugin_result = runner.run()
+        assert plugin_result[PLUGIN_CHECK_AND_SET_PLATFORMS_KEY]
+        assert plugin_result[PLUGIN_CHECK_AND_SET_PLATFORMS_KEY] == set(result)
+    else:
+        with pytest.raises(Exception) as e:
+            plugin_result = runner.run()
+            assert "no koji target or platform list" in str(e)
+
+
+@pytest.mark.parametrize(('platforms', 'platform_only', 'cluster_platforms', 'result'), [
+    ('x86_64 ppc64le', '', 'x86_64', ['x86_64']),
+    ('x86_64 ppc64le arm64', ['x86_64', 'arm64'], 'x86_64', ['x86_64']),
+])
+def test_platforms_from_cluster_config(tmpdir, platforms, platform_only,
+                                       cluster_platforms, result):
+    write_container_yaml(tmpdir, platform_only=platform_only)
+
+    tasker, workflow = prepare(tmpdir)
+
+    if platforms:
+        set_orchestrator_platforms(workflow, platforms.split())
+
+    build_json = {'metadata': {'labels': {}}}
+    flexmock(util).should_receive('get_build_json').and_return(build_json)
+
+    mock_config = MockConfig(cluster_platforms)
+    flexmock(reactor_config).should_receive('get_config').and_return(mock_config)
 
     runner = PreBuildPluginsRunner(tasker, workflow, [{
         'name': PLUGIN_CHECK_AND_SET_PLATFORMS_KEY,

--- a/tests/plugins/test_check_and_set_platforms.py
+++ b/tests/plugins/test_check_and_set_platforms.py
@@ -136,20 +136,29 @@ def test_check_and_set_platforms(tmpdir, platforms, platform_exclude, platform_o
         assert plugin_result[PLUGIN_CHECK_AND_SET_PLATFORMS_KEY] is None
 
 
-@pytest.mark.parametrize(('labels', 'platforms', 'orchestrator_platforms', 'result'), [
-    ({}, None, None, None),
-    ({}, 'x86_64 arm64', ['spam', 'bacon'], ['arm64', 'x86_64']),
-    ({'isolated': True}, 'spam bacon', ['x86_64', 'arm64'], ['arm64', 'x86_64']),
-    ({'isolated': True}, 'x86_64 arm64', None, ['arm64', 'x86_64']),
-    ({'isolated': True}, None, ['x86_64', 'arm64'], None),
-    ({'scratch': True}, 'spam bacon', ['x86_64', 'arm64'], ['arm64', 'x86_64']),
-    ({'scratch': True}, 'x86_64 arm64', None, ['arm64', 'x86_64']),
-    ({'scratch': True}, None, ['x86_64', 'arm64'], None),
+@pytest.mark.parametrize(('labels', 'platforms', 'orchestrator_platforms', 'platform_only',
+                          'result'), [
+    ({}, None, None, '', None),
+    ({}, 'x86_64 arm64', ['spam', 'bacon'], '', ['arm64', 'x86_64']),
+    ({'isolated': True}, 'spam bacon', ['x86_64', 'arm64'], '', ['arm64', 'x86_64']),
+    ({'isolated': True}, 'x86_64 arm64', None, '', ['arm64', 'x86_64']),
+    ({'isolated': True}, None, ['x86_64', 'arm64'], '', None),
+    ({'scratch': True}, 'spam bacon', ['x86_64', 'arm64'], '', ['arm64', 'x86_64']),
+    ({'scratch': True}, 'x86_64 arm64', None, '', ['arm64', 'x86_64']),
+    ({'scratch': True}, None, ['x86_64', 'arm64'], '', None),
+    ({'scratch': True}, 'x86_64 arm64', ['x86_64', 'arm64'], 'x86_64', ['x86_64']),
+    ({'scratch': True}, 'x86_64 arm64 s390x', ['x86_64', 'arm64'], 'x86_64', ['x86_64', 'arm64']),
 ])
-def test_check_isolated_or_scratch(tmpdir, labels, platforms, orchestrator_platforms, result):
+def test_check_isolated_or_scratch(tmpdir, labels, platforms,
+                                   orchestrator_platforms, platform_only, result):
+    platforms_dict = {}
+    if platform_only != '':
+        platforms_dict['platforms'] = {}
+        platforms_dict['platforms']['only'] = platform_only
+
     container_path = os.path.join(str(tmpdir), REPO_CONTAINER_CONFIG)
     with open(container_path, 'w') as f:
-        f.write(yaml.safe_dump({}))
+        f.write(yaml.safe_dump(platforms_dict))
         f.flush()
 
     tasker, workflow = prepare(tmpdir)

--- a/tests/plugins/test_orchestrate_build.py
+++ b/tests/plugins/test_orchestrate_build.py
@@ -762,6 +762,8 @@ def test_orchestrate_build_choose_clusters(tmpdir, clusters_x86_64,
         assert plat_annotations['build']['cluster-url'] == 'https://chosen_{}.com/'.format(plat)
 
 
+# This test tests code paths that can no longer be hit in actual operation since
+# we exclude platforms with no clusters in check_and_set_platforms.
 def test_orchestrate_build_unknown_platform(tmpdir, reactor_config_map):  # noqa
     workflow = mock_workflow(tmpdir, platforms=['x86_64', 'spam'])
     mock_osbs()

--- a/tests/plugins/test_pull_base_image.py
+++ b/tests/plugins/test_pull_base_image.py
@@ -377,20 +377,6 @@ class TestValidateBaseImage(object):
                                     check_platforms=True)
         assert log_message in caplog.text()
 
-    def test_manifest_list_fallback_to_orchestrate_build_args(self, caplog):
-
-        def workflow_callback(workflow):
-            self.prepare(workflow)
-            del workflow.prebuild_results[PLUGIN_CHECK_AND_SET_PLATFORMS_KEY]
-            return workflow
-
-        log_message = 'manifest list for all required platforms'
-        test_pull_base_image_plugin(LOCALHOST_REGISTRY, BASE_IMAGE,
-                                    [], [], reactor_config_map=True,
-                                    workflow_callback=workflow_callback,
-                                    check_platforms=True)
-        assert log_message in caplog.text()
-
     def test_expected_platforms_unknown(self, caplog):
 
         def workflow_callback(workflow):

--- a/tests/plugins/test_resolve_composes.py
+++ b/tests/plugins/test_resolve_composes.py
@@ -267,10 +267,6 @@ class TestResolveComposes(object):
         workflow.buildstep_plugins_conf[0]['args']['platforms'] = arches
         self.run_plugin_with_args(workflow, reactor_config_map=reactor_config_map)
 
-    def test_request_compose_fallback(self, workflow, reactor_config_map):  # noqa:F811
-        del workflow.prebuild_results[PLUGIN_CHECK_AND_SET_PLATFORMS_KEY]
-        self.run_plugin_with_args(workflow, reactor_config_map=reactor_config_map)
-
     def test_request_compose_for_modules(self, workflow, reactor_config_map):  # noqa:F811
         repo_config = dedent("""\
             compose:
@@ -360,8 +356,10 @@ class TestResolveComposes(object):
         for flag in flags:
             repo_config += ("    {0}: {1}\n".format(flag, flags[flag]))
         mock_repo_config(workflow._tmpdir, repo_config)
-        del workflow.prebuild_results[PLUGIN_CHECK_AND_SET_PLATFORMS_KEY]
-        workflow.buildstep_plugins_conf[0]['args']['platforms'] = arches
+        if arches:
+            workflow.prebuild_results[PLUGIN_CHECK_AND_SET_PLATFORMS_KEY] = set(arches)
+        else:
+            del workflow.prebuild_results[PLUGIN_CHECK_AND_SET_PLATFORMS_KEY]
         tag_compose = deepcopy(ODCS_COMPOSE)
 
         sig_keys = SIGNING_INTENTS[signing_intent]

--- a/tests/plugins/test_resolve_composes.py
+++ b/tests/plugins/test_resolve_composes.py
@@ -370,7 +370,7 @@ class TestResolveComposes(object):
             tag_compose['arches'] = ' '.join(arches)
             (flexmock(ODCSClient)
                 .should_receive('start_compose')
-                .with_args(source_type='tag', source=KOJI_TAG_NAME, arches=arches,
+                .with_args(source_type='tag', source=KOJI_TAG_NAME, arches=sorted(arches),
                            packages=['spam', 'bacon', 'eggs'], sigkeys=sig_keys)
                 .and_return(tag_compose).once())
         else:


### PR DESCRIPTION
The main point of this pull request is to drop (with a warning) platforms that aren't in the enabled set of clusters. This is useful because the koji_target is used for two things:

 * The package set as implemented by the 'koji' plugin
 * The list of architectures

If the koji_target for the package set you want to use has architectures that aren't enabled for OSBS, this prevents that from causing failures.

To implement this robustly, the PR consolidates handling of platforms to check_and_set_platforms, and assumes that it *will* be run even in the (unusual) case of no koji_target. I'll follow up with a PR to osbs-client to implement that.

A number of test cases are removed because they were testing the same things going through different code paths and don't make sense or don't work now that the handling is consolidated.