### PR TITLE
pre_change_from_in_df: adjust for ImageName having a default tag

### DIFF
--- a/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
+++ b/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
@@ -225,6 +225,12 @@ class StoreMetadataInOSv3Plugin(ExitPlugin):
         except AttributeError:
             dockerfile_contents = ""
 
+        def parent_images_to_str(parent_images):
+            results = {}
+            for base_image_name, parent_image_name in parent_images.items():
+                results[base_image_name.to_str()] = parent_image_name.to_str()
+            return results
+
         annotations = {
             "dockerfile": dockerfile_contents,
             "repositories": json.dumps(self.get_repositories()),
@@ -233,7 +239,7 @@ class StoreMetadataInOSv3Plugin(ExitPlugin):
             "base-image-name": base_image_name,
             "image-id": self.workflow.builder.image_id or '',
             "digests": json.dumps(self.get_pullspecs(self.get_digests())),
-            "parent_images": json.dumps(self.workflow.builder.parent_images),
+            "parent_images": json.dumps(parent_images_to_str(self.workflow.builder.parent_images)),
             "plugins-metadata": json.dumps(self.get_plugin_metadata()),
             "filesystem": json.dumps(self.get_filesystem_metadata()),
         }

--- a/atomic_reactor/plugins/pre_pull_base_image.py
+++ b/atomic_reactor/plugins/pre_pull_base_image.py
@@ -69,11 +69,11 @@ class PullBaseImagePlugin(PreBuildPlugin):
         build_json = get_build_json()
         current_platform = platform.processor() or 'x86_64'
         self.manifest_list_cache = {}
-        for nonce, parent in enumerate(sorted(self.workflow.builder.parent_images.keys())):
-            image = ImageName.parse(parent)
+        for nonce, parent in enumerate(sorted(self.workflow.builder.parent_images.keys(),
+                                              key=str)):
+            image = parent
             is_base_image = False
             # original_base_image is an ImageName, so compare parent as an ImageName also
-            # since image is parent as an ImageName, just use that
             if image == self.workflow.builder.original_base_image:
                 is_base_image = True
                 image = self._resolve_base_image(build_json)
@@ -91,7 +91,7 @@ class PullBaseImagePlugin(PreBuildPlugin):
                 new_image = image
             else:
                 new_image = self._pull_and_tag_image(image, build_json, str(nonce))
-            self.workflow.builder.parent_images[parent] = str(new_image)
+            self.workflow.builder.parent_images[parent] = new_image
 
             if is_base_image:
                 self.workflow.builder.set_base_image(str(new_image),

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -73,6 +73,10 @@ class ImageName(object):
     def parse(cls, image_name):
         result = cls()
 
+        if isinstance(image_name, cls):
+            logger.debug("Attempting to parse ImageName %s as an ImageName", image_name)
+            return image_name
+
         # registry.org/namespace/repo:tag
         s = image_name.split('/', 2)
 

--- a/tests/plugins/test_store_metadata.py
+++ b/tests/plugins/test_store_metadata.py
@@ -57,7 +57,7 @@ class X(object):
     source.dockerfile_path = None
     source.path = None
     base_image = ImageName(repo="qwe", tag="asd")
-    parent_images = {base_image.to_str(): "sha256:spamneggs"}
+    parent_images = {base_image: ImageName.parse("sha256:spamneggs")}
     original_base_image = base_image.copy()
     # image = ImageName.parse("test-image:unique_tag_123")
 

--- a/tests/stubs.py
+++ b/tests/stubs.py
@@ -10,6 +10,7 @@ of the BSD license. See the LICENSE file for details.
 from __future__ import unicode_literals
 
 from os.path import dirname
+from atomic_reactor.util import ImageName
 
 
 # Stubs for commonly-mocked classes
@@ -75,7 +76,8 @@ class StubInsideBuilder(object):
         return self
 
     def set_parent_inspection_data(self, image, inspection_data):
-        self._parent_inspection_data[image] = inspection_data
+        image_name = ImageName.parse(image)
+        self._parent_inspection_data[image_name] = inspection_data
         return self
 
     def set_source(self, source):

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -48,11 +48,11 @@ def test_parent_images(parents_pulled, tmpdir, source_params):
     s = get_source_instance_for(source_params)
     b = InsideBuilder(s, '')
 
-    orig_base = str(b.base_image)
+    orig_base = b.base_image
     assert orig_base in b.parent_images
     assert b.parent_images[orig_base] is None
     b.set_base_image("spam:eggs", parents_pulled=parents_pulled)
-    assert b.parent_images[orig_base] == "spam:eggs"
+    assert b.parent_images[orig_base] == ImageName.parse("spam:eggs")
     assert b._parents_pulled == parents_pulled
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -113,6 +113,15 @@ def test_image_name_format():
         assert image_name.to_str() == expected
 
 
+def test_image_name_parse_image_name(caplog):
+    warning = 'Attempting to parse ImageName test:latest as an ImageName'
+    test = ImageName.parse("test")
+    assert warning not in caplog.text()
+    image_test = ImageName.parse(test)
+    assert warning in caplog.text()
+    assert test is image_test
+
+
 @pytest.mark.parametrize(('repo', 'organization', 'enclosed_repo'), (
     ('fedora', 'spam', 'spam/fedora'),
     ('spam/fedora', 'spam', 'spam/fedora'),


### PR DESCRIPTION
now that ImageNames supply a default tag of ':latest', pre_change_from needs to be updated to take into account the new logic.
    
in the plugin itself, this involves being explicit about when a value is a raw string, an ImageName, or an ImageName.to_str().
    
In the test cases, this requires providing ':latest' tags for parent_images keys.
    
One test case was changed use a literal expected value instead of a calculated expected value, both as good practice and because calculating the expected value became much more complicated.