### PR TITLE
Move fixtures to conftest.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,11 +8,11 @@ of the BSD license. See the LICENSE file for details.
 
 from __future__ import print_function, unicode_literals
 
-import uuid
 import pytest
 import requests
 import requests.exceptions
 from tests.constants import LOCALHOST_REGISTRY_HTTP, DOCKER0_REGISTRY_HTTP, MOCK
+from tests.util import uuid_value
 
 from atomic_reactor.util import ImageName
 from atomic_reactor.core import DockerTasker
@@ -21,13 +21,9 @@ if MOCK:
     from tests.docker_mock import mock_docker
 
 
-def get_uuid():
-    return uuid.uuid4().hex
-
-
 @pytest.fixture()
 def temp_image_name():
-    return ImageName(repo=("atomic-reactor-tests-%s" % get_uuid()))
+    return ImageName(repo=("atomic-reactor-tests-%s" % uuid_value()))
 
 
 @pytest.fixture()

--- a/tests/plugins/test_add_dockerfile.py
+++ b/tests/plugins/test_add_dockerfile.py
@@ -16,7 +16,6 @@ from atomic_reactor.plugins.pre_add_labels_in_df import AddLabelsPlugin
 from atomic_reactor.util import ImageName, df_parser
 from atomic_reactor.constants import INSPECT_CONFIG
 from tests.constants import MOCK_SOURCE, MOCK
-from tests.fixtures import docker_tasker  # noqa
 if MOCK:
     from tests.docker_mock import mock_docker
 

--- a/tests/plugins/test_add_filesystem.py
+++ b/tests/plugins/test_add_filesystem.py
@@ -44,7 +44,6 @@ from atomic_reactor.constants import PLUGIN_ADD_FILESYSTEM_KEY, PLUGIN_CHECK_AND
 from atomic_reactor import koji_util, util
 from tests.constants import (MOCK_SOURCE, DOCKERFILE_GIT, DOCKERFILE_SHA1,
                              MOCK, IMPORTED_IMAGE_ID)
-from tests.fixtures import docker_tasker, reactor_config_map  # noqa
 if MOCK:
     from tests.docker_mock import mock_docker
     from tests.retry_mock import mock_get_retry_session
@@ -356,7 +355,7 @@ def test_missing_yum_repourls(tmpdir, reactor_config_map):  # noqa
 ])
 @pytest.mark.parametrize('raise_error', [True, False])
 def test_image_task_failure(tmpdir, build_cancel, error_during_cancel, raise_error, caplog,
-                            reactor_config_map):
+                            reactor_config_map, docker_tasker):
     if MOCK:
         mock_docker()
 
