### PR TITLE
Add support for Bearer token auth registries

### DIFF
--- a/atomic_reactor/auth.py
+++ b/atomic_reactor/auth.py
@@ -1,0 +1,172 @@
+"""
+Copyright (c) 2018 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+from __future__ import unicode_literals
+
+from requests.auth import AuthBase, HTTPBasicAuth
+from requests.cookies import extract_cookies_to_jar
+from requests.utils import parse_dict_header
+from six.moves.urllib.parse import urlparse
+import requests
+import re
+
+
+class HTTPBearerAuth(AuthBase):
+    """Performs Bearer authentication for the given Request object.
+
+    username and password are optional. If provided, they will be used
+    when fetching the Bearer token from realm. Otherwise, Bearer token
+    is retrivied with anonymous access.
+
+    Once Bearer token is retrieved, it will be cached and used in subsequent
+    requests. Since tokens are specific to repositories, the token cache may
+    store multiple tokens.
+
+    Supports registry v2 API only.
+    """
+    BEARER_PATTERN = re.compile(r'bearer ', flags=re.IGNORECASE)
+    V2_REPO_PATTERN = re.compile(r'^/v2/(.*)/(manifests|tags|blobs)/')
+
+    def __init__(self, username=None, password=None, verify=True, access=('pull',)):
+        """Initialize HTTPBearerAuth object.
+
+        :param username: str, username to be used for authentication
+        :param password: str, password to be used for authentication
+        :param verify: bool, whether or not to verify server identity when
+            fetching Bearer token from realm
+        :param access: iter<str>, iterable (list, tuple, etc) of access to be
+            requested; possible values to be included are 'pull' and/or 'push'
+        """
+        self.username = username
+        self.password = password
+        self.verify = verify
+        self.access = access
+
+        self._token_cache = {}
+
+    def __call__(self, response):
+        repo = self._get_repo_from_url(response.url)
+
+        if repo in self._token_cache:
+            self._set_header(response, repo)
+            return response
+
+        def handle_401_with_repo(response, **kwargs):
+            return self.handle_401(response, repo, **kwargs)
+
+        response.register_hook('response', handle_401_with_repo)
+        return response
+
+    def handle_401(self, response, repo, **kwargs):
+        """Fetch Bearer token and retry."""
+        if response.status_code != requests.codes.unauthorized:
+            return response
+
+        auth_info = response.headers.get('www-authenticate', '')
+
+        if 'bearer' not in auth_info.lower():
+            return response
+
+        self._token_cache[repo] = self._get_token(auth_info, repo)
+
+        # Consume content and release the original connection
+        # to allow our new request to reuse the same one.
+        # This pattern was inspired by the source code of requests.auth.HTTPDigestAuth
+        response.content
+        response.close()
+        retry_request = response.request.copy()
+        extract_cookies_to_jar(retry_request._cookies, response.request, response.raw)
+        retry_request.prepare_cookies(retry_request._cookies)
+
+        self._set_header(retry_request, repo)
+        retry_response = response.connection.send(retry_request, **kwargs)
+        retry_response.history.append(response)
+        retry_response.request = retry_request
+
+        return retry_response
+
+    def _get_token(self, auth_info, repo):
+        bearer_info = parse_dict_header(self.BEARER_PATTERN.sub('', auth_info, count=1))
+        # If repo could not be determined, do not set scope - implies global access
+        if repo:
+            bearer_info['scope'] = 'repository:{}:{}'.format(repo, ','.join(self.access))
+        realm = bearer_info.pop('realm')
+
+        realm_auth = None
+        if self.username and self.password:
+            realm_auth = HTTPBasicAuth(self.username, self.password)
+
+        realm_response = requests.get(realm, params=bearer_info, verify=self.verify,
+                                      auth=realm_auth)
+        realm_response.raise_for_status()
+        return realm_response.json()['token']
+
+    def _set_header(self, response, repo):
+        response.headers['Authorization'] = 'Bearer {}'.format(self._token_cache[repo])
+
+    def _get_repo_from_url(self, url):
+        url_parts = urlparse(url)
+        repo = None
+        v2_match = self.V2_REPO_PATTERN.search(url_parts.path)
+        if v2_match:
+            repo = v2_match.group(1)
+        return repo
+
+
+class HTTPRegistryAuth(AuthBase):
+    """Custom requests auth handler for constainer registries.
+
+    Supports both Basic Auth and Bearer Auth (v2 API only).
+
+    For v1 API requests, Basic Auth is the only supported
+    authentication mechanism.
+
+    For v2 API requests, Basic Auth is attempted first, if
+    status code of response is 401, Bearer Auth is then
+    attempted.
+    """
+
+    V1_URL = re.compile(r'^/v1/')
+    V2_URL = re.compile(r'^/v2/')
+
+    def __init__(self, username=None, password=None):
+        self.username = username
+        self.password = password
+
+        self.v1_auth = None
+        self.v2_auths = []
+
+    def __call__(self, request):
+        url_parts = urlparse(request.url)
+
+        if self.V1_URL.search(url_parts.path):
+            if not self.username or not self.password:
+                # V1 API only supports basic auth which requires user/pass
+                return request
+
+            if not self.v1_auth:
+                self.v1_auth = HTTPBasicAuth(self.username, self.password)
+
+            return self.v1_auth(request)
+
+        if self.V2_URL.search(url_parts.path):
+
+            if not self.v2_auths:
+                # It's safe to always add bearer auth handler because
+                # it's only activated if indicated by www-authenticate response header
+                self.v2_auths.append(HTTPBearerAuth(self.username, self.password))
+
+                if self.username and self.password:
+                    self.v2_auths.append(HTTPBasicAuth(self.username, self.password))
+
+            for auth in self.v2_auths:
+                request = auth(request)
+                if 'authorization' in (k.lower() for k in request.headers.keys()):
+                    # One of the auth handlers has a token for the request
+                    break
+
+        return request

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -47,6 +47,7 @@ from atomic_reactor.constants import (DOCKERFILE_FILENAME, REPO_CONTAINER_CONFIG
                                       PLUGIN_KOJI_PARENT_KEY,
                                       PARENT_IMAGE_BUILDS_KEY, PARENT_IMAGES_KOJI_BUILDS,
                                       BASE_IMAGE_KOJI_BUILD, BASE_IMAGE_BUILD_ID_KEY)
+from atomic_reactor.auth import HTTPRegistryAuth
 
 from dockerfile_parse import DockerfileParser
 from pkg_resources import resource_stream
@@ -692,14 +693,14 @@ class RegistrySession(object):
         self._resolved = None
         self.insecure = insecure
 
-        self.auth = None
+        username = None
+        password = None
         if dockercfg_path:
             dockercfg = Dockercfg(dockercfg_path).get_credentials(registry)
 
             username = dockercfg.get('username')
             password = dockercfg.get('password')
-            if username and password:
-                self.auth = requests.auth.HTTPBasicAuth(username, password)
+        self.auth = HTTPRegistryAuth(username, password)
 
         self._fallback = None
         if re.match('http(s)?://', self.registry):

--- a/tests/plugins/test_delete_from_registry.py
+++ b/tests/plugins/test_delete_from_registry.py
@@ -11,6 +11,7 @@ from __future__ import print_function, unicode_literals
 import pytest
 from flexmock import flexmock
 
+from atomic_reactor.auth import HTTPRegistryAuth
 from atomic_reactor.constants import PLUGIN_GROUP_MANIFESTS_KEY
 from atomic_reactor.util import ImageName, ManifestDigest
 from atomic_reactor.core import DockerTasker
@@ -28,7 +29,6 @@ from tempfile import mkdtemp
 import os
 import json
 import requests
-import requests.auth
 
 if MOCK:
     from tests.docker_mock import mock_docker
@@ -176,7 +176,7 @@ def test_delete_from_registry_plugin(saved_digests, req_registries, tmpdir, orch
             if dig in deleted_digests:
                 continue
             url = "https://" + reg + "/v2/" + tag.split(":")[0] + "/manifests/" + dig
-            auth_type = requests.auth.HTTPBasicAuth if req_registries[reg] else None
+            auth_type = HTTPRegistryAuth
             (flexmock(requests.Session)
                 .should_receive('delete')
                 .with_args(url, verify=bool, auth=auth_type)
@@ -255,7 +255,7 @@ def test_delete_from_registry_failures(tmpdir, status_code, reactor_config_map):
             if dig in deleted_digests:
                 continue
             url = "https://" + reg + "/v2/" + tag.split(":")[0] + "/manifests/" + dig
-            auth_type = requests.auth.HTTPBasicAuth if req_registries[reg] else None
+            auth_type = HTTPRegistryAuth
 
             response = requests.Response()
             response.status_code = status_code

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
 flexmock
 ordereddict
-responses
+responses>=0.9.0
 pytest==3.2.5
 pytest-capturelog==0.7
 pytest-cov==2.5.1

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,273 @@
+"""
+Copyright (c) 2018 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+from __future__ import unicode_literals
+
+from atomic_reactor.auth import HTTPBearerAuth, HTTPRegistryAuth
+from requests.auth import HTTPBasicAuth
+import base64
+import json
+import pytest
+import requests
+import responses
+
+
+BEARER_TOKEN = 'the-token'
+BEARER_REALM_URL = 'https://registry.example.com/v2/auth'
+
+
+def bearer_unauthorized_callback(request):
+    headers = {'www-authenticate': 'Bearer realm={}'.format(BEARER_REALM_URL)}
+    return (401, headers, json.dumps('unauthorized'))
+
+
+def bearer_success_callback(request):
+    assert request.headers['Authorization'] == 'Bearer {}'.format(BEARER_TOKEN)
+    return (200, {}, json.dumps('success'))
+
+
+def b64encode(username, password):
+    return base64.b64encode('{}:{}'.format(username, password).encode('utf-8')).decode('utf-8')
+
+
+class TestHTTPBearerAuth(object):
+
+    @pytest.mark.parametrize('verify', (True, False))
+    def test_initialization(self, verify):
+        username = 'the-user'
+        password = 'top-secret'
+        access = ('pull', 'push')
+
+        auth = HTTPBearerAuth(username=username, password=password, verify=verify, access=access)
+
+        assert auth.username == username
+        assert auth.password == password
+        assert auth.verify == verify
+        assert auth.access == access
+
+    @responses.activate
+    @pytest.mark.parametrize(('username', 'password', 'basic_auth'), (
+        (None, None, False),
+        ('spam', None, False),
+        (None, 'bacon', False),
+        ('spam', 'bacon', True),
+    ))
+    def test_token_negotiation(self, username, password, basic_auth):
+
+        def bearer_realm_callback(request):
+            # Verify if username and password were provided, token is negotiated
+            # with realm via basic auth.
+            if basic_auth:
+                creds = b64encode(username, password)
+                assert request.headers['authorization'] == 'Basic {}'.format(creds)
+            else:
+                assert 'authorization' not in request.headers
+
+            return (200, {}, json.dumps({'token': BEARER_TOKEN}))
+
+        responses.add_callback(responses.GET, BEARER_REALM_URL + '?scope=repository:fedora:pull',
+                               callback=bearer_realm_callback, match_querystring=True)
+
+        url = 'https://registry.example.com/v2/fedora/tags/list'
+
+        responses.add_callback(responses.GET, url, callback=bearer_unauthorized_callback)
+        responses.add_callback(responses.GET, url, callback=bearer_success_callback)
+
+        auth = HTTPBearerAuth(username=username, password=password)
+
+        assert requests.get(url, auth=auth).json() == 'success'
+        assert len(responses.calls) == 3
+
+    @responses.activate
+    def test_token_cached_per_repo(self):
+        responses.add(responses.GET, BEARER_REALM_URL + '?scope=repository:fedora:pull',
+                      json={'token': BEARER_TOKEN}, match_querystring=True)
+        responses.add(responses.GET, BEARER_REALM_URL + '?scope=repository:centos:pull',
+                      json={'token': BEARER_TOKEN}, match_querystring=True)
+
+        fedora_url = 'https://registry.example.com/v2/fedora/tags/list'
+        responses.add_callback(responses.GET, fedora_url, callback=bearer_unauthorized_callback)
+        responses.add(responses.GET, fedora_url, status=200, json='fedora-success')
+        responses.add(responses.GET, fedora_url, status=200, json='fedora-success-also')
+
+        centos_url = 'https://registry.example.com/v2/centos/tags/list'
+        responses.add_callback(responses.GET, centos_url, callback=bearer_unauthorized_callback)
+        responses.add(responses.GET, centos_url, status=200, json='centos-success')
+        responses.add(responses.GET, centos_url, status=200, json='centos-success-also')
+
+        auth = HTTPBearerAuth()
+
+        assert requests.get(fedora_url, auth=auth).json() == 'fedora-success'
+        assert requests.get(fedora_url, auth=auth).json() == 'fedora-success-also'
+
+        assert requests.get(centos_url, auth=auth).json() == 'centos-success'
+        assert requests.get(centos_url, auth=auth).json() == 'centos-success-also'
+
+        assert len(responses.calls) == 8
+
+    @responses.activate
+    @pytest.mark.parametrize(('partial_url', 'repo'), (
+        ('tags/list', 'fedora'),
+        ('manifests/latest', 'fedora'),
+        ('blobs/abcd12345', 'fedora'),
+        ('blobs/uploads', 'fedora'),
+        ('blobs/uploads/123456789', 'fedora'),
+        ('tags/list', 'spam/fedora'),
+        ('manifests/latest', 'spam/fedora'),
+        ('blobs/abcd12345', 'spam/fedora'),
+        ('blobs/uploads', 'spam/fedora'),
+        ('blobs/uploads/123456789', 'spam/fedora'),
+    ))
+    def test_repo_extracted_from_url(self, partial_url, repo):
+        responses.add(responses.GET, '{}?scope=repository:{}:pull'.format(BEARER_REALM_URL, repo),
+                      json={'token': BEARER_TOKEN}, match_querystring=True)
+
+        repo_url = 'https://registry.example.com/v2/{}/{}'.format(repo, partial_url)
+        responses.add_callback(responses.GET, repo_url, callback=bearer_unauthorized_callback)
+        responses.add(responses.GET, repo_url, status=200, json='success')
+
+        auth = HTTPBearerAuth()
+
+        assert requests.get(repo_url, auth=auth).json() == 'success'
+
+    @responses.activate
+    @pytest.mark.parametrize('partial_url', (
+        'v2',
+        '_catalog',
+    ))
+    def test_request_global_access(self, partial_url):
+        responses.add(responses.GET, BEARER_REALM_URL, json={'token': BEARER_TOKEN},
+                      match_querystring=True)
+
+        repo_url = 'https://registry.example.com/{}'.format(partial_url)
+        responses.add_callback(responses.GET, repo_url, callback=bearer_unauthorized_callback)
+        responses.add(responses.GET, repo_url, status=200, json='success')
+
+        auth = HTTPBearerAuth()
+
+        assert requests.get(repo_url, auth=auth).json() == 'success'
+
+    @responses.activate
+    def test_non_401_error_propagated(self):
+
+        def bearer_teapot_callback(request):
+            headers = {'www-authenticate': 'Bearer realm={}'.format(BEARER_REALM_URL)}
+            return (418, headers, json.dumps("I'm a teapot!"))
+
+        url = 'https://registry.example.com/v2/fedora/tags/list'
+        responses.add_callback(responses.GET, url, callback=bearer_teapot_callback)
+        responses.add(responses.GET, url, status=200, json='success')  # Not actually called
+
+        auth = HTTPBearerAuth()
+
+        response = requests.get(url, auth=auth)
+        assert response.json() == "I'm a teapot!"
+        assert response.status_code == 418
+        assert len(responses.calls) == 1
+
+    @responses.activate
+    def test_not_bearer_auth(self):
+        url = 'https://registry.example.com/v2/fedora/tags/list'
+
+        def unsupported_callback(request):
+            headers = {'www-authenticate': 'Spam realm={}'.format(BEARER_REALM_URL)}
+            return (401, headers, json.dumps('unauthorized'))
+
+        responses.add_callback(responses.GET, url, callback=unsupported_callback)
+        responses.add(responses.GET, url, status=200, json='success')  # Not actually called
+
+        auth = HTTPBearerAuth()
+
+        response = requests.get(url, auth=auth)
+        assert response.json() == 'unauthorized'
+        assert response.status_code == 401
+        assert len(responses.calls) == 1
+
+
+class TestHTTPRegistryAuth(object):
+
+    def test_initialization(self):
+        auth = HTTPRegistryAuth(username='the-user', password='top-secret')
+        assert auth.username == 'the-user'
+        assert auth.password == 'top-secret'
+
+    @responses.activate
+    @pytest.mark.parametrize(('username', 'password', 'basic_auth'), (
+        ('spam', 'bacon', True),
+        (None, 'bacon', False),
+        ('spam', None, False),
+        (None, None, False),
+    ))
+    def test_v1(self, username, password, basic_auth):
+        url = 'https://registry.example.com/v1/repositories/fedora/tags/latest'
+
+        def auth_callback(request):
+            # Verify if username and password were provided, basic auth is used
+            if basic_auth:
+                creds = b64encode(username, password)
+                assert request.headers['authorization'] == 'Basic {}'.format(creds)
+            else:
+                assert 'authorization' not in request.headers
+
+            return (200, {}, json.dumps('success'))
+
+        responses.add_callback(responses.GET, url, callback=auth_callback)
+
+        auth = HTTPRegistryAuth(username=username, password=password)
+        assert requests.get(url, auth=auth).json() == 'success'
+        if basic_auth:
+            assert isinstance(auth.v1_auth, HTTPBasicAuth)
+        else:
+            assert auth.v1_auth is None
+
+    @responses.activate
+    @pytest.mark.parametrize(('username', 'password', 'auth_type'), (
+        ('spam', 'bacon', 'basic'),
+        (None, 'bacon', None),
+        ('spam', None, None),
+        (None, None, None),
+        ('spam', 'bacon', 'bearer'),
+        (None, 'bacon', 'bearer'),
+        ('spam', None, 'bearer'),
+        (None, None, 'bearer'),
+    ))
+    def test_v2(self, username, password, auth_type):
+        bearer_token = 'the-bearer-token'
+        realm_url = 'https://registry.example.com/v2/auth'
+
+        responses.add(responses.GET, '{}?scope=repository:fedora:pull'.format(realm_url),
+                      json={'token': bearer_token}, match_querystring=True)
+
+        def auth_callback(request):
+            if auth_type == 'basic':
+                creds = b64encode(username, password)
+                assert request.headers['authorization'] == 'Basic {}'.format(creds)
+                return (200, {}, json.dumps('success'))
+
+            if auth_type == 'bearer':
+                header_value = 'Bearer {}'.format(bearer_token)
+                if header_value != request.headers.get('authorization'):
+                    auth_headers = {'www-authenticate': 'Bearer realm={}'.format(realm_url)}
+                    return (401, auth_headers, json.dumps('unauthorized'))
+                else:
+                    return (200, {}, json.dumps('success'))
+
+            assert 'authorization' not in request.headers
+            return (200, {}, json.dumps('success'))
+
+        repo_url = 'https://registry.example.com/v2/fedora/tags/list'
+        responses.add_callback(responses.GET, repo_url, callback=auth_callback)
+
+        auth = HTTPRegistryAuth(username=username, password=password)
+        assert requests.get(repo_url, auth=auth).json() == 'success'
+        if username and password:
+            assert len(auth.v2_auths) == 2
+            assert isinstance(auth.v2_auths[0], HTTPBearerAuth)
+            assert isinstance(auth.v2_auths[1], HTTPBasicAuth)
+        else:
+            assert len(auth.v2_auths) == 1
+            assert isinstance(auth.v2_auths[0], HTTPBearerAuth)


### PR DESCRIPTION
Still needs unit tests, but I'd really appreciate some early feedback.

I've tested this against multiple container registries: Pulp, OpenShift Registry, Quay.io, and Proxy to Quay.io.