### PR TITLE
Get module information from Koji instead of the PDC

### DIFF
--- a/atomic_reactor/plugins/build_orchestrate_build.py
+++ b/atomic_reactor/plugins/build_orchestrate_build.py
@@ -27,7 +27,7 @@ from atomic_reactor.build import BuildResult
 from atomic_reactor.plugin import BuildStepPlugin
 from atomic_reactor.plugins.pre_reactor_config import (get_config,
                                                        get_arrangement_version, get_koji,
-                                                       get_odcs, get_pdc, get_pulp,
+                                                       get_odcs, get_pulp,
                                                        get_prefer_schema1_digest, get_smtp,
                                                        get_source_registry, get_sources_command,
                                                        get_artifacts_allowed_domains,
@@ -337,14 +337,6 @@ class OrchestrateBuildPlugin(BuildStepPlugin):
         odcs_map = get_odcs(self.workflow, odcs_fallback)
         self.config_kwargs['odcs_url'] = odcs_map['api_url']
         self.config_kwargs['odcs_insecure'] = odcs_map.get('insecure', False)
-
-        pdc_fallback = {
-            'api_url': self.config_kwargs.get('pdc_url'),
-            'insecure': self.config_kwargs.get('pdc_insecure')
-        }
-        pdc_map = get_pdc(self.workflow, pdc_fallback)
-        self.config_kwargs['pdc_url'] = pdc_map['api_url']
-        self.config_kwargs['pdc_insecure'] = pdc_map.get('insecure', False)
 
         pulp_fallback = {'name': self.config_kwargs.get('pulp_registry_name')}
         pulp_map = get_pulp(self.workflow, pulp_fallback)

--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -26,7 +26,7 @@ try:
     from atomic_reactor.plugins.pre_flatpak_create_dockerfile import get_flatpak_source_info
     from atomic_reactor.plugins.pre_resolve_module_compose import get_compose_info
 except ImportError:
-    # modulemd and/or pdc_client not available
+    # modulemd not available
     def get_flatpak_source_info(_):
         return None
 

--- a/atomic_reactor/plugins/exit_koji_promote.py
+++ b/atomic_reactor/plugins/exit_koji_promote.py
@@ -32,7 +32,7 @@ try:
     from atomic_reactor.plugins.pre_flatpak_create_dockerfile import get_flatpak_source_info
     from atomic_reactor.plugins.pre_resolve_module_compose import get_compose_info
 except ImportError:
-    # modulemd and/or pdc_client not available
+    # modulemd not available
     def get_flatpak_source_info(_):
         return None
 

--- a/atomic_reactor/plugins/pre_reactor_config.py
+++ b/atomic_reactor/plugins/pre_reactor_config.py
@@ -141,18 +141,6 @@ def get_smtp_session(workflow, fallback):
     return smtplib.SMTP(config['host'])
 
 
-def get_pdc(workflow, fallback=NO_FALLBACK):
-    return get_value(workflow, 'pdc', fallback)
-
-
-def get_pdc_session(workflow, fallback):
-    config = get_pdc(workflow, fallback)
-
-    from pdc_client import PDCClient
-    return PDCClient(server=config['api_url'], ssl_verify=not config.get('insecure', False),
-                     develop=True)
-
-
 def get_arrangement_version(workflow, fallback=NO_FALLBACK):
     return get_value(workflow, 'arrangement_version', fallback)
 

--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -260,22 +260,6 @@
         "additionalProperties": false,
         "required": ["host", "from_address"]
     },
