### PR TITLE
Travis: add install section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,10 @@ env:
     - OS=fedora
       OS_VERSION=28
       PYTHON_VERSION=3
+install:
+  - pip install coveralls
 script:
- - pip install coveralls
- - ./test.sh
+  - ./test.sh
 after_success: coveralls
 notifications:
   email: false


### PR DESCRIPTION
Without install section, travis do default `pip install -r
requirements.txt` and we don't need it. It only slowdowns builds.

Signed-off-by: Martin Bašti <mbasti@redhat.com>