### PR TITLE
YumRepo: add a simple class for handling yum repos

### DIFF
--- a/atomic_reactor/plugins/pre_add_yum_repo.py
+++ b/atomic_reactor/plugins/pre_add_yum_repo.py
@@ -14,6 +14,7 @@ actually places the repo file in the build environment.
 import os
 from atomic_reactor.constants import YUM_REPOS_DIR
 from atomic_reactor.plugin import PreBuildPlugin
+from atomic_reactor.yum_util import YumRepo
 from atomic_reactor.util import render_yum_repo
 
 
@@ -32,8 +33,7 @@ class AddYumRepoPlugin(PreBuildPlugin):
         """
         # call parent constructor
         super(AddYumRepoPlugin, self).__init__(tasker, workflow)
-        self.baseurl = baseurl
-        self.repo_name = repo_name
+        self.repo = YumRepo(baseurl=baseurl, name=repo_name, enabled=True)
 
     def run(self):
         """
@@ -46,6 +46,6 @@ class AddYumRepoPlugin(PreBuildPlugin):
             'enabled': 1,
             'gpgcheck': 0,
         }
-        path = os.path.join(YUM_REPOS_DIR, self.repo_name + ".repo")
+        path = YumRepo(os.path.join(YUM_REPOS_DIR, self.repo_name)).dst_filename
         self.log.info("yum repo of koji target: '%s'", path)
         self.workflow.files[path] = render_yum_repo(repo)

--- a/atomic_reactor/plugins/pre_add_yum_repo_by_url.py
+++ b/atomic_reactor/plugins/pre_add_yum_repo_by_url.py
@@ -23,82 +23,8 @@ Example configuration to add content of repo file at URL:
 }
 
 """
-from atomic_reactor.constants import YUM_REPOS_DIR
 from atomic_reactor.plugin import PreBuildPlugin
-from atomic_reactor.util import get_retrying_requests_session
-from hashlib import md5
-import os
-import os.path
-
-try:
-    # py2
-    from urlparse import unquote, urlsplit
-    import ConfigParser as configparser
-    # We import BytesIO as StringIO as configparser can't properly write
-    from io import BytesIO, BytesIO as StringIO
-except ImportError:
-    # py3
-    from urllib.parse import unquote, urlsplit
-    import configparser
-    from io import BytesIO, StringIO
-
-
-class YumRepo(object):
-    def __init__(self, repourl, dst_repos_dir=YUM_REPOS_DIR):
-        self.repourl = repourl
-        self.dst_repos_dir = dst_repos_dir
-        self.content = None
-
-    @property
-    def filename(self):
-        '''Returns the filename to be used for saving the repo file.
-
-        The filename is derived from the repo url by injecting a suffix
-        after the name and before the file extension. This suffix is a
-        partial md5 checksum of the full repourl. This avoids multiple
-        repos from being written to the same file.
-        '''
-        urlpath = unquote(urlsplit(self.repourl, allow_fragments=False).path)
-        basename = os.path.basename(urlpath)
-        suffix = '-' + md5(self.repourl.encode('utf-8')).hexdigest()[:5]
-        final_name = suffix.join(os.path.splitext(basename))
-        return final_name
-
-    @property
-    def dst_filename(self):
-        return os.path.join(self.dst_repos_dir, self.filename)
-
-    def fetch(self):
-        session = get_retrying_requests_session()
-        response = session.get(self.repourl)
-        response.raise_for_status()
-        self.content = response.content
-
-    def is_valid(self):
-        # Using BytesIO as configparser in 2.7 can't work with unicode
-        # see http://bugs.python.org/issue11597
-        with BytesIO(self.content) as buf:
-            self.config = configparser.ConfigParser()
-            try:
-                # Try python3 method
-                try:
-                    self.config.read_string(self.content.decode('unicode_escape'))
-                except AttributeError:
-                    # Fallback to py2 method
-                    self.config.readfp(buf)
-            except configparser.Error:
-                self.log.warn("Invalid repo file found: '%s'", self.content)
-                return False
-            else:
-                return True
-
-    def set_proxy_for_all_repos(self, proxy_name):
-        for section in self.config.sections():
-            self.config.set(section, 'proxy', proxy_name)
-
-        with StringIO() as output:
-            self.config.write(output)
-            self.content = output.getvalue()
+from atomic_reactor.yum_util import YumRepo
 
 
 class AddYumRepoByUrlPlugin(PreBuildPlugin):

--- a/atomic_reactor/plugins/pre_flatpak_create_dockerfile.py
+++ b/atomic_reactor/plugins/pre_flatpak_create_dockerfile.py
@@ -29,6 +29,8 @@ from atomic_reactor.plugins.pre_resolve_module_compose import get_compose_info
 from atomic_reactor.plugins.build_orchestrate_build import override_build_kwarg
 from atomic_reactor.rpm_util import rpm_qf_args
 from atomic_reactor.util import render_yum_repo, split_module_spec
+from atomic_reactor.yum_util import YumRepo
+
 
 DOCKERFILE_TEMPLATE = '''FROM {base_image}
 
@@ -172,7 +174,7 @@ class FlatpakCreateDockerfilePlugin(PreBuildPlugin):
             'gpgcheck': 0,
         }
 
-        path = os.path.join(YUM_REPOS_DIR, repo_name + '.repo')
+        path = YumRepo(os.path.join(YUM_REPOS_DIR, repo_name)).dst_filename
         self.workflow.files[path] = render_yum_repo(repo, escape_dollars=False)
 
         override_build_kwarg(self.workflow, 'module_compose_id', compose_info.compose_id)

--- a/atomic_reactor/plugins/pre_koji.py
+++ b/atomic_reactor/plugins/pre_koji.py
@@ -9,8 +9,9 @@ of the BSD license. See the LICENSE file for details.
 Pre build plugin for koji build system
 """
 import os
