### PR TITLE
Adjust data in parent_image_builds in koji import

### DIFF
--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -1349,9 +1349,9 @@ def get_parent_image_koji_data(workflow):
     parents = {}
     for img, build in (koji_parent.get(PARENT_IMAGES_KOJI_BUILDS) or {}).items():
         if not build:
-            parents[img] = None
+            parents[str(img)] = None
         else:
-            parents[img] = {key: val for key, val in build.items() if key in ('id', 'nvr')}
+            parents[str(img)] = {key: val for key, val in build.items() if key in ('id', 'nvr')}
     image_metadata[PARENT_IMAGE_BUILDS_KEY] = parents
 
     base_info = koji_parent.get(BASE_IMAGE_KOJI_BUILD) or {}

--- a/tests/plugins/test_koji_import.py
+++ b/tests/plugins/test_koji_import.py
@@ -1112,9 +1112,9 @@ class TestKojiImport(object):
 
         koji_parent_result = {
             BASE_IMAGE_KOJI_BUILD: dict(id=16, extra='build info'),
-            PARENT_IMAGES_KOJI_BUILDS: dict(
-                base=dict(nvr='base-16.0-1', id=16, extra='build_info'),
-            ),
+            PARENT_IMAGES_KOJI_BUILDS: {
+                ImageName.parse('base'): dict(nvr='base-16.0-1', id=16, extra='build_info'),
+            },
         }
         workflow.prebuild_results[PLUGIN_KOJI_PARENT_KEY] = koji_parent_result
 
@@ -1124,8 +1124,8 @@ class TestKojiImport(object):
         image_metadata = koji_session.metadata['build']['extra']['image']
         key = PARENT_IMAGE_BUILDS_KEY
         assert key in image_metadata
-        assert image_metadata[key]['base'] == dict(nvr='base-16.0-1', id=16)
-        assert 'extra' not in image_metadata[key]['base']
+        assert image_metadata[key]['base:latest'] == dict(nvr='base-16.0-1', id=16)
+        assert 'extra' not in image_metadata[key]['base:latest']
         key = BASE_IMAGE_BUILD_ID_KEY
         assert key in image_metadata
         assert image_metadata[key] == 16


### PR DESCRIPTION
When importing build into Koji, all dict keys are required to be of str
type.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>