### PR TITLE
still more ImageName default tag fixes

### DIFF
--- a/atomic_reactor/build.py
+++ b/atomic_reactor/build.py
@@ -211,12 +211,14 @@ class InsideBuilder(LastLogger, BuilderStateMachine):
                     """).format(stmt['content'], stage))
 
     def set_base_image(self, base_image, parents_pulled=True, insecure=False):
-        logger.info("setting base image to '%s'", base_image)
         self.base_image = ImageName.parse(base_image)
         self.original_base_image = self.original_base_image or self.base_image
         self.parent_images[self.original_base_image] = self.base_image
         self._parents_pulled = parents_pulled
         self._base_image_insecure = insecure
+        logger.info("set base image to '%s' with original base '%s'", self.base_image,
+                    self.original_base_image)
+
 
     # inspect base image lazily just before it's needed - pre plugins may change the base image
     @property

--- a/atomic_reactor/build.py
+++ b/atomic_reactor/build.py
@@ -219,7 +219,6 @@ class InsideBuilder(LastLogger, BuilderStateMachine):
         logger.info("set base image to '%s' with original base '%s'", self.base_image,
                     self.original_base_image)
 
-
     # inspect base image lazily just before it's needed - pre plugins may change the base image
     @property
     def base_image_inspect(self):
@@ -317,3 +316,15 @@ class InsideBuilder(LastLogger, BuilderStateMachine):
             logger.error("multiple (%d) images found for image '%s'", items_count, self.image)
             raise RuntimeError("multiple (%d) images found for image '%s'" % (items_count,
                                                                               self.image))
+
+    def parent_images_to_str(self):
+        results = {}
+        for base_image_name, parent_image_name in self.parent_images.items():
+            base_str = str(base_image_name)
+            parent_str = str(parent_image_name)
+            if base_image_name and parent_image_name:
+                results[base_str] = parent_str
+            else:
+                logger.debug("None in: base {} has parent {}".format(base_str, parent_str))
+
+        return results

--- a/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
+++ b/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
@@ -225,12 +225,6 @@ class StoreMetadataInOSv3Plugin(ExitPlugin):
         except AttributeError:
             dockerfile_contents = ""
 
-        def parent_images_to_str(parent_images):
-            results = {}
-            for base_image_name, parent_image_name in parent_images.items():
-                results[base_image_name.to_str()] = parent_image_name.to_str()
-            return results
-
         annotations = {
             "dockerfile": dockerfile_contents,
             "repositories": json.dumps(self.get_repositories()),
@@ -239,7 +233,7 @@ class StoreMetadataInOSv3Plugin(ExitPlugin):
             "base-image-name": base_image_name,
             "image-id": self.workflow.builder.image_id or '',
             "digests": json.dumps(self.get_pullspecs(self.get_digests())),
-            "parent_images": json.dumps(parent_images_to_str(self.workflow.builder.parent_images)),
+            "parent_images": json.dumps(self.workflow.builder.parent_images_to_str()),
             "plugins-metadata": json.dumps(self.get_plugin_metadata()),
             "filesystem": json.dumps(self.get_filesystem_metadata()),
         }

--- a/atomic_reactor/plugins/pre_change_from_in_df.py
+++ b/atomic_reactor/plugins/pre_change_from_in_df.py
@@ -55,8 +55,8 @@ class ChangeFromPlugin(PreBuildPlugin):
             # something updated parent_images entry for base without updating
             # the build's base_image; treat it as an error
             raise BaseImageMismatch(
-                "Parent image '{}' does not match base_image '{}'"
-                .format(builder.parent_images[df_base], build_base)
+                "Parent image '{}' for df_base {} does not match base_image '{}'"
+                .format(builder.parent_images[df_base], df_base, build_base)
             )
 
         unresolved = [key for key, val in builder.parent_images.items() if not val]

--- a/tests/plugins/test_store_metadata.py
+++ b/tests/plugins/test_store_metadata.py
@@ -57,9 +57,18 @@ class X(object):
     source.dockerfile_path = None
     source.path = None
     base_image = ImageName(repo="qwe", tag="asd")
-    parent_images = {base_image: ImageName.parse("sha256:spamneggs")}
+    parent_images = {
+       base_image: ImageName.parse("sha256:spamneggs"),
+       ImageName.parse("sha256:spamneggs"): None,
+    }
     original_base_image = base_image.copy()
     # image = ImageName.parse("test-image:unique_tag_123")
+
+    def parent_images_to_str(self):
+        results = {
+            "qwe:asd": "sha256:spamneggs"
+        }
+        return results
 
 
 class XBeforeDockerfile(object):
@@ -69,6 +78,9 @@ class XBeforeDockerfile(object):
     source.path = None
     base_image = None
     parent_images = {}
+
+    def parent_images_to_str(self):
+        return {}
 
     @property
     def df_path(self):
@@ -144,7 +156,7 @@ def prepare(pulp_registries=None, docker_registries=None, before_dockerfile=Fals
         setattr(workflow, 'builder', XBeforeDockerfile())
         setattr(workflow.builder, 'base_image_inspect', {})
     else:
-        setattr(workflow, 'builder', X)
+        setattr(workflow, 'builder', X())
         setattr(workflow.builder, 'base_image_inspect', {'Id': '01234567'})
         workflow.build_logs = [
             "a", "b",
@@ -207,7 +219,6 @@ RUN yum install -y python-django
 CMD blabla"""
     df = df_parser(str(tmpdir))
     df.content = df_content
