### PR TITLE
yum repo utils: detect if the repourl already has an md5sum

### DIFF
--- a/atomic_reactor/plugins/pre_add_yum_repo.py
+++ b/atomic_reactor/plugins/pre_add_yum_repo.py
@@ -33,7 +33,8 @@ class AddYumRepoPlugin(PreBuildPlugin):
         """
         # call parent constructor
         super(AddYumRepoPlugin, self).__init__(tasker, workflow)
-        self.repo = YumRepo(baseurl=baseurl, name=repo_name, enabled=True)
+        self.repo_name = repo_name
+        self.baseurl = baseurl
 
     def run(self):
         """

--- a/atomic_reactor/plugins/pre_inject_yum_repo.py
+++ b/atomic_reactor/plugins/pre_inject_yum_repo.py
@@ -77,7 +77,8 @@ class InjectYumRepoPlugin(PreBuildPlugin):
         os.mkdir(host_repos_path)
 
         for repo, repo_content in self.workflow.files.items():
-            yum_repo = YumRepo(repourl=repo, content=repo_content, dst_repos_dir=host_repos_path)
+            yum_repo = YumRepo(repourl=repo, content=repo_content, dst_repos_dir=host_repos_path,
+                               add_hash=False)
             repos_host_cont_mapping[repo] = yum_repo.write_and_return_content()
 
         # Find out the USER inherited from the base image

--- a/atomic_reactor/yum_util.py
+++ b/atomic_reactor/yum_util.py
@@ -35,9 +35,10 @@ REPO_SUFFIX = ".repo"
 
 
 class YumRepo(object):
-    def __init__(self, repourl, content='', dst_repos_dir=YUM_REPOS_DIR):
+    def __init__(self, repourl, content='', dst_repos_dir=YUM_REPOS_DIR, add_hash=True):
         if not repourl.endswith(REPO_SUFFIX):
             repourl += REPO_SUFFIX
+        self.add_hash = add_hash
         self.repourl = repourl
         self.dst_repos_dir = dst_repos_dir
 
@@ -54,7 +55,10 @@ class YumRepo(object):
         '''
         urlpath = unquote(urlsplit(self.repourl, allow_fragments=False).path)
         basename = os.path.basename(urlpath)
-        suffix = '-' + md5(self.repourl.encode('utf-8')).hexdigest()[:5]
+        if self.add_hash:
+            suffix = '-' + md5(self.repourl.encode('utf-8')).hexdigest()[:5]
+        else:
+            suffix = ''
         final_name = suffix.join(os.path.splitext(basename))
         return final_name
 

--- a/tests/plugins/test_yum_inject.py
+++ b/tests/plugins/test_yum_inject.py
@@ -239,7 +239,7 @@ def test_single_repourl(tmpdir):
         df.lines = df_content.lines_before_add + df_content.lines_before_remove
         tasker, workflow = prepare(df.dockerfile_path,
                                    df_content.inherited_user)
-        filename = 'test.repo'
+        filename = 'test-ccece.repo'
         unique_filename = 'test-ccece.repo'
         repo_path = os.path.join(YUM_REPOS_DIR, filename)
         workflow.files[repo_path] = repocontent
@@ -288,8 +288,8 @@ def test_multiple_repourls(tmpdir):
         df.lines = df_content.lines_before_add + df_content.lines_before_remove
         tasker, workflow = prepare(df.dockerfile_path,
                                    df_content.inherited_user)
-        filename1 = 'myrepo.repo'
-        filename2 = 'repo-2.repo'
+        filename1 = 'myrepo-457b5.repo'
+        filename2 = 'repo-2-7c47d.repo'
         unique_filename1 = 'myrepo-457b5.repo'
         unique_filename2 = 'repo-2-7c47d.repo'
         repo_path1 = os.path.join(YUM_REPOS_DIR, filename1)

--- a/tests/test_yum_util.py
+++ b/tests/test_yum_util.py
@@ -13,16 +13,17 @@ from atomic_reactor.yum_util import YumRepo
 import pytest
 
 
-@pytest.mark.parametrize(('repourl', 'filename'), (
-    ('http://example.com/a/b/c/myrepo.repo', 'myrepo-d0856.repo'),
-    ('http://example.com/a/b/c/myrepo', 'myrepo-d0856.repo'),
-    ('http://example.com/repo-2.repo', 'repo-2-ba4b3.repo'),
-    ('http://example.com/repo-2', 'repo-2-ba4b3.repo'),
-    ('http://example.com/spam/myrepo.repo', 'myrepo-608de.repo'),
-    ('http://example.com/bacon/myrepo', 'myrepo-a1f78.repo'),
+@pytest.mark.parametrize(('repourl', 'add_hash', 'filename'), (
+    ('http://example.com/a/b/c/myrepo.repo', True, 'myrepo-d0856.repo'),
+    ('http://example.com/a/b/c/myrepo', True, 'myrepo-d0856.repo'),
+    ('http://example.com/repo-2.repo', True, 'repo-2-ba4b3.repo'),
+    ('http://example.com/repo-2', True, 'repo-2-ba4b3.repo'),
+    ('http://example.com/spam/myrepo.repo', True, 'myrepo-608de.repo'),
+    ('http://example.com/bacon/myrepo', True, 'myrepo-a1f78.repo'),
+    ('http://example.com/spam/myrepo-608de.repo', False, 'myrepo-608de.repo'),
 ))
-def test_add_repo_to_url(repourl, filename):
-    repo = YumRepo(repourl)
+def test_add_repo_to_url(repourl, add_hash, filename):
+    repo = YumRepo(repourl, add_hash=add_hash)
     assert repo.filename == filename
 
 


### PR DESCRIPTION
Don't append md5sums to repourls that already have md5sums.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>