### PR TITLE
verify_media_types plugin

### DIFF
--- a/atomic_reactor/plugins/exit_verify_media_types.py
+++ b/atomic_reactor/plugins/exit_verify_media_types.py
@@ -1,0 +1,134 @@
+"""Copyright (c) 2018 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+
+After squashing our image, verify that it has the media types that
+the registry expects
+"""
+
+from __future__ import unicode_literals
+
+from atomic_reactor.constants import (PLUGIN_GROUP_MANIFESTS_KEY,
+                                      MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_SCHEMA1,
+                                      MEDIA_TYPE_DOCKER_V2_SCHEMA2,
+                                      MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST)
+
+from atomic_reactor.plugin import ExitPlugin
+from atomic_reactor.util import get_manifest_digests, get_platforms, RegistrySession
+from atomic_reactor.plugins.pre_reactor_config import (get_registries,
+                                                       get_platform_to_goarch_mapping)
+from copy import deepcopy
+from itertools import chain
+
+
+def verify_v1_image(image, registry, log, insecure=False, dockercfg_path=None):
+    registry_session = RegistrySession(registry, insecure=insecure, dockercfg_path=dockercfg_path)
+
+    headers = {'Accept': MEDIA_TYPE_DOCKER_V1}
+    url = '/v1/repositories/{0}/tags/{1}'.format(image.get_repo(), image.tag)
+    log.debug("verify_v1_image: querying {0}, headers: {1}".format(url, headers))
+
+    response = registry_session.get(url, headers=headers)
+    for r in chain(response.history, [response]):
+        log.debug("verify_v1_image: [%s] %s", r.status_code, r.url)
+
+    log.debug("verify_v1_image: response headers: %s", response.headers)
+    response.raise_for_status()
+
+    # if we returned ok, then everything is fine.
+    return True
+
+
+class VerifyMediaTypesPlugin(ExitPlugin):
+    key = 'verify_media_types'
+    is_allowed_to_fail = False
+
+    def run(self):
+        # Only run if the build was successful
+        if self.workflow.build_process_failed:
+            self.log.info("Not running for failed build")
+            return []
+
+        # Work out the name of the image to pull
+        if not self.workflow.tag_conf.unique_images:
+            raise ValueError("no unique image set, impossible to verify media types")
+        if self.workflow.push_conf.pulp_registries:
+            raise RuntimeError("pulp registry configure, verify_media_types should not run")
+        image = self.workflow.tag_conf.unique_images[0]
+
+        media_types = set()
+        registries = deepcopy(get_registries(self.workflow, {}))
+        for registry_name, registry in registries.items():
+            initial_media_types = registry.get('expected_media_types', [])
+            if not initial_media_types:
+                continue
+
+            expected_media_types = self.set_manifest_list_expectations(initial_media_types)
+
+            pullspec = image.copy()
+            pullspec.registry = registry_name
+            insecure = registry.get('insecure', False)
+            secret = registry.get('secret', None)
+
+            check_digests = (MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST in expected_media_types or
+                             MEDIA_TYPE_DOCKER_V2_SCHEMA2 in expected_media_types or
+                             MEDIA_TYPE_DOCKER_V2_SCHEMA1 in expected_media_types)
+            if check_digests:
+                digests = get_manifest_digests(pullspec, registry_name, insecure, secret,
+                                               require_digest=False)
+                if digests:
+                    if digests.v2_list:
+                        self.log.info("Manifest list found")
+                        if MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST in expected_media_types:
+                            media_types.add(MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST)
+                    if digests.v2:
+                        self.log.info("V2 schema 2 digest found")
+                        if MEDIA_TYPE_DOCKER_V2_SCHEMA2 in expected_media_types:
+                            media_types.add(MEDIA_TYPE_DOCKER_V2_SCHEMA2)
+                    if digests.v1:
+                        self.log.info("V2 schema 1 digest found")
+                        if MEDIA_TYPE_DOCKER_V2_SCHEMA1 in expected_media_types:
+                            media_types.add(MEDIA_TYPE_DOCKER_V2_SCHEMA1)
+
+            if MEDIA_TYPE_DOCKER_V1 in expected_media_types:
+                if verify_v1_image(pullspec, registry_name, self.log, insecure, secret):
+                    media_types.add(MEDIA_TYPE_DOCKER_V1)
+
+            # sorting the media type here so the failure message is predictable for unit tests
+            missing_types = []
+            for media_type in sorted(expected_media_types):
+                if media_type not in media_types:
+                    missing_types.append(media_type)
+            if missing_types:
+                raise KeyError("expected media types {0} ".format(missing_types) +
+                               "not in available media types {0}".format(sorted(media_types)))
+        return sorted(media_types)
+
+    def set_manifest_list_expectations(self, expected_media_types):
+        if not self.workflow.postbuild_results.get(PLUGIN_GROUP_MANIFESTS_KEY):
+            self.log.debug('Cannot check if only manifest list digest should be returned '
+                           'because group manifests plugin did not run')
+            return expected_media_types
+
+        platforms = get_platforms(self.workflow)
+        if not platforms:
+            self.log.debug('Cannot check if only manifest list digest should be returned '
+                           'because we have no platforms list')
+            return expected_media_types
+
+        try:
+            platform_to_goarch = get_platform_to_goarch_mapping(self.workflow)
+        except KeyError:
+            self.log.debug('Cannot check if only manifest list digest should be returned '
+                           'because there are no platform descriptors')
+            return expected_media_types
+
+        for plat in platforms:
+            if platform_to_goarch[plat] == 'amd64':
+                self.log.debug('amd64 was built, all media types available')
+                return expected_media_types
+
+        self.log.debug('amd64 was not built, only manifest list digest is available')
+        return [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]

