### PR TITLE
Fix CI build F27-py3

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -66,6 +66,15 @@ fi
 
 # Install package
 $RUN $PKG install -y $PIP_PKG
+
+# fix biscuits installation (dependency of responses)
+# pip installation requires newer version of responses than provided by F27
+# so it is build by pip locally and needs gcc+devel packages to build
+# successfully
+if [[ ${PYTHON_VERSION} == 3 && ${OS_VERSION} == 27 ]]; then
+    ${RUN} ${PKG} install -y gcc redhat-rpm-config "${PYTHON}-devel"
+fi
+
 if [[ $PYTHON_VERSION == 3 && $OS_VERSION == rawhide ]]; then
   # https://fedoraproject.org/wiki/Changes/Making_sudo_pip_safe
   $RUN mkdir -p /usr/local/lib/python3.6/site-packages/


### PR DESCRIPTION
Package *biscuits* from pip3 requires gcc+devel libs for successfull
build. This package is required only for python3.

It is dependency of responses package, but F27 provides older version
than is required (responses>=0.9.0), thus pip must build it locally.

Signed-off-by: Martin Bašti <mbasti@redhat.com>