### PR TITLE
flatpak_create_oci: Fix docker compatibility issues

### DIFF
--- a/atomic_reactor/plugins/prepub_flatpak_create_oci.py
+++ b/atomic_reactor/plugins/prepub_flatpak_create_oci.py
@@ -261,7 +261,10 @@ class FlatpakCreateOciPlugin(PrePublishPlugin):
     def _export_filesystem(self):
         image = self.workflow.image
         self.log.info("Creating temporary docker container")
-        container_dict = self.tasker.d.create_container(image)
+        # The command here isn't used, since we only use the container for export,
+        # but (in some circumstances) the docker daemon will error out if no
+        # command is specified.
+        container_dict = self.tasker.d.create_container(image, command=["/bin/bash"])
         container_id = container_dict['Id']
 
         try:

--- a/tests/plugins/test_flatpak_create_oci.py
+++ b/tests/plugins/test_flatpak_create_oci.py
@@ -723,7 +723,7 @@ def test_flatpak_create_oci(tmpdir, docker_tasker, config_name, breakage, mock_f
 
     (flexmock(docker_tasker.d.wrapped)
      .should_receive('create_container')
-     .with_args(workflow.image)
+     .with_args(workflow.image, command=["/bin/bash"])
      .and_return({'Id': CONTAINER_ID}))
     (flexmock(docker_tasker.d.wrapped)
      .should_receive('export')


### PR DESCRIPTION
This patch fixes two issues found when testing Flatpak support in a Fedora 28 environment:

 * Errors from create_container() when no command is provided
 * ApiClient.export() returning a generator instead of a file-like object

I can't point to the exact upstream change for either. The first should be safely compatible with old versions as well, the second may not be, but should be fine in the places where we're actually going to use this  code for Flatpak creation.
