### PR TITLE
flatpak_create_dockerfile: create a skeleton /dev in the installroot

### DIFF
--- a/atomic_reactor/plugins/pre_flatpak_create_dockerfile.py
+++ b/atomic_reactor/plugins/pre_flatpak_create_dockerfile.py
@@ -37,6 +37,10 @@ LABEL version="{stream}"
 LABEL release="{version}"
 
 ADD atomic-reactor-includepkgs /tmp/
+
+RUN mkdir -p /var/tmp/flatpak-build/dev && \
+    for i in null zero random urandom ; do cp -a /dev/$i /var/tmp/flatpak-build/dev ; done
+
 RUN cat /tmp/atomic-reactor-includepkgs >> /etc/dnf/dnf.conf && \\
     dnf -y --nogpgcheck \\
     --disablerepo=* \\


### PR DESCRIPTION
rpm scripts that are being run in the installroot to create the Flatpak
filesystem may access certain standard files in /dev - create a very
small /dev/ to make such scripts work reliably. See, for example:
https://bugzilla.redhat.com/show_bug.cgi?id=1614162#c3