### PR TITLE
Explicitly enable modules to install into a Flatpak

### DIFF
--- a/atomic_reactor/plugins/pre_resolve_module_compose.py
+++ b/atomic_reactor/plugins/pre_resolve_module_compose.py
@@ -57,10 +57,12 @@ class ComposeInfo(object):
     def koji_metadata(self):
         sorted_modules = [self.modules[k] for k in sorted(self.modules.keys())]
 
+        # We exclude the 'platform' pseudo-module here since we don't enable
+        # it for package installation - it doesn't influence the image contents
         return {
             'source_modules': [self.source_spec],
             'modules': ['-'.join((m.name, m.stream, m.version)) for
-                        m in sorted_modules]
+                        m in sorted_modules if m.name != 'platform']
         }
 
 

--- a/tests/flatpak.py
+++ b/tests/flatpak.py
@@ -11,12 +11,46 @@ try:
 except ImportError:
     MODULEMD_AVAILABLE = False
 
+PLATFORM_MODULEMD = """
+document: modulemd
+version: 2
+data:
+  name: platform
+  stream: f28
+  version: 5
+  context: 00000000
+  summary: Fedora 29 traditional base
+  description: >-
+    Fedora 29 traditional base
+  license:
+    module:
+    - MIT
+  xmd:
+    mbs:
+      mse: TRUE
+      commit: f28
+      buildrequires: {}
+      koji_tag: module-f28-build
+      requires: {}
+  dependencies:
+  - {}
+  profiles:
+    buildroot:
+      rpms:
+      - bash
+    srpm-buildroot:
+      rpms:
+      - bash
+  buildopts:
+    rpms: {}
+"""
+
 FLATPAK_APP_MODULEMD = """
 document: modulemd
 version: 2
 data:
   name: eog
-  stream: f26
+  stream: f28
   version: 20170629213428
   summary: Eye of GNOME Application Module
   description: The Eye of GNOME image viewer (eog) is the official image viewer for
@@ -111,9 +145,9 @@ data:
       gnome-desktop3, libepoxy, hunspell, libgusb, glib2, enchant, at-spi2-atk]
   dependencies:
   - buildrequires:
-      flatpak-runtime: [f28]
+      platform: [f28]
     requires:
-      flatpak-runtime: [f28]
+      platform: [f28]
   license:
     module: [MIT]
   profiles:
@@ -202,15 +236,21 @@ APP_CONFIG = {
     'base_module': 'eog',
     'modules': {
         'eog': {
-            'stream': 'f26',
+            'stream': 'f28',
             'version': '20170629213428',
             'metadata': FLATPAK_APP_MODULEMD,
             'rpms': FLATPAK_APP_RPMS,
         },
         'flatpak-runtime': {
-            'stream': 'f26',
+            'stream': 'f28',
             'version': '20170701152209',
             'metadata': FLATPAK_RUNTIME_MODULEMD,
+            'rpms': [],  # We don't use this currently
+        },
+        'platform': {
+            'stream': 'f28',
+            'version': '5',
+            'metadata': PLATFORM_MODULEMD,
             'rpms': [],  # We don't use this currently
         },
     },
@@ -221,9 +261,15 @@ RUNTIME_CONFIG = {
     'base_module': 'flatpak-runtime',
     'modules': {
         'flatpak-runtime': {
-            'stream': 'f26',
+            'stream': 'f28',
             'version': '20170629185228',
             'metadata': FLATPAK_RUNTIME_MODULEMD,
+            'rpms': [],  # We don't use this currently
+        },
+        'platform': {
+            'stream': 'f28',
+            'version': '5',
+            'metadata': PLATFORM_MODULEMD,
             'rpms': [],  # We don't use this currently
         },
     },
@@ -235,9 +281,15 @@ SDK_CONFIG = {
     'profile': 'sdk',
     'modules': {
         'flatpak-runtime': {
-            'stream': 'f26',
+            'stream': 'f28',
             'version': '20170629185228',
             'metadata': FLATPAK_RUNTIME_MODULEMD,
+            'rpms': [],  # We don't use this currently
+        },
+        'platform': {
+            'stream': 'f28',
+            'version': '5',
+            'metadata': PLATFORM_MODULEMD,
             'rpms': [],  # We don't use this currently
         },
     },

--- a/tests/plugins/test_koji_import.py
+++ b/tests/plugins/test_koji_import.py
@@ -1532,9 +1532,9 @@ class TestKojiImport(object):
         assert isinstance(image, dict)
 
         assert image.get('flatpak') is True
-        assert image.get('modules') == ['eog-f26-20170629213428',
-                                        'flatpak-runtime-f26-20170701152209']
-        assert image.get('source_modules') == ['eog:f26']
+        assert image.get('modules') == ['eog-f28-20170629213428',
+                                        'flatpak-runtime-f28-20170701152209']
+        assert image.get('source_modules') == ['eog:f28']
 
     @pytest.mark.parametrize(('config', 'expected'), [
         ({'pulp_push': False,

--- a/tests/plugins/test_koji_promote.py
+++ b/tests/plugins/test_koji_promote.py
@@ -1454,9 +1454,9 @@ class TestKojiPromote(object):
         assert isinstance(image, dict)
 
         assert image.get('flatpak') is True
-        assert image.get('modules') == ['eog-f26-20170629213428',
-                                        'flatpak-runtime-f26-20170701152209']
-        assert image.get('source_modules') == ['eog:f26']
+        assert image.get('modules') == ['eog-f28-20170629213428',
+                                        'flatpak-runtime-f28-20170701152209']
+        assert image.get('source_modules') == ['eog:f28']
 
     @pytest.mark.parametrize('logs_return_bytes', [
         True,


### PR DESCRIPTION
Versions of DNF in Fedora 28 and later understand modular content, and won't install packages from modules unless the modules are enabled. So to support (and require) using a newer base_image,
explicitly 'dnf module enable' the modules from the compose we generated before installing packages. It's necessary to exclude the 'platform' pseudo-module from this, so update test data so we can test this exclusion.