### PR TITLE
verify_media_types: take advantage of the plugin

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -92,6 +92,7 @@ PLUGIN_COMPARE_COMPONENTS_KEY = 'compare_components'
 PLUGIN_CHECK_AND_SET_PLATFORMS_KEY = 'check_and_set_platforms'
 PLUGIN_REMOVE_WORKER_METADATA_KEY = 'remove_worker_metadata'
 PLUGIN_RESOLVE_COMPOSES_KEY = 'resolve_composes'
+PLUGIN_VERIFY_MEDIA_KEY = 'verify_media'
 
 # some shared dict keys for build metadata that gets recorded with koji.
 # for consistency of metadata in historical builds, these values basically cannot change.

--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -39,7 +39,8 @@ except ImportError:
 
 from atomic_reactor.constants import (
     PLUGIN_KOJI_IMPORT_PLUGIN_KEY, PLUGIN_PULP_PULL_KEY, PLUGIN_PULP_SYNC_KEY,
-    PLUGIN_FETCH_WORKER_METADATA_KEY, PLUGIN_GROUP_MANIFESTS_KEY, PLUGIN_RESOLVE_COMPOSES_KEY
+    PLUGIN_FETCH_WORKER_METADATA_KEY, PLUGIN_GROUP_MANIFESTS_KEY, PLUGIN_RESOLVE_COMPOSES_KEY,
+    PLUGIN_VERIFY_MEDIA_KEY
 )
 from atomic_reactor.util import (Output, get_build_json,
                                  df_parser, ImageName, get_primary_images,
@@ -205,10 +206,11 @@ class KojiImportPlugin(ExitPlugin):
                 media_types = json.loads(annotations['media-types'])
                 break
 
-        # Append media_types from pulp pull
-        pulp_pull_results = self.workflow.exit_results.get(PLUGIN_PULP_PULL_KEY)
-        if pulp_pull_results:
-            media_types += pulp_pull_results
+        # Append media_types from pulp pull or verify images
+        media_results = (self.workflow.exit_results.get(PLUGIN_PULP_PULL_KEY) or
+                         self.workflow.exit_results.get(PLUGIN_VERIFY_MEDIA_KEY))
+        if media_results:
+            media_types += media_results
 
         if media_types:
             extra['image']['media_types'] = sorted(list(set(media_types)))

--- a/atomic_reactor/plugins/exit_verify_media_types.py
+++ b/atomic_reactor/plugins/exit_verify_media_types.py
@@ -10,7 +10,7 @@ the registry expects
 
 from __future__ import unicode_literals
 
-from atomic_reactor.constants import (PLUGIN_GROUP_MANIFESTS_KEY,
+from atomic_reactor.constants import (PLUGIN_GROUP_MANIFESTS_KEY, PLUGIN_VERIFY_MEDIA_KEY,
                                       MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_SCHEMA1,
                                       MEDIA_TYPE_DOCKER_V2_SCHEMA2,
                                       MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST)
@@ -42,7 +42,7 @@ def verify_v1_image(image, registry, log, insecure=False, dockercfg_path=None):
 
 
 class VerifyMediaTypesPlugin(ExitPlugin):
-    key = 'verify_media_types'
+    key = PLUGIN_VERIFY_MEDIA_KEY
     is_allowed_to_fail = False
 
     def run(self):


### PR DESCRIPTION
Add code to exit_koji_import.py and exit_store_metadata_in_osv3.py to get the media type metadata 
from verify_media_types if that information isn't available from pulp_pull.

Add a warning in input_osv3 to detect if an arrangement 6 build has neither of pulp_pull or 
verify_media_types or if it has both of them.