### PR TITLE
Allow setting the Flatpak base image in the reactor config map

### DIFF
--- a/atomic_reactor/plugins/pre_flatpak_create_dockerfile.py
+++ b/atomic_reactor/plugins/pre_flatpak_create_dockerfile.py
@@ -24,6 +24,7 @@ from flatpak_module_tools.flatpak_builder import FlatpakSourceInfo, FlatpakBuild
 
 from atomic_reactor.constants import DOCKERFILE_FILENAME, YUM_REPOS_DIR
 from atomic_reactor.plugin import PreBuildPlugin
+from atomic_reactor.plugins.pre_reactor_config import get_flatpak_base_image
 from atomic_reactor.plugins.pre_resolve_module_compose import get_compose_info
 from atomic_reactor.plugins.build_orchestrate_build import override_build_kwarg
 from atomic_reactor.rpm_util import rpm_qf_args
@@ -92,7 +93,7 @@ class FlatpakCreateDockerfilePlugin(PreBuildPlugin):
         # call parent constructor
         super(FlatpakCreateDockerfilePlugin, self).__init__(tasker, workflow)
 
-        self.base_image = base_image
+        self.base_image = get_flatpak_base_image(workflow, base_image)
 
     def _load_source(self):
         flatpak_yaml = self.workflow.source.config.flatpak

--- a/atomic_reactor/plugins/pre_reactor_config.py
+++ b/atomic_reactor/plugins/pre_reactor_config.py
@@ -347,6 +347,16 @@ def get_default_image_build_method(workflow, fallback=CONTAINER_DEFAULT_BUILD_ME
     return value
 
 
+def get_flatpak_base_image(workflow, fallback=NO_FALLBACK):
+    flatpak = get_value(workflow, 'flatpak', {})
+    try:
+        return flatpak['base_image']
+    except KeyError:
+        if fallback != NO_FALLBACK:
+            return fallback
+        raise
+
+
 class ClusterConfig(object):
     """
     Configuration relating to a particular cluster

--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -485,6 +485,17 @@
     "default_image_build_method": {
         "description": "Specify different default buildstep plugin for worker builds",
         "enum": ["docker_api", "imagebuilder"]
+    },
+    "flatpak": {
+        "description": "Flatpak specific properties",
+        "type": "object",
+        "properties": {
+            "base_image": {
+                "description": "host image used to install packages when creating a Flatpak",
+                "type": "string"
+            }
+        },
+        "additionalProperties": false
     }
   },
   "definitions": {


### PR DESCRIPTION
The Flatpak base image is not specific to a particular build, so should
be set in the reactor config map.