-    workflow.builder = X
     workflow.builder.df_path = df.dockerfile_path
     workflow.builder.df_dir = str(tmpdir)
 
@@ -426,7 +437,6 @@ RUN yum install -y python-django
 CMD blabla"""
     df = df_parser(str(tmpdir))
     df.content = df_content
-    workflow.builder = X
     workflow.builder.df_path = df.dockerfile_path
     workflow.builder.df_dir = str(tmpdir)
 
@@ -492,7 +502,6 @@ RUN yum install -y python-django
 CMD blabla"""
     df = df_parser(str(tmpdir))
     df.content = df_content
-    workflow.builder = X
     workflow.builder.df_path = df.dockerfile_path
     workflow.builder.df_dir = str(tmpdir)
 
@@ -527,7 +536,6 @@ RUN yum install -y python-django
 CMD blabla"""
     df = df_parser(str(tmpdir))
     df.content = df_content
-    workflow.builder = X
     workflow.builder.df_path = df.dockerfile_path
     workflow.builder.df_dir = str(tmpdir)
 
@@ -580,7 +588,6 @@ RUN yum install -y python-django
 CMD blabla"""
     df = df_parser(str(tmpdir))
     df.content = df_content
-    workflow.builder = X
     workflow.builder.df_path = df.dockerfile_path
     workflow.builder.df_dir = str(tmpdir)
 
@@ -668,7 +675,6 @@ RUN yum install -y python-django
 CMD blabla"""
     df = df_parser(str(tmpdir))
     df.content = df_content
-    workflow.builder = X
     workflow.builder.df_path = df.dockerfile_path
     workflow.builder.df_dir = str(tmpdir)
 
@@ -732,7 +738,6 @@ RUN yum install -y python-django
 CMD blabla"""
     df = df_parser(str(tmpdir))
     df.content = df_content
-    workflow.builder = X
     workflow.builder.df_path = df.dockerfile_path
     workflow.builder.df_dir = str(tmpdir)
 
@@ -768,7 +773,6 @@ RUN yum install -y python-django
 CMD blabla"""
     df = df_parser(str(tmpdir))
     df.content = df_content
-    workflow.builder = X
     workflow.builder.df_path = df.dockerfile_path
     workflow.builder.df_dir = str(tmpdir)
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -293,3 +293,18 @@ def test_build_result():
     assert not BuildResult.make_remote_image_result().is_image_available()
 
     assert not BuildResult.make_remote_image_result().is_failed()
+
+
+def test_parent_images_to_str(tmpdir, caplog):
+    if MOCK:
+        mock_docker()
+
+    source = {'provider': 'path', 'uri': 'file://' + DOCKERFILE_OK_PATH, 'tmpdir': str(tmpdir)}
+    b = InsideBuilder(get_source_instance_for(source), 'built-img')
+    b.set_base_image("spam")
+    b.parent_images["bacon"] = None
+    expected_results = {
+        "fedora:latest": "spam:latest"
+    }
+    assert b.parent_images_to_str() == expected_results
+    assert "None in: base bacon has parent None" in caplog.text()


### PR DESCRIPTION
Add some more information to build.py and change_from_in_df to make it easier to determine why a
parent image isn't found on a BaseMismatchError.

Fix exit_store_metadata to not crash if a parent image is None.