--- a/atomic_reactor/plugins/pre_reactor_config.py
+++ b/atomic_reactor/plugins/pre_reactor_config.py
@@ -233,6 +233,7 @@ def get_registries(workflow, fallback=NO_FALLBACK):
         if registry.get('auth'):
             regdict['secret'] = registry['auth']['cfg_path']
         regdict['insecure'] = registry.get('insecure', False)
+        regdict['expected_media_types'] = registry.get('expected_media_types', [])
 
         registries_cm[reguri.docker_uri] = regdict
 

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -132,6 +132,11 @@ registries:
 - url: https://container-registry.example.com/v2
   auth:
       cfg_path: /var/run/secrets/atomic-reactor/v2-registry-dockercfg
+- url: https://v1-container-registry.example.com/v1
+  insecure: True
+- url: https://better-container-registry.example.com/v2
+  expected_media_types:
+  - application/json
 
 source_registry:
     url: https://registry.private.example.com

--- a/tests/plugins/test_reactor_config.py
+++ b/tests/plugins/test_reactor_config.py
@@ -551,6 +551,7 @@ class TestReactorConfigPlugin(object):
                 if registry.get('auth'):
                     regdict['secret'] = registry['auth']['cfg_path']
                 regdict['insecure'] = registry.get('insecure', False)
+                regdict['expected_media_types'] = registry.get('expected_media_types', [])
 
                 registries_cm[reguri.docker_uri] = regdict
 