-from atomic_reactor.constants import YUM_REPOS_DIR
 from atomic_reactor.plugin import PreBuildPlugin
+from atomic_reactor.constants import YUM_REPOS_DIR
+from atomic_reactor.yum_util import YumRepo
 from atomic_reactor.util import render_yum_repo
 from atomic_reactor.plugins.pre_reactor_config import (get_koji_session, get_yum_proxy,
                                                        get_koji_path_info)
@@ -95,6 +96,6 @@ class KojiPlugin(PreBuildPlugin):
             self.log.info("Setting yum proxy to %s", self.proxy)
             repo['proxy'] = self.proxy
 
-        path = os.path.join(YUM_REPOS_DIR, self.target + ".repo")
+        path = YumRepo(os.path.join(YUM_REPOS_DIR, self.target)).dst_filename
         self.log.info("yum repo of koji target: '%s'", path)
         self.workflow.files[path] = render_yum_repo(repo, escape_dollars=False)

--- a/atomic_reactor/yum_util.py
+++ b/atomic_reactor/yum_util.py
@@ -1,0 +1,101 @@
+"""
+Copyright (c) 2018 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+
+Utility functions to manipulate a yum repo. Guarantees that a yum repo will have a unique
+name and the .repo suffix.
+
+"""
+from atomic_reactor.constants import YUM_REPOS_DIR
+from atomic_reactor.util import get_retrying_requests_session
+from hashlib import md5
+import os
+import os.path
+import logging
+
+try:
+    # py2
+    from urlparse import unquote, urlsplit
+    import ConfigParser as configparser
+    # We import BytesIO as StringIO as configparser can't properly write
+    from io import BytesIO, BytesIO as StringIO
+except ImportError:
+    # py3
+    from urllib.parse import unquote, urlsplit
+    import configparser
+    from io import BytesIO, StringIO
+
+
+logger = logging.getLogger(__name__)
+
+REPO_SUFFIX = ".repo"
+
+
+class YumRepo(object):
+    def __init__(self, repourl, content='', dst_repos_dir=YUM_REPOS_DIR):
+        if not repourl.endswith(REPO_SUFFIX):
+            repourl += REPO_SUFFIX
+        self.repourl = repourl
+        self.dst_repos_dir = dst_repos_dir
+
+        self.content = content
+
+    @property
+    def filename(self):
+        '''Returns the filename to be used for saving the repo file.
+
+        The filename is derived from the repo url by injecting a suffix
+        after the name and before the file extension. This suffix is a
+        partial md5 checksum of the full repourl. This avoids multiple
+        repos from being written to the same file.
+        '''
+        urlpath = unquote(urlsplit(self.repourl, allow_fragments=False).path)
+        basename = os.path.basename(urlpath)
+        suffix = '-' + md5(self.repourl.encode('utf-8')).hexdigest()[:5]
+        final_name = suffix.join(os.path.splitext(basename))
+        return final_name
+
+    @property
+    def dst_filename(self):
+        return os.path.join(self.dst_repos_dir, self.filename)
+
+    def fetch(self):
+        session = get_retrying_requests_session()
+        response = session.get(self.repourl)
+        response.raise_for_status()
+        self.content = response.content
+
+    def is_valid(self):
+        # Using BytesIO as configparser in 2.7 can't work with unicode
+        # see http://bugs.python.org/issue11597
+        with BytesIO(self.content) as buf:
+            self.config = configparser.ConfigParser()
+            try:
+                # Try python2 method
+                try:
+                    self.config.read_string(self.content.decode('unicode_escape'))
+                except AttributeError:
+                    # Fallback to py3 method
+                    self.config.readfp(buf)
+            except configparser.Error:
+                logger.warn("Invalid repo file found: '%s'", self.content)
+                return False
+            else:
+                return True
+
+    def set_proxy_for_all_repos(self, proxy_name):
+        for section in self.config.sections():
+            self.config.set(section, 'proxy', proxy_name)
+
+        with StringIO() as output:
+            self.config.write(output)
+            self.content = output.getvalue()
+
+    def write_and_return_content(self):
+        logger.info("writing repo to '%s'", self.dst_filename)
+        with open(self.dst_filename, "wb") as fp:
+            fp.write(self.content.encode("utf-8"))
+        logger.debug("%s\n%s", self.repourl, self.content.strip())

