### PR TITLE
Add ImageName.enclose method

### DIFF
--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -125,6 +125,17 @@ class ImageName(object):
     def pulp_repo(self):
         return self.to_str(registry=False, tag=False).replace("/", "-")
 
+    def enclose(self, organization):
+        if self.namespace == organization:
+            return
+
+        repo_parts = [self.repo]
+        if self.namespace:
+            repo_parts.insert(0, self.namespace)
+
+        self.namespace = organization
+        self.repo = '-'.join(repo_parts)
+
     def __str__(self):
         return self.to_str(registry=True, tag=True)
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -113,6 +113,36 @@ def test_image_name_format():
         assert image_name.to_str() == expected
 
 
+@pytest.mark.parametrize(('repo', 'organization', 'enclosed_repo'), (
+    ('fedora', 'spam', 'spam/fedora'),
+    ('spam/fedora', 'spam', 'spam/fedora'),
+    ('spam/fedora', 'maps', 'maps/spam-fedora'),
+))
+@pytest.mark.parametrize('registry', (
+    'example.registry.com',
+    'example.registry.com:8888',
+    None,
+))
+@pytest.mark.parametrize('tag', ('bacon', None))
+def test_image_name_enclose(repo, organization, enclosed_repo, registry, tag):
+    reference = repo
+    if tag:
+        reference = '{}:{}'.format(repo, tag)
+    if registry:
+        reference = '{}/{}'.format(registry, reference)
+
+    image_name = ImageName.parse(reference)
+    assert image_name.get_repo() == repo
+    assert image_name.registry == registry
+    assert image_name.tag == (tag or 'latest')
+
+    image_name.enclose(organization)
+    assert image_name.get_repo() == enclosed_repo
+    # Verify that registry and tag are unaffected
+    assert image_name.registry == registry
+    assert image_name.tag == (tag or 'latest')
+
+
 def test_image_name_comparison():
     # make sure that both "==" and "!=" are implemented right on both Python major releases
     i1 = ImageName(registry='foo.com', namespace='spam', repo='bar', tag='1')


### PR DESCRIPTION
This allows an image reference to be modified so it can be nested under
a namespace/organization.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>