### PR TITLE
 Update development environment setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,28 @@
 # Contributing to Atomic Reactor
 
-If you're reading this, it means that you want to contribute to Atomic Reactor. Great! Here are some tips to make sure your pull request gets accepted.
-Note: there are quite a few tools mentioned through this tutorial. To get them all, including Atomic Reactor dependencies, you can run `pip install -r requirements-devel.txt`.
-Also note: while this seems to be an awfully long text, chances are you adhere to most of it just because you're a great developer. And don't worry! Us, core devs, must send code through pull requests, too (well, assuming it isn't an obvious oneliner).
+## Environment preparation
+
+While Atomic Reactor depends on the `docker-py` python package, one of its dependencies (docker-squash) requires the `docker` package to be installed.  Although docker and docker-py have different names in pypi, they are just different versions of the same package, i.e., they are installed under the same namespace. Hence, when we install one of these packages after the other, pip will overwrite files from the first installed package with files from the second one.
+
+For now, Atomic Reactor does not support the `docker` python package, so we want to keep the `docker-py` installation in our environment. For that, you must install docker-squash (which pulls docker) before docker-py, so the former will be overwritten by the latter.
+
+Note that just changing the order of the lists in the requirements file [does not guarantee the packages will be installed in that order](https://pip.pypa.io/en/stable/reference/pip_install/#installation-order).
+
+To make sure `docker` will get pulled before docker-py (and then overwritten by it), we can install our dependencies with
+
+```
+pip install docker-squash
+python setup.py develop
+pip install -r requirements-devel.txt
+```
+
+For python 2 environments, you should activate tests related to dockpulp
+
+```
+pip install git+https://github.com/release-engineering/dockpulp
+```
+
+If all tests pass (`pytest tests`), your environment is set.
 
 ## General Rules
 

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
 -r tests/requirements.txt
-pytest-cov
 pyflakes
 pep8
+git+https://github.com/projectatomic/osbs-client


### PR DESCRIPTION
Atomic Reactor uses `docker-py`, which was renamed to `docker` in later versions. Although these two packages coexist in pypi, they share the same namespace in the system, i.e., the installation of one will overwrite a previous installation of the other.

In [5d706d0](https://github.com/goldmann/docker-squash/commit/5d706d04de176f570ff55427af3bb8dbf4af56a3#diff-b4ef698db8ca845e5845c4618278f29aL1), docker-squash performed a dependency change substituting docker-py by
docker, introduced in docker-squash version 1.0.6.

Atomic Reactor now requires docker-squash >= 1.0.7. This means that it requires both docker-py and docker, which cannot coexist due to the namespace sharing.

When setting up a development environment, if we first install `docker-py` then install `docker-squash` (pulling docker), we get the following error when running unit tests:

```
tests/test_cli.py:39: in <module>
    dt = DockerTasker()
atomic_reactor/core.py:288: in __init__
    self.d = WrappedDocker(**client_kwargs)
atomic_reactor/core.py:249: in __init__
    self.wrapped = docker.APIClient(**kwargs)
/usr/local/lib/python3.6/site-packages/docker/api/client.py:113: in __init__
    config_dict=self._general_configs
E   TypeError: load_config() got an unexpected keyword argument 'config_dict'
```

In travis, we are doing the opposite: first we install docker-squash (which pulls docker) and only then we install docker-py, overwriting the docker package installation (this being the reason why this error is not triggered in CI).

One can replicate the error by installing docker-py before docker-squash (and therefore, overwriting docker-py with docker).

This PR introduces instructions to a functional development environment setup, also removing a redundancy in the development requirements file.

It also highlights the fact that Atomic Reactor have been using docker-squash with a dependency version which is no longer supported upstream (docker gets overwritten by docker-py).

Given the way `test.sh` is structured (it installs docker squash before applying the requirements list), am I right to assume this is a known issue?