### PR TITLE
long term fix for ImageNames without tags

### DIFF
--- a/atomic_reactor/core.py
+++ b/atomic_reactor/core.py
@@ -509,7 +509,7 @@ class DockerTasker(LastLogger):
         """
         logger.info("pulling image '%s' from registry", image)
         logger.debug("image = '%s', insecure = '%s'", image, insecure)
-        tag = image.tag or 'latest'
+        tag = image.tag
         try:
             command_result = self.retry_generator(self.d.pull,
                                                   image.to_str(tag=False),

--- a/atomic_reactor/plugins/exit_pulp_publish.py
+++ b/atomic_reactor/plugins/exit_pulp_publish.py
@@ -94,7 +94,7 @@ class PulpPublishPlugin(ExitPlugin):
         pulp_registry = self.pulp_handler.get_registry_hostname()
         crane_repos = [ImageName(registry=pulp_registry,
                                  repo=image.to_str(registry=False, tag=False),
-                                 tag=image.tag or 'latest') for image in image_names]
+                                 tag=image.tag) for image in image_names]
 
         for image_name in crane_repos:
             self.log.info("image available at %s", str(image_name))

--- a/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
+++ b/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
@@ -139,7 +139,7 @@ class StoreMetadataInOSv3Plugin(ExitPlugin):
                         pullspecs.append({
                             "registry": registry.uri,
                             "repository": image.to_str(registry=False, tag=False),
-                            "tag": image.tag or 'latest',
+                            "tag": image.tag,
                             "digest": digest[digest_version],
                             "version": digest_version
                         })

--- a/atomic_reactor/pulp_util.py
+++ b/atomic_reactor/pulp_util.py
@@ -169,7 +169,7 @@ class PulpHandler(object):
         for image in image_names:
             repo_id = image.pulp_repo
             self.log.info("adding repo %s", repo_id)
-            tag = image.tag if image.tag else 'latest'
+            tag = image.tag
             if repo_prefix:
                 repo_id = repo_prefix + repo_id
 

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -66,7 +66,7 @@ class ImageName(object):
         self.registry = registry
         self.namespace = namespace
         self.repo = repo
-        self.tag = tag
+        self.tag = tag or 'latest'
 
     @classmethod
     def parse(cls, image_name):
@@ -1090,7 +1090,7 @@ def get_inspect_for_image(image, registry, insecure=False, dockercfg_path=None):
 
 
 def get_config_and_id_from_registry(image, registry, digest, insecure=False,
-                             dockercfg_path=None, version='v2'):
+                                    dockercfg_path=None, version='v2'):
     """Return image config by digest
 
     :param image: ImageName, the remote image to inspect

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -815,7 +815,7 @@ def query_registry(registry_session, image, digest=None, version='v1', is_blob=F
     """
 
     context = '/'.join([x for x in [image.namespace, image.repo] if x])
-    reference = digest or image.tag or 'latest'
+    reference = digest or image.tag
     object_type = 'manifests'
     if is_blob:
         object_type = 'blobs'
@@ -967,7 +967,7 @@ def get_manifest_digests(image, registry, insecure=False, dockercfg_path=None,
 
         digests[version] = response.headers['Docker-Content-Digest']
         context = '/'.join([x for x in [image.namespace, image.repo] if x])
-        tag = image.tag or 'latest'
+        tag = image.tag
         logger.debug('Image %s:%s has %s manifest digest: %s',
                      context, tag, version, digests[version])
 
@@ -1118,7 +1118,7 @@ def get_config_and_id_from_registry(image, registry, digest, insecure=False,
     blob_config = config_response.json()
 
     context = '/'.join([x for x in [image.namespace, image.repo] if x])
-    tag = image.tag or 'latest'
+    tag = image.tag
     logger.debug('Image %s:%s has config:\n%s', context, tag, blob_config)
 
     return blob_config, config_digest

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -42,6 +42,7 @@ MOCK_SOURCE = {'provider': 'git', 'uri': 'asd'}
 
 REGISTRY_PORT = "5000"
 DOCKER0_IP = "172.17.42.1"
+TEST_IMAGE_NAME = "atomic-reactor-test-image:latest"
 TEST_IMAGE = "atomic-reactor-test-image"
 
 LOCALHOST_REGISTRY = "localhost:%s" % REGISTRY_PORT

--- a/tests/plugins/test_change_from_in_df.py
+++ b/tests/plugins/test_change_from_in_df.py
@@ -148,7 +148,7 @@ def test_parent_images_unresolved(tmpdir):
     workflow.builder.base_image = ImageName.parse('eggs')
 
     # we want to fail because some img besides base was not resolved
-    workflow.builder.parent_images = {'spam': 'eggs', 'extra:image': None}
+    workflow.builder.parent_images = {'spam': 'eggs:latest', 'extra:image': None}
 
     with pytest.raises(ParentImageUnresolved):
         ChangeFromPlugin(docker_tasker(), workflow).run()

--- a/tests/plugins/test_store_metadata.py
+++ b/tests/plugins/test_store_metadata.py
@@ -37,7 +37,8 @@ from atomic_reactor.plugins.pre_reactor_config import (ReactorConfigPlugin,
                                                        ReactorConfig)
 from atomic_reactor.util import ImageName, LazyGit, ManifestDigest, df_parser
 import pytest
-from tests.constants import LOCALHOST_REGISTRY, DOCKER0_REGISTRY, TEST_IMAGE, INPUT_IMAGE
+from tests.constants import (LOCALHOST_REGISTRY, DOCKER0_REGISTRY, TEST_IMAGE, TEST_IMAGE_NAME,
+                             INPUT_IMAGE)
 from tests.util import is_string_type
 from tests.fixtures import reactor_config_map  # noqa
 
@@ -135,7 +136,7 @@ def prepare(pulp_registries=None, docker_registries=None, before_dockerfile=Fals
 
     for docker_registry in docker_registries:
         r = workflow.push_conf.add_docker_registry(docker_registry)
-        r.digests[TEST_IMAGE] = ManifestDigest(v1=DIGEST_NOT_USED, v2=DIGEST1)
+        r.digests[TEST_IMAGE_NAME] = ManifestDigest(v1=DIGEST_NOT_USED, v2=DIGEST1)
         r.digests["namespace/image:asd123"] = ManifestDigest(v1=DIGEST_NOT_USED,
                                                              v2=DIGEST2)
 
@@ -709,15 +710,15 @@ CMD blabla"""
     ([], [], False,
      {'unique': [], 'primary': []}),
     ([('spam', 'spam:8888')], ['docker:9999'], False,
-     {'primary': ['docker:9999/atomic-reactor-test-image',
-                  'spam:8888/atomic-reactor-test-image'],
+     {'primary': ['docker:9999/atomic-reactor-test-image:latest',
+                  'spam:8888/atomic-reactor-test-image:latest'],
       'unique': ['docker:9999/namespace/image:asd123',
                  'spam:8888/namespace/image:asd123']}),
     ([('spam', 'spam:8888')], ['docker:9999'], True,
-     {'primary': ['spam:8888/atomic-reactor-test-image'],
+     {'primary': ['spam:8888/atomic-reactor-test-image:latest'],
       'unique': ['spam:8888/namespace/image:asd123']}),
     ([], ['docker:9999'], True,
-     {'primary': ['docker:9999/atomic-reactor-test-image'],
+     {'primary': ['docker:9999/atomic-reactor-test-image:latest'],
       'unique': ['docker:9999/namespace/image:asd123']}),
 ])
 def test_filter_nonpulp_repositories(tmpdir, pulp_registries, docker_registries,

--- a/tests/plugins/test_tag_and_push.py
+++ b/tests/plugins/test_tag_and_push.py
@@ -18,7 +18,8 @@ from atomic_reactor.plugins.pre_reactor_config import (ReactorConfigPlugin,
                                                        WORKSPACE_CONF_KEY,
                                                        ReactorConfig)
 from atomic_reactor.util import ImageName, ManifestDigest, get_exported_image_metadata
-from tests.constants import LOCALHOST_REGISTRY, TEST_IMAGE, INPUT_IMAGE, MOCK, DOCKER0_REGISTRY
+from tests.constants import (LOCALHOST_REGISTRY, TEST_IMAGE, TEST_IMAGE_NAME, INPUT_IMAGE, MOCK,
+                             DOCKER0_REGISTRY)
 from tests.fixtures import reactor_config_map  # noqa
 
 import json
@@ -97,15 +98,15 @@ class X(object):
     False,
 ])
 @pytest.mark.parametrize(("image_name", "logs", "should_raise", "has_config"), [
-    (TEST_IMAGE, PUSH_LOGS_1_X, False, False),
-    (TEST_IMAGE, PUSH_LOGS_1_9, False, False),
-    (TEST_IMAGE, PUSH_LOGS_1_10, False, True),
-    (TEST_IMAGE, PUSH_LOGS_1_10_NOT_IN_STATUS, False, False),
-    (DOCKER0_REGISTRY + '/' + TEST_IMAGE, PUSH_LOGS_1_X, True, False),
-    (DOCKER0_REGISTRY + '/' + TEST_IMAGE, PUSH_LOGS_1_9, True, False),
-    (DOCKER0_REGISTRY + '/' + TEST_IMAGE, PUSH_LOGS_1_10, True, True),
-    (DOCKER0_REGISTRY + '/' + TEST_IMAGE, PUSH_LOGS_1_10_NOT_IN_STATUS, True, True),
-    (TEST_IMAGE, PUSH_ERROR_LOGS, True, False),
+    (TEST_IMAGE_NAME, PUSH_LOGS_1_X, False, False),
+    (TEST_IMAGE_NAME, PUSH_LOGS_1_9, False, False),
+    (TEST_IMAGE_NAME, PUSH_LOGS_1_10, False, True),
+    (TEST_IMAGE_NAME, PUSH_LOGS_1_10_NOT_IN_STATUS, False, False),
+    (DOCKER0_REGISTRY + '/' + TEST_IMAGE_NAME, PUSH_LOGS_1_X, True, False),
+    (DOCKER0_REGISTRY + '/' + TEST_IMAGE_NAME, PUSH_LOGS_1_9, True, False),
+    (DOCKER0_REGISTRY + '/' + TEST_IMAGE_NAME, PUSH_LOGS_1_10, True, True),
+    (DOCKER0_REGISTRY + '/' + TEST_IMAGE_NAME, PUSH_LOGS_1_10_NOT_IN_STATUS, True, True),
+    (TEST_IMAGE_NAME, PUSH_ERROR_LOGS, True, False),
 ])
 @pytest.mark.parametrize(("file_name", "dockerconfig_contents"), [
     (".dockercfg", {LOCALHOST_REGISTRY: {"username": "user",
@@ -433,7 +434,7 @@ def test_tag_and_push_plugin_oci(
             assert '--dest-creds=user:mypassword' in args
         assert '--dest-tls-verify=false' in args
         assert args[-2] == 'oci:' + oci_dir + ':' + REF_NAME
-        assert args[-1] == 'docker://' + LOCALHOST_REGISTRY + '/' + TEST_IMAGE
+        assert args[-1] == 'docker://' + LOCALHOST_REGISTRY + '/' + TEST_IMAGE_NAME
         return ''
 
     (flexmock(subprocess)
@@ -527,8 +528,8 @@ def test_tag_and_push_plugin_oci(
         tasker.remove_image(image)
         assert len(workflow.push_conf.docker_registries) > 0
 
-        assert workflow.push_conf.docker_registries[0].digests[TEST_IMAGE].v1 is None
-        assert workflow.push_conf.docker_registries[0].digests[TEST_IMAGE].v2 is None
-        assert workflow.push_conf.docker_registries[0].digests[TEST_IMAGE].oci == DIGEST_OCI
+        assert workflow.push_conf.docker_registries[0].digests[TEST_IMAGE_NAME].v1 is None
+        assert workflow.push_conf.docker_registries[0].digests[TEST_IMAGE_NAME].v2 is None
+        assert workflow.push_conf.docker_registries[0].digests[TEST_IMAGE_NAME].oci == DIGEST_OCI
 
         assert workflow.push_conf.docker_registries[0].config is config_json

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -66,7 +66,7 @@ if MOCK:
     from tests.retry_mock import mock_get_retry_session
 
 TEST_DATA = {
-    "repository.com/image-name": ImageName(registry="repository.com", repo="image-name"),
+    "repository.com/image-name:latest": ImageName(registry="repository.com", repo="image-name"),
     "repository.com/prefix/image-name:1": ImageName(registry="repository.com",
                                                     namespace="prefix",
                                                     repo="image-name", tag="1"),
@@ -74,16 +74,14 @@ TEST_DATA = {
                                                                namespace="prefix",
                                                                repo="image-name",
                                                                tag="sha256:12345"),
-    "repository.com/prefix/image-name": ImageName(registry="repository.com",
-                                                  namespace="prefix",
-                                                  repo="image-name"),
-    "image-name": ImageName(repo="image-name"),
+    "repository.com/prefix/image-name:latest": ImageName(registry="repository.com",
+                                                         namespace="prefix",
+                                                         repo="image-name"),
+    "image-name:latest": ImageName(repo="image-name"),
 
-    "registry:5000/image-name:latest": ImageName(registry="registry:5000",
-                                                 repo="image-name", tag="latest"),
     "registry:5000/image-name@sha256:12345": ImageName(registry="registry:5000",
                                                        repo="image-name", tag="sha256:12345"),
-    "registry:5000/image-name": ImageName(registry="registry:5000", repo="image-name"),
+    "registry:5000/image-name:latest": ImageName(registry="registry:5000", repo="image-name"),
 
     "fedora:20": ImageName(repo="fedora", tag="20"),
     "fedora@sha256:12345": ImageName(repo="fedora", tag="sha256:12345"),


### PR DESCRIPTION
Change ImageName to have a default tag of "latest", instead of None.

Adjust the unit test cases appropriately.

Change pre_pull_base_image to compare ImageNames to ImageNames when deciding whether a
particular parent of an image is actually the base image for that image.

Remove some ad-hoc fixes people put it in to give ImageName.tags a sensible default.