-    "pdc": {
-        "description": "Product Definition Center (PDC) instance",
-        "type": "object",
-        "properties": {
-            "api_url": {
-                "description": "PDC api url, including api version",
-                "type": "string"
-            },
-            "insecure": {
-                "description": "Don't check SSL certificate for api_url",
-                "type": "boolean"
-            }
-        },
-        "additionalProperties": false,
-        "required": ["api_url"]
-    },
     "arrangement_version": {
         "description": "Arrangement version",
         "type": "integer"

--- a/docs/flatpak.md
+++ b/docs/flatpak.md
@@ -5,7 +5,6 @@ In addition to building docker images from Dockerfiles, atomic-reactor can also 
 Building Flatpaks requires, in addition to a Koji installation:
 
  * A [MBS (module-build-service)](https://pagure.io/fm-orchestrator/) instance set up to build modules in Koji
- * A [PDC (product definition center)](https://github.com/product-definition-center/product-definition-center) instance to store information about the built modules
  * An [ODCS (on demand compose service)](https://pagure.io/odcs/) instance to create repositories for the build modules
 
 A modified version of osbs-box for testing Flatpak building can be found at:

--- a/requirements-flatpak.txt
+++ b/requirements-flatpak.txt
@@ -1,2 +1,1 @@
 flatpak-module-tools
-pdc-client

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -93,10 +93,6 @@ smtp:
     send_to_submitter: True
     send_to_pkg_owner: True
 
-pdc:
-    api_url: https://pdc.example.com/rest_api/v1
-    insecure: True
-
 arrangement_version: 6
 
 artifacts_allowed_domains:

--- a/tests/koji/__init__.py
+++ b/tests/koji/__init__.py
@@ -15,6 +15,14 @@ TASK_STATES = {
     'FAILED': 5,
 }
 
+BUILD_STATES = {
+    'BUILDING': 0,
+    'COMPLETE': 1,
+    'DELETED': 2,
+    'FAILED': 3,
+    'CANCELED': 4,
+}
+
 CHECKSUM_TYPES = {
     0: 'md5',
     1: 'sha1',

--- a/tests/plugins/test_orchestrate_build.py
+++ b/tests/plugins/test_orchestrate_build.py
@@ -314,9 +314,6 @@ def test_orchestrate_build(tmpdir, caplog, config_kwargs,
         reactor_dict['odcs'] = {'api_url': 'odcs_url'}
         expected_kwargs['odcs_insecure'] = False
         expected_kwargs['odcs_url'] = reactor_dict['odcs']['api_url']
-        reactor_dict['pdc'] = {'api_url': 'pdc_url'}
-        expected_kwargs['pdc_url'] = reactor_dict['pdc']['api_url']
-        expected_kwargs['pdc_insecure'] = False
         reactor_dict['pulp'] = {'name': 'pulp_name'}
         expected_kwargs['pulp_registry_name'] = reactor_dict['pulp']['name']
         reactor_dict['prefer_schema1_digest'] = False
@@ -374,7 +371,6 @@ def test_orchestrate_build(tmpdir, caplog, config_kwargs,
         expected_kwargs['registry_api_versions'] = ''
         expected_kwargs['source_registry_uri'] = None
         expected_kwargs['yum_proxy'] = None
-        expected_kwargs['pdc_url'] = None
         expected_kwargs['odcs_url'] = None
         expected_kwargs['smtp_additional_addresses'] = ''
         expected_kwargs['koji_root'] = None
@@ -382,7 +378,6 @@ def test_orchestrate_build(tmpdir, caplog, config_kwargs,
         expected_kwargs['smtp_to_submitter'] = None
         expected_kwargs['artifacts_allowed_domains'] = ''
         expected_kwargs['smtp_to_pkgowner'] = None
-        expected_kwargs['pdc_insecure'] = None
         expected_kwargs['prefer_schema1_digest'] = None
         expected_kwargs['pulp_registry_name'] = None
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1019,22 +1019,23 @@ def test_clone_git_repo_retry(tmpdir, retry_times, raise_exc):
 
 
 @pytest.mark.parametrize(('module', 'should_raise', 'expected'), [
-    ('eog', True, None),
+    ('eog', "must include at least NAME:STREAM", None),
     ('eog:f26', False, ModuleSpec('eog', 'f26')),
     ('eog:f26/default', False, ModuleSpec('eog', 'f26', profile='default')),
-    ('eog-f26', False, ModuleSpec('eog', 'f26')),
     ('eog:f26:20170629213428', False, ModuleSpec('eog', 'f26', '20170629213428')),
+    ('eog:f26:20170629213428:12345678', False,
+     ModuleSpec('eog', 'f26', '20170629213428', '12345678')),
     ('eog:f26:20170629213428/default', False,
      ModuleSpec('eog', 'f26', '20170629213428', profile='default')),
-    ('eog-f26-20170629213428', False, ModuleSpec('eog', 'f26', '20170629213428')),
-    ('a-b-c-20176291342855', False, ModuleSpec('a-b', 'c', '20176291342855')),
-    ('a-b-c-d', False, ModuleSpec('a-b-c', 'd')),
-    ('a:b:c:d', True, None),
+    ('a:b:c:d:e', "should be NAME:STREAM[:VERSION[:CONTEXT]][/PROFILE]", None),
+    ('a:b::d', "contains empty components", None),
+    ('a:b:c:d/', "contains empty components", None),
 ])
 def test_split_module_spec(module, should_raise, expected):
     if should_raise:
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError) as e:
             split_module_spec(module)
+        assert should_raise in str(e)
     else:
         assert split_module_spec(module) == expected
 


### PR DESCRIPTION
The information (modulemd file, list of built RPMs) that we were previously
looking up in the PDC is also available directly from Koji. Since there is
a plan to retire the PDC, switch over to reading the information from Koji.
    
There is some complexity because older versions of ODCS (like what is deployed
currently in Fedora) return the modules in the compose as NAME:STREAM:VERSION
instead of NAME:STREAM:VERSION:CONTEXT, and in that case, we have to hunt
for the right build in Koji.
    
With this change, Flatpak building will only work with Koji configuration
in the reactor config map, but that's the recommended set up in any case.

[ Upgrading the Fedora ODCS is being looked at, if that happens, I'll update this pull request to simplifiy it ]