@@ -620,7 +619,7 @@ def test_image_download(tmpdir, docker_tasker, architecture, architectures, down
         assert plugin_result['filesystem-koji-task-id'] is None
 
 
-@pytest.mark.parametrize(('koji_target'), [None, '', 'guest-fedora-23-docker'])  # noqa:F811
+@pytest.mark.parametrize(('koji_target'), [None, '', 'guest-fedora-23-docker'])
 @responses.activate
 def test_image_build_overwrites_target(tmpdir, koji_target, reactor_config_map):
     plugin = create_plugin_instance(tmpdir,
@@ -645,7 +644,7 @@ def test_image_build_overwrites_target(tmpdir, koji_target, reactor_config_map):
     ]
 
 
-def test_no_target_set(tmpdir, reactor_config_map):  # noqa:F811
+def test_no_target_set(tmpdir, reactor_config_map):
     plugin = create_plugin_instance(tmpdir,
                                     reactor_config_map=reactor_config_map,
                                     koji_target='')

--- a/tests/plugins/test_add_help.py
+++ b/tests/plugins/test_add_help.py
@@ -18,7 +18,6 @@ from atomic_reactor import start_time as atomic_reactor_start_time
 
 from datetime import datetime as dt
 from tests.constants import MOCK_SOURCE
-from tests.fixtures import docker_tasker  # noqa
 
 from textwrap import dedent
 from flexmock import flexmock

--- a/tests/plugins/test_add_labels.py
+++ b/tests/plugins/test_add_labels.py
@@ -27,7 +27,6 @@ import pytest
 from copy import deepcopy
 from flexmock import flexmock
 from tests.constants import MOCK_SOURCE, DOCKERFILE_GIT, DOCKERFILE_SHA1, MOCK
-from tests.fixtures import docker_tasker, reactor_config_map  # noqa
 if MOCK:
     from tests.docker_mock import mock_docker
 

--- a/tests/plugins/test_bump_release.py
+++ b/tests/plugins/test_bump_release.py
@@ -31,7 +31,6 @@ from atomic_reactor.plugins.pre_reactor_config import (ReactorConfigPlugin,
                                                        WORKSPACE_CONF_KEY,
                                                        ReactorConfig)
 from atomic_reactor.util import df_parser
-from tests.fixtures import docker_tasker, reactor_config_map  # noqa
 from flexmock import flexmock
 import pytest
 

--- a/tests/plugins/test_change_from_in_df.py
+++ b/tests/plugins/test_change_from_in_df.py
@@ -20,7 +20,6 @@ from atomic_reactor.plugins.pre_reactor_config import (ReactorConfigPlugin,
                                                        WORKSPACE_CONF_KEY,
                                                        ReactorConfig)
 from atomic_reactor.util import ImageName, df_parser
-from tests.fixtures import docker_tasker, reactor_config_map  # noqa
 from tests.constants import SOURCE
 from tests.stubs import StubInsideBuilder
 from textwrap import dedent
@@ -45,7 +44,7 @@ def mock_workflow():
     return workflow
 
 
-def run_plugin(workflow, reactor_config_map, allow_failure=False, organization=None):  # noqa
+def run_plugin(workflow, reactor_config_map, docker_tasker, allow_failure=False, organization=None):
     if reactor_config_map:
         workflow.plugin_workspace[ReactorConfigPlugin.key] = {}
         workflow.plugin_workspace[ReactorConfigPlugin.key][WORKSPACE_CONF_KEY] =\
@@ -53,7 +52,7 @@ def run_plugin(workflow, reactor_config_map, allow_failure=False, organization=N
                            'registries_organization': organization})
 
     result = PreBuildPluginsRunner(
-       docker_tasker(), workflow,
+       docker_tasker, workflow,
        [{
           'name': ChangeFromPlugin.key,
           'args': {},
@@ -66,8 +65,8 @@ def run_plugin(workflow, reactor_config_map, allow_failure=False, organization=N
     return result[ChangeFromPlugin.key]
 
 
-@pytest.mark.parametrize('organization', [None, 'my_organization'])  # noqa
-def test_update_base_image(organization, tmpdir, reactor_config_map):
+@pytest.mark.parametrize('organization', [None, 'my_organization'])
+def test_update_base_image(organization, tmpdir, reactor_config_map, docker_tasker):
     df_content = dedent("""\
         FROM {}
         LABEL horses=coconuts
@@ -90,12 +89,12 @@ def test_update_base_image(organization, tmpdir, reactor_config_map):
     workflow.builder.set_parent_inspection_data(base_str, dict(Id=base_str))
     workflow.builder.tasker.inspect_image = lambda *_: dict(Id=base_str)
 
-    run_plugin(workflow, reactor_config_map=reactor_config_map, organization=organization)
+    run_plugin(workflow, reactor_config_map, docker_tasker, organization=organization)
     expected_df = df_content.format(base_str)
     assert dfp.content == expected_df
 
 
-def test_update_base_image_inspect_broken(tmpdir, caplog):
+def test_update_base_image_inspect_broken(tmpdir, caplog, docker_tasker):
     """exercise code branch where the base image inspect comes back without an Id"""
     df_content = "FROM base:image"
     dfp = df_parser(str(tmpdir))
@@ -110,13 +109,13 @@ def test_update_base_image_inspect_broken(tmpdir, caplog):
     workflow.builder.set_parent_inspection_data(image_str, dict(no_id="here"))
 
     with pytest.raises(NoIdInspection):
-        ChangeFromPlugin(docker_tasker(), workflow).run()
+        ChangeFromPlugin(docker_tasker, workflow).run()
     assert dfp.content == df_content  # nothing changed
     assert "missing in inspection" in caplog.text()
 
 
 @pytest.mark.parametrize('organization', [None, 'my_organization'])  # noqa
-def test_update_parent_images(organization, tmpdir, reactor_config_map):
+def test_update_parent_images(organization, tmpdir, reactor_config_map, docker_tasker):
     """test the happy path for updating multiple parents"""
     df_content = dedent("""\
         FROM first:parent AS builder1
@@ -169,11 +168,11 @@ def test_update_parent_images(organization, tmpdir, reactor_config_map):
     for image_name, image_id in img_ids.items():
         workflow.builder.set_parent_inspection_data(image_name, dict(Id=image_id))
 
-    run_plugin(workflow, reactor_config_map=reactor_config_map, organization=organization)
+    run_plugin(workflow, reactor_config_map, docker_tasker, organization=organization)
     assert dfp.content == expected_df_content
 
 
-def test_parent_images_unresolved(tmpdir):
+def test_parent_images_unresolved(tmpdir, docker_tasker):
     """test when parent_images hasn't been filled in with unique tags."""
     dfp = df_parser(str(tmpdir))
     dfp.content = "FROM spam"
@@ -188,10 +187,10 @@ def test_parent_images_unresolved(tmpdir):
     }
 
     with pytest.raises(ParentImageUnresolved):
-        ChangeFromPlugin(docker_tasker(), workflow).run()
+        ChangeFromPlugin(docker_tasker, workflow).run()
 
 
-def test_parent_images_missing(tmpdir):
+def test_parent_images_missing(tmpdir, docker_tasker):
     """test when parent_images has been mangled and lacks parents compared to dockerfile."""
     dfp = df_parser(str(tmpdir))
     dfp.content = dedent("""\
@@ -206,10 +205,10 @@ def test_parent_images_missing(tmpdir):
     workflow.builder.base_image = ImageName.parse("build-name:3")
 
     with pytest.raises(ParentImageMissing):
-        ChangeFromPlugin(docker_tasker(), workflow).run()
+        ChangeFromPlugin(docker_tasker, workflow).run()
 
 
-def test_parent_images_mismatch_base_image(tmpdir):
+def test_parent_images_mismatch_base_image(tmpdir, docker_tasker):
     """test when base_image has been updated differently from parent_images."""
     dfp = df_parser(str(tmpdir))
     dfp.content = "FROM base:image"
@@ -221,4 +220,4 @@ def test_parent_images_mismatch_base_image(tmpdir):
     }
 
     with pytest.raises(BaseImageMismatch):
-        ChangeFromPlugin(docker_tasker(), workflow).run()
+        ChangeFromPlugin(docker_tasker, workflow).run()

--- a/tests/plugins/test_check_and_set_rebuild.py
+++ b/tests/plugins/test_check_and_set_rebuild.py
@@ -24,7 +24,6 @@ from osbs.api import OSBS
 import osbs.conf
 from flexmock import flexmock
 from tests.constants import MOCK, MOCK_SOURCE
-from tests.fixtures import docker_tasker, reactor_config_map  # noqa
 from textwrap import dedent
 if MOCK:
     from tests.docker_mock import mock_docker
@@ -109,7 +108,7 @@ class TestCheckRebuild(object):
         with pytest.raises(PluginFailedException):
             runner.run()
 
-    def test_check_no_buildconfig(self, tmpdir, monkeypatch):
+    def test_check_no_buildconfig(self, tmpdir, monkeypatch, reactor_config_map):
         key = 'is_autorebuild'
         value = 'true'
         workflow, runner = self.prepare(tmpdir, key, value, reactor_config_map=reactor_config_map)

--- a/tests/plugins/test_delete_from_registry.py
+++ b/tests/plugins/test_delete_from_registry.py
@@ -23,7 +23,6 @@ from atomic_reactor.plugins.pre_reactor_config import (ReactorConfigPlugin,
                                                        WORKSPACE_CONF_KEY,
                                                        ReactorConfig)
 from tests.constants import LOCALHOST_REGISTRY, DOCKER0_REGISTRY, MOCK, TEST_IMAGE, INPUT_IMAGE
-from tests.fixtures import reactor_config_map  # noqa
 
 from tempfile import mkdtemp
 import os

--- a/tests/plugins/test_fetch_maven_artifacts.py
+++ b/tests/plugins/test_fetch_maven_artifacts.py
@@ -38,7 +38,6 @@ from atomic_reactor.plugins.pre_reactor_config import (ReactorConfigPlugin,
                                                        ReactorConfig)
 from atomic_reactor.util import ImageName
 from tests.constants import MOCK_SOURCE, MOCK
-from tests.fixtures import docker_tasker, reactor_config_map  # noqa
 from textwrap import dedent
 
 if MOCK:

--- a/tests/plugins/test_flatpak_create_dockerfile.py
+++ b/tests/plugins/test_flatpak_create_dockerfile.py
@@ -27,7 +27,6 @@ from atomic_reactor.source import VcsInfo, SourceConfig
 from atomic_reactor.util import ImageName
 
 from tests.constants import (MOCK_SOURCE, FLATPAK_GIT, FLATPAK_SHA1)
-from tests.fixtures import docker_tasker, reactor_config_map  # noqa
 from tests.flatpak import MODULEMD_AVAILABLE, build_flatpak_test_configs, setup_flatpak_compose_info
 
 if MODULEMD_AVAILABLE:

--- a/tests/plugins/test_flatpak_create_oci.py
+++ b/tests/plugins/test_flatpak_create_oci.py
@@ -25,7 +25,6 @@ from atomic_reactor.plugin import PrePublishPluginsRunner, PluginFailedException
 from atomic_reactor.util import ImageName
 
 from tests.constants import TEST_IMAGE
-from tests.fixtures import docker_tasker  # noqa
 from tests.flatpak import (MODULEMD_AVAILABLE, FLATPAK_APP_FINISH_ARGS,
                            setup_flatpak_source_info, build_flatpak_test_configs)
 

--- a/tests/plugins/test_group_manifests.py
+++ b/tests/plugins/test_group_manifests.py
@@ -28,7 +28,6 @@ from atomic_reactor.plugins.post_group_manifests import GroupManifestsPlugin
 from atomic_reactor.plugins.pre_reactor_config import (ReactorConfigPlugin,
                                                        WORKSPACE_CONF_KEY,
                                                        ReactorConfig)
-from tests.fixtures import reactor_config_map  # noqa
 
 if MOCK:
     from tests.docker_mock import mock_docker

--- a/tests/plugins/test_import_image.py
+++ b/tests/plugins/test_import_image.py
@@ -27,7 +27,6 @@ from osbs.exceptions import OsbsResponseException
 from flexmock import flexmock
 import pytest
 from tests.constants import INPUT_IMAGE, SOURCE, MOCK
-from tests.fixtures import reactor_config_map  # noqa
 if MOCK:
     from tests.docker_mock import mock_docker
 
@@ -57,7 +56,7 @@ class ImageStreamResponse:
 DEFAULT_TAGS_AMOUNT = 6
 
 
-def prepare(tmpdir, insecure_registry=None, namespace=None,  # noqa:F811
+def prepare(tmpdir, insecure_registry=None, namespace=None,
             primary_images_tag_conf=DEFAULT_TAGS_AMOUNT,
             primary_images_annotations=DEFAULT_TAGS_AMOUNT, build_process_failed=False,
             organization=None, reactor_config_map=False,):

--- a/tests/plugins/test_inject_parent_image.py
+++ b/tests/plugins/test_inject_parent_image.py
@@ -37,7 +37,6 @@ from atomic_reactor.plugins.pre_reactor_config import (ReactorConfigPlugin,
 from atomic_reactor.util import ImageName
 from flexmock import flexmock
 from tests.constants import MOCK, MOCK_SOURCE
-from tests.fixtures import reactor_config_map  # noqa
 from osbs.utils import graceful_chain_del
 
 import copy

--- a/tests/plugins/test_koji.py
+++ b/tests/plugins/test_koji.py
@@ -33,7 +33,6 @@ from atomic_reactor.core import DockerTasker
 from atomic_reactor.inner import DockerBuildWorkflow
 from atomic_reactor.plugin import PreBuildPluginsRunner
 from atomic_reactor.util import ImageName
-from tests.fixtures import reactor_config_map  # noqa
 from flexmock import flexmock
 import pytest
 from tests.constants import SOURCE, MOCK

--- a/tests/plugins/test_koji_import.py
+++ b/tests/plugins/test_koji_import.py
@@ -61,7 +61,6 @@ from atomic_reactor.constants import (IMAGE_TYPE_DOCKER_ARCHIVE,
                                       PARENT_IMAGES_KOJI_BUILDS, BASE_IMAGE_BUILD_ID_KEY,
                                       PLUGIN_VERIFY_MEDIA_KEY, PARENT_IMAGE_BUILDS_KEY)
 from tests.constants import SOURCE, MOCK
-from tests.fixtures import reactor_config_map  # noqa
 from tests.flatpak import MODULEMD_AVAILABLE, setup_flatpak_source_info
 
 from flexmock import flexmock

--- a/tests/plugins/test_koji_parent.py
+++ b/tests/plugins/test_koji_parent.py
@@ -38,7 +38,6 @@ from atomic_reactor.plugins.pre_reactor_config import (ReactorConfigPlugin,
                                                        ReactorConfig)
 from atomic_reactor.util import ImageName
 from flexmock import flexmock
-from tests.fixtures import reactor_config_map  # noqa
 from tests.constants import MOCK, MOCK_SOURCE
 
 import pytest

--- a/tests/plugins/test_koji_promote.py
+++ b/tests/plugins/test_koji_promote.py
@@ -49,7 +49,6 @@ from atomic_reactor.rpm_util import parse_rpm_output
 from atomic_reactor.source import GitSource, PathSource
 from atomic_reactor.build import BuildResult
 from tests.constants import SOURCE, MOCK
-from tests.fixtures import reactor_config_map  # noqa
 from tests.flatpak import MODULEMD_AVAILABLE, setup_flatpak_source_info
 
 try:

--- a/tests/plugins/test_koji_tag_build.py
+++ b/tests/plugins/test_koji_tag_build.py
@@ -38,7 +38,6 @@ from atomic_reactor.inner import DockerBuildWorkflow
 from atomic_reactor.util import ImageName
 from atomic_reactor.build import BuildResult
 from tests.constants import SOURCE, MOCK
-from tests.fixtures import reactor_config_map  # noqa
 
 from flexmock import flexmock
 import pytest
@@ -131,7 +130,7 @@ def mock_environment(tmpdir, session=None, build_process_failed=False,
     return tasker, workflow
 
 
-def create_runner(tasker, workflow, ssl_certs=False, principal=None,  # noqa:F811
+def create_runner(tasker, workflow, ssl_certs=False, principal=None,
                   keytab=None, poll_interval=0.01, proxy_user=None,
                   reactor_config_map=False, use_args=True):
     args = {
@@ -197,7 +196,7 @@ class TestKojiPromote(object):
         result = runner.run()
         assert result[KojiTagBuildPlugin.key] is None
 
-    @pytest.mark.parametrize('params', [  # noqa:F811
+    @pytest.mark.parametrize('params', [
         {
             'should_raise': False,
             'principal': None,
@@ -265,7 +264,7 @@ class TestKojiPromote(object):
         with pytest.raises(PluginFailedException):
             runner.run()
 
-    @pytest.mark.parametrize('task_states', [  # noqa:F811
+    @pytest.mark.parametrize('task_states', [
         ['FREE', 'ASSIGNED', 'FAILED'],
         ['CANCELED'],
         [None],
@@ -278,7 +277,7 @@ class TestKojiPromote(object):
         with pytest.raises(PluginFailedException):
             runner.run()
 
-    @pytest.mark.parametrize('use_import', [  # noqa:F811
+    @pytest.mark.parametrize('use_import', [
         (True, False)
     ])
     def test_koji_tag_build_success(self, tmpdir, use_import, reactor_config_map):

--- a/tests/plugins/test_koji_upload.py
+++ b/tests/plugins/test_koji_upload.py
@@ -44,7 +44,6 @@ from atomic_reactor.rpm_util import parse_rpm_output
 from atomic_reactor.source import GitSource
 from atomic_reactor.build import BuildResult
 from tests.constants import SOURCE, MOCK
-from tests.fixtures import reactor_config_map  # noqa
 
 from flexmock import flexmock
 import pytest

--- a/tests/plugins/test_orchestrate_build.py
+++ b/tests/plugins/test_orchestrate_build.py
@@ -32,7 +32,6 @@ from osbs.build.build_response import BuildResponse
 from osbs.exceptions import OsbsException
 from osbs.core import Openshift
 from tests.constants import MOCK_SOURCE, TEST_IMAGE, INPUT_IMAGE, SOURCE
-from tests.fixtures import reactor_config_map  # noqa
 from tests.docker_mock import mock_docker
 from textwrap import dedent
 from copy import deepcopy

--- a/tests/plugins/test_pull_base_image.py
+++ b/tests/plugins/test_pull_base_image.py
@@ -26,7 +26,6 @@ from atomic_reactor.plugins.pre_reactor_config import (ReactorConfigPlugin,
                                                        WORKSPACE_CONF_KEY,
                                                        ReactorConfig)
 from requests.exceptions import HTTPError, RetryError, Timeout
-from tests.fixtures import reactor_config_map, inspect_only  # noqa
 from tests.constants import MOCK, MOCK_SOURCE, LOCALHOST_REGISTRY
 
 if MOCK:

--- a/tests/plugins/test_pulp.py
+++ b/tests/plugins/test_pulp.py
@@ -33,7 +33,6 @@ import subprocess
 import pytest
 from flexmock import flexmock
 from tests.constants import INPUT_IMAGE, SOURCE, MOCK
-from tests.fixtures import reactor_config_map  # noqa
 if MOCK:
     from tests.docker_mock import mock_docker
 

--- a/tests/plugins/test_pulp_publish.py
+++ b/tests/plugins/test_pulp_publish.py
@@ -33,7 +33,6 @@ except (ImportError):
 import pytest
 from flexmock import flexmock
 from tests.constants import INPUT_IMAGE, SOURCE, MOCK
-from tests.fixtures import reactor_config_map  # noqa
 if MOCK:
     from tests.docker_mock import mock_docker
 

--- a/tests/plugins/test_pulp_sync.py
+++ b/tests/plugins/test_pulp_sync.py
@@ -37,7 +37,6 @@ from atomic_reactor.plugins.pre_reactor_config import (ReactorConfigPlugin,
                                                        ReactorConfig)
 from atomic_reactor.constants import PLUGIN_PULP_PUSH_KEY
 from atomic_reactor.pulp_util import PulpLogWrapper
-from tests.fixtures import reactor_config_map  # noqa
 
 from flexmock import flexmock
 import json

--- a/tests/plugins/test_pulp_tag.py
+++ b/tests/plugins/test_pulp_tag.py
@@ -23,7 +23,6 @@ from atomic_reactor.plugins.pre_reactor_config import (ReactorConfigPlugin,
                                                        WORKSPACE_CONF_KEY,
                                                        ReactorConfig)
 from atomic_reactor.constants import PLUGIN_PULP_TAG_KEY
-from tests.fixtures import reactor_config_map  # noqa
 
 try:
     if sys.version_info.major > 2:

--- a/tests/plugins/test_pyrpkg_fetch_artefacts.py
+++ b/tests/plugins/test_pyrpkg_fetch_artefacts.py
@@ -19,7 +19,6 @@ from atomic_reactor.plugins.pre_pyrpkg_fetch_artefacts import DistgitFetchArtefa
 from atomic_reactor.util import ImageName
 from flexmock import flexmock
 from tests.constants import INPUT_IMAGE, MOCK, MOCK_SOURCE
-from tests.fixtures import docker_tasker  # noqa
 if MOCK:
     from tests.docker_mock import mock_docker  # noqa
 

--- a/tests/plugins/test_reactor_config.py
+++ b/tests/plugins/test_reactor_config.py
@@ -50,7 +50,6 @@ from atomic_reactor.plugins.pre_reactor_config import (ReactorConfig,
                                                        NO_FALLBACK)
 from tests.constants import TEST_IMAGE, REACTOR_CONFIG_MAP
 from tests.docker_mock import mock_docker
-from tests.fixtures import reactor_config_map  # noqa
 from flexmock import flexmock
 
 
@@ -214,7 +213,7 @@ class TestReactorConfigPlugin(object):
         captured_errs = [x.message for x in caplog.records()]
         assert any("cannot validate" in x for x in captured_errs)
 
-    @pytest.mark.parametrize(('config', 'errors'), [  # noqa:F811
+    @pytest.mark.parametrize(('config', 'errors'), [
         ("""\
           clusters:
             foo:
@@ -334,7 +333,7 @@ class TestReactorConfigPlugin(object):
         with pytest.raises(ValueError):
             plugin.run()
 
-    @pytest.mark.parametrize(('config', 'clusters'), [  # noqa:F811
+    @pytest.mark.parametrize(('config', 'clusters'), [
         # Empty config
         ("", []),
 
@@ -384,7 +383,7 @@ class TestReactorConfigPlugin(object):
         assert set([(x.name, x.max_concurrent_builds)
                     for x in enabled]) == set(clusters)
 
-    @pytest.mark.parametrize(('extra_config', 'fallback', 'error'), [  # noqa:F811
+    @pytest.mark.parametrize(('extra_config', 'fallback', 'error'), [
         ('clusters_client_config_dir: /the/path', None, None),
         ('clusters_client_config_dir: /the/path', '/unused/path', None),
         (None, '/the/path', None),

--- a/tests/plugins/test_resolve_composes.py
+++ b/tests/plugins/test_resolve_composes.py
@@ -50,7 +50,6 @@ from atomic_reactor.util import ImageName, read_yaml
 from datetime import datetime, timedelta
 from flexmock import flexmock
 from tests.constants import MOCK, MOCK_SOURCE
-from tests.fixtures import reactor_config_map  # noqa
 from textwrap import dedent
 
 import logging
@@ -247,10 +246,10 @@ def mock_koji_session():
 
 class TestResolveComposes(object):
 
-    def test_request_compose(self, workflow, reactor_config_map):  # noqa:F811
+    def test_request_compose(self, workflow, reactor_config_map):
         self.run_plugin_with_args(workflow, reactor_config_map=reactor_config_map)
 
-    @pytest.mark.parametrize('arches', (  # noqa:F811
+    @pytest.mark.parametrize('arches', (
         ['x86_64', 'ppc64le'],
         ['x86_64'],
     ))
@@ -267,7 +266,7 @@ class TestResolveComposes(object):
         workflow.buildstep_plugins_conf[0]['args']['platforms'] = arches
         self.run_plugin_with_args(workflow, reactor_config_map=reactor_config_map)
 
-    def test_request_compose_for_modules(self, workflow, reactor_config_map):  # noqa:F811
+    def test_request_compose_for_modules(self, workflow, reactor_config_map):
         repo_config = dedent("""\
             compose:
                 modules:
@@ -287,7 +286,7 @@ class TestResolveComposes(object):
 
         self.run_plugin_with_args(workflow, reactor_config_map=reactor_config_map)
 
-    @pytest.mark.parametrize(('compose_arches', 'pulp_arches', 'multilib_arches',  # noqa:F811
+    @pytest.mark.parametrize(('compose_arches', 'pulp_arches', 'multilib_arches',
                               'request_multilib'), [
         (['i686'], None, None, None),
         (['i686'], None, ['i686'], ['i686']),
@@ -378,7 +377,7 @@ class TestResolveComposes(object):
             assert 'multilib_method' not in compose_config
         assert composed_arches == set(compose_arches)
 
-    @pytest.mark.parametrize(('pulp_arches', 'arches', 'signing_intent', 'expected_intent'), (  # noqa:F811
+    @pytest.mark.parametrize(('pulp_arches', 'arches', 'signing_intent', 'expected_intent'), (
         (None, None, 'unsigned', 'unsigned'),
         # For the next test, since arches is none, no compose is performed even though pulp_arches
         # has a value. Expected intent doesn't change when nothing is composed.
@@ -492,7 +491,7 @@ class TestResolveComposes(object):
 
         assert plugin_result['signing_intent'] == expected_intent
 
-    def test_request_compose_for_pulp_no_content_sets(self, workflow, reactor_config_map):  # noqa:F811
+    def test_request_compose_for_pulp_no_content_sets(self, workflow, reactor_config_map):
         (flexmock(ODCSClient)
             .should_receive('start_compose')
             .with_args(
@@ -521,13 +520,13 @@ class TestResolveComposes(object):
 
         self.run_plugin_with_args(workflow, reactor_config_map=reactor_config_map)
 
-    def test_signing_intent_and_compose_ids_mutex(self, workflow, reactor_config_map):  # noqa:F811
+    def test_signing_intent_and_compose_ids_mutex(self, workflow, reactor_config_map):
         plugin_args = {'compose_ids': [1, 2], 'signing_intent': 'unsigned'}
         self.run_plugin_with_args(workflow, plugin_args,
                                   expect_error='cannot be used at the same time',
                                   reactor_config_map=reactor_config_map)
 
-    @pytest.mark.parametrize(('plugin_args', 'expected_kwargs'), (  # noqa:F811
+    @pytest.mark.parametrize(('plugin_args', 'expected_kwargs'), (
         ({
             'odcs_insecure': True,
         }, {'insecure': True}),
@@ -592,7 +591,7 @@ class TestResolveComposes(object):
 
         self.run_plugin_with_args(workflow, plug_args, reactor_config_map=reactor_config_map)
 
-    @pytest.mark.parametrize(('plugin_args', 'ssl_login'), (  # noqa:F811
+    @pytest.mark.parametrize(('plugin_args', 'ssl_login'), (
         ({
             'koji_target': KOJI_TARGET_NAME,
             'koji_hub': KOJI_BUILD_ID,
@@ -625,7 +624,7 @@ class TestResolveComposes(object):
         self.run_plugin_with_args(workflow, plugin_args,
                                   expect_error='koji_hub is required when koji_target is used')
 
-    @pytest.mark.parametrize(('default_si', 'config_si', 'arg_si', 'parent_si', 'expected_si',  # noqa:F811
+    @pytest.mark.parametrize(('default_si', 'config_si', 'arg_si', 'parent_si', 'expected_si',
                               'overridden'), (
         # Downgraded by parent's signing intent
         ('release', None, None, 'beta', 'beta', True),
@@ -725,7 +724,7 @@ class TestResolveComposes(object):
         }
         assert plugin_result == expected_result
 
-    @pytest.mark.parametrize(('composes_intent', 'expected_intent'), (  # noqa:F811
+    @pytest.mark.parametrize(('composes_intent', 'expected_intent'), (
         (('release', 'beta'), 'beta'),
         (('beta', 'release'), 'beta'),
         (('release', 'release'), 'release'),
@@ -759,7 +758,7 @@ class TestResolveComposes(object):
         assert plugin_result['signing_intent'] == expected_intent
         assert plugin_result['composes'] == composes
 
-    @pytest.mark.parametrize(('config', 'error_message'), (  # noqa:F811
+    @pytest.mark.parametrize(('config', 'error_message'), (
         (dedent("""\
             compose:
                 packages: []
@@ -789,7 +788,7 @@ class TestResolveComposes(object):
         self.run_plugin_with_args(workflow, expect_error=error_message,
                                   reactor_config_map=reactor_config_map)
 
-    def test_only_pulp_repos(self, workflow, reactor_config_map):  # noqa:F811
+    def test_only_pulp_repos(self, workflow, reactor_config_map):
         mock_repo_config(workflow._tmpdir,
                          dedent("""\
                              compose:
@@ -807,7 +806,7 @@ class TestResolveComposes(object):
             .and_return(ODCS_COMPOSE))
         self.run_plugin_with_args(workflow, reactor_config_map=reactor_config_map)
 
-    @pytest.mark.parametrize(('state_name', 'time_to_expire_delta', 'expect_renew'), (  # noqa:F811
+    @pytest.mark.parametrize(('state_name', 'time_to_expire_delta', 'expect_renew'), (
         ('removed', timedelta(), True),
         ('removed', timedelta(hours=-2), True),
         ('done', timedelta(), True),
@@ -865,11 +864,11 @@ class TestResolveComposes(object):
         else:
             assert plugin_result['composes'] == [old_odcs_compose]
 
-    def test_inject_yum_repos_from_new_compose(self, workflow, reactor_config_map):  # noqa:F811
+    def test_inject_yum_repos_from_new_compose(self, workflow, reactor_config_map):
         self.run_plugin_with_args(workflow, reactor_config_map=reactor_config_map)
         assert self.get_override_yum_repourls(workflow) == [ODCS_COMPOSE_REPOFILE]
 
-    def test_inject_yum_repos_from_existing_composes(self, workflow, reactor_config_map):  # noqa:F811
+    def test_inject_yum_repos_from_existing_composes(self, workflow, reactor_config_map):
         compose_ids = []
         expected_yum_repourls = []
 
@@ -896,7 +895,7 @@ class TestResolveComposes(object):
 
         assert self.get_override_yum_repourls(workflow) == expected_yum_repourls
 
-    def test_abort_when_odcs_config_missing(self, tmpdir, caplog, workflow, reactor_config_map):  # noqa:F811
+    def test_abort_when_odcs_config_missing(self, tmpdir, caplog, workflow, reactor_config_map):
         # Clear out default reactor config
         mock_reactor_config(workflow, tmpdir, data='')
         with caplog.atLevel(logging.INFO):
@@ -905,7 +904,7 @@ class TestResolveComposes(object):
         msg = 'Aborting plugin execution: ODCS config not found'
         assert msg in (x.message for x in caplog.records())
 
-    def test_abort_when_compose_config_missing(self, caplog, workflow, reactor_config_map):  # noqa:F811
+    def test_abort_when_compose_config_missing(self, caplog, workflow, reactor_config_map):
         # Clear out default git repo config
         mock_repo_config(workflow._tmpdir, '')
         # Ensure no compose_ids are passed to plugin
@@ -916,7 +915,7 @@ class TestResolveComposes(object):
         msg = 'Aborting plugin execution: "compose" config not set and compose_ids not given'
         assert msg in (x.message for x in caplog.records())
 
-    def test_invalid_koji_build_target(self, workflow, reactor_config_map):  # noqa:F811
+    def test_invalid_koji_build_target(self, workflow, reactor_config_map):
         plugin_args = {
             'koji_hub': KOJI_HUB,
             'koji_target': 'spam',
@@ -925,7 +924,7 @@ class TestResolveComposes(object):
         self.run_plugin_with_args(workflow, plugin_args, expect_error=expect_error,
                                   reactor_config_map=reactor_config_map)
 
-    @pytest.mark.parametrize(('plugin_args', 'msg'), (  # noqa:F811
+    @pytest.mark.parametrize(('plugin_args', 'msg'), (
         ({'signing_intent': 'spam'},
          'Autorebuild detected: Ignoring signing_intent plugin parameter'),
 
@@ -941,7 +940,7 @@ class TestResolveComposes(object):
 
         assert msg in (x.message for x in caplog.records())
 
-    def run_plugin_with_args(self, workflow, plugin_args=None,  # noqa:F811
+    def run_plugin_with_args(self, workflow, plugin_args=None,
                              expect_error=None, reactor_config_map=False,
                              platforms=ODCS_COMPOSE_DEFAULT_ARCH_LIST, is_pulp=None):
         plugin_args = plugin_args or {}

--- a/tests/plugins/test_resolve_module_compose.py
+++ b/tests/plugins/test_resolve_module_compose.py
@@ -47,7 +47,6 @@ except ImportError:
     import koji
 
 from tests.constants import (MOCK_SOURCE, FLATPAK_GIT, FLATPAK_SHA1)
-from tests.fixtures import docker_tasker  # noqa
 from tests.flatpak import FLATPAK_APP_MODULEMD, FLATPAK_APP_RPMS
 from tests.retry_mock import mock_get_retry_session
 

--- a/tests/plugins/test_rpmqa.py
+++ b/tests/plugins/test_rpmqa.py
@@ -19,7 +19,6 @@ from atomic_reactor.rpm_util import parse_rpm_output
 from atomic_reactor.util import ImageName
 from tests.constants import DOCKERFILE_GIT
 from tests.docker_mock import mock_docker
-from tests.fixtures import docker_tasker  # noqa
 from tests.stubs import StubInsideBuilder
 from tests.test_inner import FakeLogger
 import atomic_reactor.core
@@ -127,7 +126,7 @@ def test_rpmqa_plugin_exception(docker_tasker):  # noqa
         runner.run()
 
 
-def test_dangling_volumes_removed(docker_tasker, request):  # noqa:F811
+def test_dangling_volumes_removed(docker_tasker, request):
     fake_logger = FakeLogger()
     existing_logger = atomic_reactor.core.logger
 

--- a/tests/plugins/test_sendmail.py
+++ b/tests/plugins/test_sendmail.py
@@ -37,7 +37,6 @@ from atomic_reactor.plugins.pre_reactor_config import (ReactorConfigPlugin,
 from atomic_reactor import util
 from osbs.api import OSBS
 from osbs.exceptions import OsbsException
-from tests.fixtures import reactor_config_map  # noqa
 from smtplib import SMTPException
 
 MS, MF = SendMailPlugin.MANUAL_SUCCESS, SendMailPlugin.MANUAL_FAIL
@@ -236,7 +235,7 @@ class TestSendMailPlugin(object):
         p = SendMailPlugin(None, workflow, **kwargs)
         assert p._should_send(rebuild, success, auto_canceled, manual_canceled) == expected
 
-    @pytest.mark.parametrize(('additional_addresses', 'expected_receivers'), [  # noqa:F811
+    @pytest.mark.parametrize(('additional_addresses', 'expected_receivers'), [
         ('', None),
         ([], None),
         ([''], []),

--- a/tests/plugins/test_store_metadata.py
+++ b/tests/plugins/test_store_metadata.py
@@ -41,7 +41,6 @@ import pytest
 from tests.constants import (LOCALHOST_REGISTRY, DOCKER0_REGISTRY, TEST_IMAGE, TEST_IMAGE_NAME,
                              INPUT_IMAGE)
 from tests.util import is_string_type
-from tests.fixtures import reactor_config_map  # noqa
 
 DIGEST1 = "sha256:1da9b9e1c6bf6ab40f1627d76e2ad58e9b2be14351ef4ff1ed3eb4a156138189"
 DIGEST2 = "sha256:0000000000000000000000000000000000000000000000000000000000000000"

--- a/tests/plugins/test_tag_and_push.py
+++ b/tests/plugins/test_tag_and_push.py
@@ -20,7 +20,6 @@ from atomic_reactor.plugins.pre_reactor_config import (ReactorConfigPlugin,
 from atomic_reactor.util import ImageName, ManifestDigest, get_exported_image_metadata
 from tests.constants import (LOCALHOST_REGISTRY, TEST_IMAGE, TEST_IMAGE_NAME, INPUT_IMAGE, MOCK,
                              DOCKER0_REGISTRY)
-from tests.fixtures import reactor_config_map  # noqa
 
 import json
 import logging

--- a/tests/plugins/test_tag_from_config.py
+++ b/tests/plugins/test_tag_from_config.py
@@ -22,7 +22,6 @@ from atomic_reactor.plugins.pre_reactor_config import (ReactorConfigPlugin, Reac
 from atomic_reactor.util import ImageName, df_parser
 from atomic_reactor.constants import INSPECT_CONFIG
 from tests.constants import (MOCK_SOURCE, MOCK, IMPORTED_IMAGE_ID)
-from tests.fixtures import docker_tasker  # noqa
 if MOCK:
     from tests.docker_mock import mock_docker
 
@@ -203,7 +202,7 @@ def test_tag_parse(tmpdir, docker_tasker, unique_tags, primary_tags, expected):
             runner.run()
 
 
-@pytest.mark.parametrize(('name', 'organization', 'expected'), (  # noqa:F811
+@pytest.mark.parametrize(('name', 'organization', 'expected'), (
     ('etcd', None, 'etcd'),
     ('etcd', 'org', 'org/etcd'),
     ('custom/etcd', None, 'custom/etcd'),

--- a/tests/plugins/test_yum_inject.py
+++ b/tests/plugins/test_yum_inject.py
@@ -29,7 +29,6 @@ import os.path
 from collections import namedtuple
 import requests
 from flexmock import flexmock
-from tests.fixtures import docker_tasker  # noqa
 from tests.constants import SOURCE, MOCK
 from tests.util import requires_internet
 from tests.stubs import StubInsideBuilder

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,7 +22,7 @@ from atomic_reactor.core import DockerTasker
 from atomic_reactor.plugin import InputPluginsRunner
 import atomic_reactor.cli.main
 
-from tests.fixtures import is_registry_running, temp_image_name, get_uuid  # noqa
+from tests.util import uuid_value
 from tests.constants import LOCALHOST_REGISTRY, DOCKERFILE_GIT, DOCKERFILE_OK_PATH, FILES, MOCK
 
 if MOCK:
@@ -49,8 +49,8 @@ with_all_sources = pytest.mark.parametrize('source_provider, uri', [
 
 def setup_module(module):
     global PRIV_BUILD_IMAGE, DH_BUILD_IMAGE
-    PRIV_BUILD_IMAGE = get_uuid()
-    DH_BUILD_IMAGE = get_uuid()
+    PRIV_BUILD_IMAGE = uuid_value()
+    DH_BUILD_IMAGE = uuid_value()
     if MOCK:
         return
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -28,7 +28,6 @@ from atomic_reactor.plugin import (BuildPluginsRunner, PreBuildPluginsRunner,
 from atomic_reactor.plugins.pre_add_yum_repo_by_url import AddYumRepoByUrlPlugin
 from atomic_reactor.util import ImageName
 
-from tests.fixtures import docker_tasker  # noqa
 from tests.constants import DOCKERFILE_GIT, MOCK
 if MOCK:
     from tests.docker_mock import mock_docker

--- a/tests/test_tasker.py
+++ b/tests/test_tasker.py
@@ -8,7 +8,6 @@ of the BSD license. See the LICENSE file for details.
 
 from __future__ import print_function, unicode_literals
 
-from tests.fixtures import temp_image_name, docker_tasker  # noqa
 
 from atomic_reactor.core import DockerTasker, retry, RetryGeneratorException
 from atomic_reactor.util import ImageName, clone_git_repo, CommandResult

--- a/tests/util.py
+++ b/tests/util.py
@@ -11,8 +11,13 @@ from __future__ import unicode_literals
 
 import pytest
 import requests
+import uuid
 
 from six import string_types
+
+
+def uuid_value():
+    return uuid.uuid4().hex
 
 
 def is_string_type(obj):


### PR DESCRIPTION
To avoid PyFlakes F811 warnings regarding redefinition of unused names
when importing and using fixtures, we move our fixtures module to
conftest.py. See
https://docs.pytest.org/en/latest/fixture.html#conftest-py and the
discussion in #1093 for reference.

Signed-off-by: Athos Ribeiro <athos@redhat.com>