--- a/tests/plugins/test_verify_media_types.py
+++ b/tests/plugins/test_verify_media_types.py
@@ -1,0 +1,558 @@
+"""
+Copyright (c) 2018 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+from atomic_reactor.constants import (PLUGIN_GROUP_MANIFESTS_KEY,
+                                      PLUGIN_CHECK_AND_SET_PLATFORMS_KEY,
+                                      MEDIA_TYPE_DOCKER_V1,
+                                      MEDIA_TYPE_DOCKER_V2_SCHEMA1,
+                                      MEDIA_TYPE_DOCKER_V2_SCHEMA2,
+                                      MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST,
+                                      MEDIA_TYPE_OCI_V1, MEDIA_TYPE_OCI_V1_INDEX)
+from atomic_reactor.plugins.exit_verify_media_types import VerifyMediaTypesPlugin
+from atomic_reactor.inner import TagConf, PushConf
+from atomic_reactor.auth import HTTPRegistryAuth
+from atomic_reactor.plugins.pre_reactor_config import (ReactorConfig,
+                                                       ReactorConfigPlugin,
+                                                       ReactorConfigKeys,
+                                                       WORKSPACE_CONF_KEY)
+from osbs.utils import RegistryURI
+
+from flexmock import flexmock
+import pytest
+import requests
+import responses
+import re
+
+from tests.constants import MOCK
+if MOCK:
+    from tests.retry_mock import mock_get_retry_session
+
+DIGEST_V1 = 'sha256:7de72140ec27a911d3f88d60335f08d6530a4af136f7beab47797a196e840afd'
+DIGEST_V2 = 'sha256:85a7e3fb684787b86e64808c5b91d926afda9d6b35a0642a72d7a746452e71c1'
+
+
+class MockerTasker(object):
+    def __init__(self):
+        self.pulled_images = []
+
+    def pull_image(self, image, insecure):
+        self.pulled_images.append(image)
+        return image.to_str()
+
+    def inspect_image(self, image):
+        pass
+
+
+class TestVerifyImageTypes(object):
+    TEST_UNIQUE_IMAGE = 'foo:unique-tag'
+
+    def get_response_config_json(media_type):
+        config = {
+            'digest': 'sha256:2c782e3a93d34d89ea4cf54052768be117caed54803263dd1f3798ce42aac14',
+            'mediaType': 'application/octet-stream',
+            'size': 4132
+        }
+        layer1 = {
+            'digest': 'sha256:16dc1f96e3a1bb628be2e00518fec2bb97bd5933859de592a00e2eb7774b',
+            'mediaType': 'application/vnd.docker.image.rootfs.diff.tar.gzip',
+            'size': 71907148
+        }
+        layer2 = {
+            'digest': 'sha256:cebc0565e1f096016765f55fde87a6f60fdb1208c0b5017e35a856ff578f',
+            'mediaType': 'application/vnd.docker.image.rootfs.diff.tar.gzip',
+            'size': 3945724
+        }
+        return {
+            'config': config,
+            'layers': [layer1, layer2],
+            'mediaType': media_type,
+            'schemaVersion': 2
+        }
+
+    broken_response = {
+        'schemaVersion': 'foo',
+        'not-mediaType': 'bar'
+    }
+
+    config_response_none = requests.Response()
+    (flexmock(config_response_none,
+              raise_for_status=lambda: None,
+              status_code=requests.codes.ok,
+              json=get_response_config_json(MEDIA_TYPE_DOCKER_V2_SCHEMA2),
+              headers={
+                'Content-Type': 'application/invalid+json',
+                'Docker-Content-Digest': "12"
+              }))
+    config_response_v1 = requests.Response()
+    (flexmock(config_response_v1,
+              raise_for_status=lambda: None,
+              status_code=requests.codes.ok,
+              json=get_response_config_json(DIGEST_V1),
+              headers={
+                'Content-Type': 'application/json'
+              }))
+    config_response_config_v1 = requests.Response()
+    (flexmock(config_response_config_v1,
+              raise_for_status=lambda: None,
+              status_code=requests.codes.ok,
+              json=get_response_config_json(MEDIA_TYPE_DOCKER_V2_SCHEMA1),
+              headers={
+                'Content-Type': 'application/vnd.docker.distribution.manifest.v1+json',
+                'Docker-Content-Digest': DIGEST_V1
+              }))
+    config_response_config_v2 = requests.Response()
+    (flexmock(config_response_config_v2,
+              raise_for_status=lambda: None,
+              status_code=requests.codes.ok,
+              json=get_response_config_json(MEDIA_TYPE_DOCKER_V2_SCHEMA2),
+              headers={
+                'Content-Type': 'application/vnd.docker.distribution.manifest.v2+json',
+                'Docker-Content-Digest': DIGEST_V2
+              }))
+    config_response_config_v2_list = requests.Response()
+    (flexmock(config_response_config_v2_list,
+              raise_for_status=lambda: None,
+              status_code=requests.codes.ok,
+              json=get_response_config_json(MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST),
+              headers={
+                'Content-Type': 'application/vnd.docker.distribution.manifest.list.v2+json',
+              }))
+
+    def workflow(self, build_process_failed=False, registries=None, registry_types=None,
+                 platforms=None, platform_descriptors=None, group=True, no_amd64=False,
+                 fail=False):
+        tag_conf = TagConf()
+        tag_conf.add_unique_image(self.TEST_UNIQUE_IMAGE)
+
+        push_conf = PushConf()
+
+        if platform_descriptors is None:
+            platform_descriptors = [
+                {'platform': 'x86_64', 'architecture': 'amd64'},
+                {'platform': 'ppc64le', 'architecture': 'ppc64le'},
+                {'platform': 's390x', 'architecture': 's390x'},
+            ]
+
+        if platforms is None:
+            platforms = [descriptor['platform'] for descriptor in platform_descriptors]
+
+        if registries is None and registry_types is None:
+            registry_types = [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_SCHEMA1,
+                              MEDIA_TYPE_DOCKER_V2_SCHEMA2, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]
+
+        if registries is None:
+            registries = [{
+                'url': 'https://container-registry.example.com/v2',
+                'version': 'v2',
+                'insecure': True,
+                'expected_media_types': registry_types
+            }]
+        conf = {
+            ReactorConfigKeys.VERSION_KEY: 1,
+            'registries': registries,
+        }
+        if platform_descriptors:
+            conf['platform_descriptors'] = platform_descriptors
+
+        plugin_workspace = {
+            ReactorConfigPlugin.key: {
+                WORKSPACE_CONF_KEY: ReactorConfig(conf)
+            }
+        }
+
+        flexmock(HTTPRegistryAuth).should_receive('__new__').and_return(None)
+        mock_auth = None
+        for registry in registries:
+            def get_manifest(request):
+                media_types = request.headers.get('Accept', '').split(',')
+                content_type = media_types[0]
+
+                return (200, {'Content-Type': content_type}, '{}')
+
+            url_regex = "r'" + registry['url'] + ".*/manifests/.*'"
+            url = re.compile(url_regex)
+            responses.add_callback(responses.GET, url, callback=get_manifest)
+
+            expected_types = registry.get('expected_media_types', [])
+            if fail == "bad_results":
+                response_types = [MEDIA_TYPE_DOCKER_V1]
+            elif no_amd64:
+                response_types = [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]
+            else:
+                response_types = expected_types
+
+            reguri = RegistryURI(registry['url']).docker_uri
+            if re.match('http(s)?://', reguri):
+                urlbase = reguri
+            else:
+                urlbase = 'https://{0}'.format(reguri)
+
+            actual_v2_url = urlbase + "/v2/foo/manifests/unique-tag"
+            actual_v1_url = urlbase + "/v1/repositories/foo/tags/unique-tag"
+
+            v1_response = self.config_response_none
+            v2_response = self.config_response_none
+            v2_list_response = self.config_response_none
+            if MEDIA_TYPE_DOCKER_V2_SCHEMA1 in response_types:
+                v1_response = self.config_response_config_v1
+            if MEDIA_TYPE_DOCKER_V2_SCHEMA2 in response_types:
+                v2_response = self.config_response_config_v2
+            if MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST in response_types:
+                v2_list_response = self.config_response_config_v2_list
+            v2_header_v1 = {'Accept': MEDIA_TYPE_DOCKER_V2_SCHEMA1}
+            v2_header_v2 = {'Accept': MEDIA_TYPE_DOCKER_V2_SCHEMA2}
+            manifest_header = {'Accept': MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST}
+
+            (flexmock(requests.Session)
+                .should_receive('get')
+                .with_args(actual_v2_url, headers=v2_header_v1,
+                           auth=mock_auth, verify=False)
+                .and_return(v1_response))
+            (flexmock(requests.Session)
+                .should_receive('get')
+                .with_args(actual_v2_url, headers=v2_header_v2,
+                           auth=mock_auth, verify=False)
+                .and_return(v2_response))
+            (flexmock(requests.Session)
+                .should_receive('get')
+                .with_args(actual_v2_url, headers={'Accept': MEDIA_TYPE_OCI_V1},
+                           auth=mock_auth, verify=False)
+                .and_return(self.config_response_none))
+            (flexmock(requests.Session)
+                .should_receive('get')
+                .with_args(actual_v2_url, headers={'Accept': MEDIA_TYPE_OCI_V1_INDEX},
+                           auth=mock_auth, verify=False)
+                .and_return(self.config_response_none))
+            (flexmock(requests.Session)
+                .should_receive('get')
+                .with_args(actual_v2_url, headers=manifest_header,
+                           auth=mock_auth, verify=False)
+                .and_return(v2_list_response))
+
+            if MEDIA_TYPE_DOCKER_V1 in response_types:
+                (flexmock(requests.Session)
+                    .should_receive('get')
+                    .with_args(actual_v1_url, headers={'Accept': MEDIA_TYPE_DOCKER_V1},
+                               auth=mock_auth, verify=False)
+                    .and_return(self.config_response_v1))
+
+        digests = {'digest': None} if group else {}
+        prebuild_results = {PLUGIN_CHECK_AND_SET_PLATFORMS_KEY: platforms}
+        postbuild_results = {PLUGIN_GROUP_MANIFESTS_KEY: digests}
+
+        mock_get_retry_session()
+        builder = flexmock()
+        setattr(builder, 'image_id', 'sha256:(old)')
+        return flexmock(tag_conf=tag_conf,
+                        push_conf=push_conf,
+                        builder=builder,
+                        build_process_failed=build_process_failed,
+                        plugin_workspace=plugin_workspace,
+                        prebuild_results=prebuild_results,
+                        postbuild_results=postbuild_results)
+
+    """
+    The simplest test case, and everything works
+    """
+    @responses.activate
+    def test_verify_successful_simple(self):
+        workflow = self.workflow()
+        tasker = MockerTasker()
+
+        # Set the timeout parameters so that we retry exactly once, but quickly.
+        # With the get_manifest_digests() API, the 'broken_response' case isn't
+        # distinguishable from no manifest yet, so we retry until timout
+        plugin = VerifyMediaTypesPlugin(tasker, workflow)
+        results = plugin.run()
+
+        assert results == sorted([MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_SCHEMA1,
+                                  MEDIA_TYPE_DOCKER_V2_SCHEMA2,
+                                  MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST])
+
+    @responses.activate
+    @pytest.mark.parametrize(('registry_types', 'platform_descriptors',
+                              'group', 'no_amd64', 'expected_results'), [
+        ([],
+         [{'platform': 'arm64', 'architecture': 'arm64'}],
+         True, False, []),
+        # If group manifests ran, non-x86-64 builds can only produce
+        # MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST
+        ([MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST],
+         [{'platform': 'arm64', 'architecture': 'arm64'}],
+         True, True, [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+        ([MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST],
+         [{'platform': 'arm64', 'architecture': 'arm64'}],
+         True, True, [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+        ([MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_SCHEMA1,
+          MEDIA_TYPE_DOCKER_V2_SCHEMA2, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST],
+         [{'platform': 'arm64', 'architecture': 'arm64'}],
+         True, True, [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+        ([MEDIA_TYPE_DOCKER_V1],
+         [{'platform': 'arm64', 'architecture': 'arm64'}],
+         True, True, [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+        ([MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST],
+         [{'platform': 'x86_64', 'architecture': 'amd64'},
+          {'platform': 'arm64', 'architecture': 'arm64'}],
+         True, False, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+        ([MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_SCHEMA2, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST],
+         [{'platform': 'x86_64', 'architecture': 'amd64'},
+          {'platform': 'arm64', 'architecture': 'arm64'}],
+         True, False, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_SCHEMA2,
+                       MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+        ([MEDIA_TYPE_DOCKER_V1],
+         [{'platform': 'x86_64', 'architecture': 'amd64'},
+          {'platform': 'arm64', 'architecture': 'arm64'}],
+         True, False, [MEDIA_TYPE_DOCKER_V1]),
+        # If group manifests didn't run, non-x86-64 builds can produce any type
+        # Well, actually, the build will fail but if it didn't fail, they could produce any type
+        ([MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST],
+         [{'platform': 'arm64', 'architecture': 'arm64'}],
+         False, False, [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+        ([MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST],
+         [{'platform': 'arm64', 'architecture': 'arm64'}],
+         False, False, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+        ([MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_SCHEMA1,
+          MEDIA_TYPE_DOCKER_V2_SCHEMA2, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST],
+         [{'platform': 'arm64', 'architecture': 'arm64'}],
+         False, False, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_SCHEMA1,
+                        MEDIA_TYPE_DOCKER_V2_SCHEMA2, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+        ([MEDIA_TYPE_DOCKER_V1],
+         [{'platform': 'arm64', 'architecture': 'arm64'}],
+         False, False, [MEDIA_TYPE_DOCKER_V1]),
+        ([MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST],
+         [{'platform': 'x86_64', 'architecture': 'amd64'},
+          {'platform': 'arm64', 'architecture': 'arm64'}],
+         False, False, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+        ([MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_SCHEMA2, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST],
+         [{'platform': 'x86_64', 'architecture': 'amd64'},
+          {'platform': 'arm64', 'architecture': 'arm64'}],
+         False, False, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_SCHEMA2,
+                        MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+        ([MEDIA_TYPE_DOCKER_V1],
+         [{'platform': 'x86_64', 'architecture': 'amd64'},
+          {'platform': 'arm64', 'architecture': 'arm64'}],
+         False, False, [MEDIA_TYPE_DOCKER_V1]),
+    ])
+    def test_verify_successful_complicated(self, registry_types,
+                                           platform_descriptors, group, no_amd64,
+                                           expected_results):
+        workflow = self.workflow(registry_types=registry_types,
+                                 platform_descriptors=platform_descriptors, group=group,
+                                 no_amd64=no_amd64)
+        tasker = MockerTasker()
+
+        plugin = VerifyMediaTypesPlugin(tasker, workflow)
+        results = plugin.run()
+
+        assert results == sorted(expected_results)
+
+    """
+    Two registries, everything behaves correctly
+    """
+    @responses.activate
+    @pytest.mark.parametrize(('registries', 'platform_descriptors', 'group', 'no_amd64',
+                              'expected_results'), [
+        ([{'url': 'https://container-registry.example.com/v2',
+           'version': 'v2', 'insecure': True,
+           'expected_media_types': [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]},
+          {'url': 'https://container-registry-test.example.com/v2',
+           'version': 'v2', 'insecure': True,
+           'expected_media_types': [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]}],
+         [{'platform': 'arm64', 'architecture': 'arm64'}],
+         True, True, [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+        ([{'url': 'https://container-registry.example.com/v2',
+           'version': 'v2', 'insecure': True,
+           'expected_media_types': [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]},
+          {'url': 'https://container-registry-test.example.com/v2',
+           'version': 'v2', 'insecure': True,
+           'expected_media_types': [MEDIA_TYPE_DOCKER_V1]}],
+         [{'platform': 'arm64', 'architecture': 'arm64'}],
+         True, True, [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+        ([{'url': 'https://container-registry.example.com/v2',
+           'version': 'v2', 'insecure': True,
+           'expected_media_types': [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]},
+          {'url': 'https://container-registry-test.example.com/v2',
+           'version': 'v2', 'insecure': True,
+           'expected_media_types': [MEDIA_TYPE_DOCKER_V1]}],
+         [{'platform': 'arm64', 'architecture': 'arm64'},
+          {'platform': 'x86_64', 'architecture': 'amd64'}],
+         True, False, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+        ([{'url': 'https://container-registry.example.com/v2',
+           'version': 'v2', 'insecure': True,
+           'expected_media_types': [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]},
+          {'url': 'https://container-registry-test.example.com/v2',
+           'version': 'v2', 'insecure': True,
+           'expected_media_types': [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]}],
+         [{'platform': 'arm64', 'architecture': 'arm64'},
+          {'platform': 'x86_64', 'architecture': 'amd64'}],
+         True, False, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+        ([{'url': 'https://container-registry.example.com/v2',
+           'version': 'v2', 'insecure': True,
+           'expected_media_types': [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]},
+          {'url': 'https://container-registry-test.example.com/v2',
+           'version': 'v2', 'insecure': True,
+           'expected_media_types': [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]}],
+         [{'platform': 'arm64', 'architecture': 'arm64'}],
+         False, False, [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+        ([{'url': 'https://container-registry.example.com/v2',
+           'version': 'v2', 'insecure': True,
+           'expected_media_types': [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]},
+          {'url': 'https://container-registry-test.example.com/v2',
+           'version': 'v2', 'insecure': True,
+           'expected_media_types': [MEDIA_TYPE_DOCKER_V1]}],
+         [{'platform': 'arm64', 'architecture': 'arm64'}],
+         False, False, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+        ([{'url': 'https://container-registry.example.com/v2',
+           'version': 'v2', 'insecure': True,
+           'expected_media_types': [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]},
+          {'url': 'https://container-registry-test.example.com/v2',
+           'version': 'v2', 'insecure': True,
+           'expected_media_types': [MEDIA_TYPE_DOCKER_V1]}],
+         [{'platform': 'arm64', 'architecture': 'arm64'},
+          {'platform': 'x86_64', 'architecture': 'amd64'}],
+         False, False, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+        ([{'url': 'https://container-registry.example.com/v2',
+           'version': 'v2', 'insecure': True,
+           'expected_media_types': [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]},
+          {'url': 'https://container-registry-test.example.com/v2',
+           'version': 'v2', 'insecure': True,
+           'expected_media_types': [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]}],
+         [{'platform': 'arm64', 'architecture': 'arm64'},
+          {'platform': 'x86_64', 'architecture': 'amd64'}],
+         False, False, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+    ])
+    def test_verify_successful_two_registries(self, registries,
+                                              platform_descriptors, group, no_amd64,
+                                              expected_results):
+        workflow = self.workflow(registries=registries,
+                                 platform_descriptors=platform_descriptors, group=group,
+                                 no_amd64=no_amd64)
+        tasker = MockerTasker()
+
+        plugin = VerifyMediaTypesPlugin(tasker, workflow)
+        results = plugin.run()
+
+        assert results == sorted(expected_results)
+
+        """
+         """
+
+    """
+    Configuration is bad, but not so bad as to cause a problem
+    """
+    @responses.activate
+    @pytest.mark.parametrize(('registries', 'platforms', 'platform_descriptors',
+                              'group', 'no_amd64',
+                              'expected_results'), [
+        # Null registries and registries without expected_media_types return nothing
+        ([],
+         None, [{'platform': 'x86_64', 'architecture': 'amd64'}],
+         True, False, []),
+        ([{'url': 'https://container-registry.example.com/v2',
+           'version': 'v2', 'insecure': True}],
+         None, [{'platform': 'x86_64', 'architecture': 'amd64'}],
+         True, False, []),
+        ([{'url': 'https://container-registry.example.com/v2',
+           'version': 'v2', 'insecure': True},
+          {'url': 'https://container-registry-test.example.com/v2',
+           'version': 'v2', 'insecure': True,
+           'expected_media_types': [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]}],
+         None, [{'platform': 'arm64', 'architecture': 'arm64'}],
+         True, False, [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+
+        # no platforms or platform descriptors, assume x86_64 wasn't build
+        ([{'url': 'https://container-registry.example.com/v2',
+           'version': 'v2', 'insecure': True,
+           'expected_media_types': [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]},
+          {'url': 'https://container-registry-test.example.com/v2',
+           'version': 'v2', 'insecure': True,
+           'expected_media_types': [MEDIA_TYPE_DOCKER_V1]}],
+         ['x86_64', 'arm64'], [],
+         True, False, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+        ([{'url': 'https://container-registry.example.com/v2',
+           'version': 'v2', 'insecure': True,
+           'expected_media_types': [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]},
+          {'url': 'https://container-registry-test.example.com/v2',
+           'version': 'v2', 'insecure': True,
+           'expected_media_types': [MEDIA_TYPE_DOCKER_V1]}],
+         [], [{'platform': 'arm64', 'architecture': 'arm64'}],
+         True, False, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+    ])
+    def test_verify_malformed_two_registries(self, registries, platforms,
+                                             platform_descriptors, group, no_amd64,
+                                             expected_results):
+        workflow = self.workflow(registries=registries, platforms=platforms,
+                                 platform_descriptors=platform_descriptors, group=group,
+                                 no_amd64=no_amd64)
+        tasker = MockerTasker()
+
+        plugin = VerifyMediaTypesPlugin(tasker, workflow)
+        results = plugin.run()
+
+        assert results == sorted(expected_results)
+
+    """
+    If there is no image, this plugin shouldn't run and how did we get here?
+    """
+    @responses.activate
+    def test_verify_fail_no_image(self):
+        workflow = self.workflow()
+        workflow.tag_conf = TagConf()
+        tasker = MockerTasker()
+
+        plugin = VerifyMediaTypesPlugin(tasker, workflow)
+        with pytest.raises(ValueError) as exc:
+            plugin.run()
+        assert "no unique image set, impossible to verify media types" in str(exc.value)
+
+    """
+    If pulp is enabled, this plugin shouldn't run
+    """
+    @responses.activate
+    def test_verify_fail_pulp_image(self):
+        workflow = self.workflow()
+        workflow.push_conf.add_pulp_registry('pulp', crane_uri='crane.example.com',
+                                             server_side_sync=False)
+        tasker = MockerTasker()
+
+        plugin = VerifyMediaTypesPlugin(tasker, workflow)
+        with pytest.raises(RuntimeError) as exc:
+            plugin.run()
+        assert "pulp registry configure, verify_media_types should not run" in str(exc.value)
+
+    """
+    Build was unsuccessful, return an empty list
+    """
+    @responses.activate
+    def test_verify_fail_no_build(self):
+        workflow = self.workflow(build_process_failed=True)
+        tasker = MockerTasker()
+
+        plugin = VerifyMediaTypesPlugin(tasker, workflow)
+        results = plugin.run()
+        assert results == []
+
+    """
+    All results are garbage, so fail
+    """
+    @responses.activate
+    def test_verify_fail_bad_results(self):
+        workflow = self.workflow(fail="bad_results")
+        tasker = MockerTasker()
+
+        plugin = VerifyMediaTypesPlugin(tasker, workflow)
+        expect_media_types = [MEDIA_TYPE_DOCKER_V1]
+        expect_missing_types = sorted([MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST,
+                                       MEDIA_TYPE_DOCKER_V2_SCHEMA1, MEDIA_TYPE_DOCKER_V2_SCHEMA2])
+        missing_msg = "expected media types {0} ".format(expect_missing_types)
+        media_msg = "not in available media types {0}".format(expect_media_types)
+        failmsg = missing_msg + media_msg
+
+        with pytest.raises(KeyError) as exc:
+            plugin.run()
+        assert failmsg in str(exc.value)


### PR DESCRIPTION
Add the verify_media_types plugin. It runs in place of pulp_pull on builds that don't run pulp.

When it runs, it
1. gets the list of expected media types for each registry
2. checks there aren't any overrides for the expected types. the only current override is if the x86_64 build did not run, only manifest lists are available.
3. checks that a digest or images is available for each expected type
4. returns the list of expected types or raises if an expected type does not have a digest or image.