### PR TITLE
get_koji_module_build: Handle change to the "archives" that MBS writes

### DIFF
--- a/atomic_reactor/koji_util.py
+++ b/atomic_reactor/koji_util.py
@@ -257,6 +257,10 @@ def get_koji_module_build(session, module_spec):
             raise RuntimeError("No build found for {}".format(module_spec.to_str()))
 
     archives = session.listArchives(buildID=build['build_id'])
+    # The RPM list for the 'modulemd.txt' archive has all the RPMs, recent
+    # versions of MBS also write upload 'modulemd.<arch>.txt' archives with
+    # architecture subsets.
+    archives = [a for a in archives if a['filename'] == 'modulemd.txt']
     assert len(archives) == 1
 
     rpm_list = session.listRPMs(imageID=archives[0]['id'])

--- a/tests/plugins/test_resolve_module_compose.py
+++ b/tests/plugins/test_resolve_module_compose.py
@@ -159,6 +159,7 @@ def mock_koji_session():
      .and_return(
         [{'btype': 'module',
           'build_id': 1138198,
+          'filename': 'modulemd.txt',
           'id': 147879}]))
 
     (session

--- a/tests/test_koji_util.py
+++ b/tests/test_koji_util.py
@@ -292,7 +292,12 @@ class TestGetKojiModuleBuild(object):
             .and_return(
                 [{'btype': 'module',
                   'build_id': 1138198,
-                  'id': 147879}]))
+                  'filename': 'modulemd.txt',
+                  'id': 147879},
+                 {'btype': 'module',
+                  'build_id': 1138198,
+                  'filename': 'modulemd.x86_64.txt',
+                  'id': 147880}]))
         (session
             .should_receive('listRPMs')
             .with_args(imageID=147879)


### PR DESCRIPTION
The module build service used to store a single archive "modulemd.txt",
in koji which had all the RPMs that were built attached to it. It was changed
to write that archive, plus one archive per-architecture, with only the
relevant RPMs for that architecture (modulemd.<arch>.txt).
(https://pagure.io/fm-orchestrator/pull-request/1007)
Handle this by picking out the all-architectures version. While we actually
only need the list of RPMs for a single architecture, getting the architecture we
need to the right place in the code would require considerable plumbing,
and having a bigger list of RPMs only causes (a hopefully small) amount
processing overhead when we set include_pkgs for DNF.