### PR TITLE
Provide mechanism to disable package comparison

### DIFF
--- a/atomic_reactor/plugins/post_compare_components.py
+++ b/atomic_reactor/plugins/post_compare_components.py
@@ -6,6 +6,7 @@ This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
 from atomic_reactor.plugin import PostBuildPlugin
+from atomic_reactor.plugins.pre_reactor_config import get_package_comparison_exceptions
 from atomic_reactor.constants import (PLUGIN_COMPARE_COMPONENTS_KEY,
                                       PLUGIN_FETCH_WORKER_METADATA_KEY)
 
@@ -73,6 +74,8 @@ class CompareComponentsPlugin(PostBuildPlugin):
         if not comp_list:
             raise ValueError("No components to compare")
 
+        package_comparison_exceptions = get_package_comparison_exceptions(self.workflow)
+
         # master compare list
         master_comp = {}
 
@@ -90,6 +93,10 @@ class CompareComponentsPlugin(PostBuildPlugin):
             for component in components:
                 t = component['type']
                 name = component['name']
+
+                if name in package_comparison_exceptions:
+                    self.log.info("Ignoring comparison of package %s", name)
+                    continue
 
                 if t not in SUPPORTED_TYPES:
                     raise ValueError("Type %s not supported")

--- a/atomic_reactor/plugins/pre_reactor_config.py
+++ b/atomic_reactor/plugins/pre_reactor_config.py
@@ -350,6 +350,10 @@ def get_flatpak_base_image(workflow, fallback=NO_FALLBACK):
         raise
 
 
+def get_package_comparison_exceptions(workflow):
+    return set(get_config(workflow).conf.get('package_comparison_exceptions', []))
+
+
 class ClusterConfig(object):
     """
     Configuration relating to a particular cluster

--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -495,6 +495,13 @@
             }
         },
         "additionalProperties": false
+    },
+    "package_comparison_exceptions": {
+        "description": "List of packages that are not compared across architectures",
+        "type": "array",
+        "items": {
+            "type": "string"
+        }
     }
   },
   "definitions": {


### PR DESCRIPTION
In some cases, due to odd packaging practices, certain packages are
expected to have different versions across different arches. This change
allows admins to define a list of packages that should not be compared.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>