--- a/tests/plugins/test_koji.py
+++ b/tests/plugins/test_koji.py
@@ -240,7 +240,7 @@ class TestKoji(object):
                 with open(file_path, 'r') as fd:
                     assert fd.read() == expected
 
-        repofile = '/etc/yum.repos.d/target.repo'
+        repofile = '/etc/yum.repos.d/target-df7bc.repo'
         assert repofile in workflow.files
         content = workflow.files[repofile]
         assert content.startswith("[atomic-reactor-koji-plugin-target]\n")

--- a/tests/plugins/test_yum_inject.py
+++ b/tests/plugins/test_yum_inject.py
@@ -240,6 +240,7 @@ def test_single_repourl(tmpdir):
         tasker, workflow = prepare(df.dockerfile_path,
                                    df_content.inherited_user)
         filename = 'test.repo'
+        unique_filename = 'test-ccece.repo'
         repo_path = os.path.join(YUM_REPOS_DIR, filename)
         workflow.files[repo_path] = repocontent
         runner = PreBuildPluginsRunner(tasker, workflow, [{
@@ -249,7 +250,7 @@ def test_single_repourl(tmpdir):
 
         # Was it written correctly?
         repos_dir = os.path.join(str(tmpdir), RELATIVE_REPOS_PATH)
-        repofile = os.path.join(repos_dir, filename)
+        repofile = os.path.join(repos_dir, unique_filename)
         with open(repofile, "r") as fp:
             assert fp.read() == repocontent
 
@@ -289,6 +290,8 @@ def test_multiple_repourls(tmpdir):
                                    df_content.inherited_user)
         filename1 = 'myrepo.repo'
         filename2 = 'repo-2.repo'
+        unique_filename1 = 'myrepo-457b5.repo'
+        unique_filename2 = 'repo-2-7c47d.repo'
         repo_path1 = os.path.join(YUM_REPOS_DIR, filename1)
         repo_path2 = os.path.join(YUM_REPOS_DIR, filename2)
         workflow.files[repo_path1] = repocontent
@@ -300,7 +303,7 @@ def test_multiple_repourls(tmpdir):
 
         # Remove the repos/ directory.
         repos_dir = os.path.join(str(tmpdir), RELATIVE_REPOS_PATH)
-        for repofile in [filename1, filename2]:
+        for repofile in [unique_filename1, unique_filename2]:
             os.remove(os.path.join(repos_dir, repofile))
 
         os.rmdir(repos_dir)

--- a/tests/test_yum_util.py
+++ b/tests/test_yum_util.py
@@ -1,0 +1,34 @@
+"""
+Copyright (c) 2018 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+
+Very small subset of tests for the YumRepo class. Most testing
+is done in test_add_yum_repo_by_url
+"""
+import sys
+from atomic_reactor.yum_util import YumRepo
+import pytest
+
+
+@pytest.mark.parametrize(('repourl', 'filename'), (
+    ('http://example.com/a/b/c/myrepo.repo', 'myrepo-d0856.repo'),
+    ('http://example.com/a/b/c/myrepo', 'myrepo-d0856.repo'),
+    ('http://example.com/repo-2.repo', 'repo-2-ba4b3.repo'),
+    ('http://example.com/repo-2', 'repo-2-ba4b3.repo'),
+    ('http://example.com/spam/myrepo.repo', 'myrepo-608de.repo'),
+    ('http://example.com/bacon/myrepo', 'myrepo-a1f78.repo'),
+))
+def test_add_repo_to_url(repourl, filename):
+    repo = YumRepo(repourl)
+    assert repo.filename == filename
+
+
+def test_invalid_config():
+    repo = YumRepo('http://example.com/a/b/c/myrepo.repo', 'line noise')
+    if (sys.version_info < (3, 0)):
+        assert not repo.is_valid()
+    else:
+        assert True


### PR DESCRIPTION
Move YumRepo out of add_yum_repo_by_url and into a new yum_util file.
Add a new property to guarantee that the URL ends with .repo.
Consistently use dst_filename across all plugins to ensure that yum
repos have the same destination file on disk with the unique hex hash
and the .repo suffix.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>