### PR TITLE
resolve_module_compose: Support signing intents for Flatpaks

### DIFF
--- a/tests/flatpak.py
+++ b/tests/flatpak.py
@@ -335,7 +335,9 @@ def setup_flatpak_compose_info(workflow, config=APP_CONFIG):
     compose = ComposeInfo(source_spec,
                           42, base_module,
                           modules,
-                          repo_url)
+                          repo_url,
+                          'unsigned',
+                          False)
     set_compose_info(workflow, compose)
 
     return compose

--- a/tests/plugins/test_koji_import.py
+++ b/tests/plugins/test_koji_import.py
@@ -1543,6 +1543,10 @@ class TestKojiImport(object):
         assert image.get('modules') == ['eog-f28-20170629213428',
                                         'flatpak-runtime-f28-20170701152209']
         assert image.get('source_modules') == ['eog:f28']
+        assert image.get('odcs') == {
+            'signing_intent': 'unsigned',
+            'signing_intent_overridden': False,
+        }
 
     @pytest.mark.parametrize(('config', 'expected'), [
         ({'pulp_push': False,

--- a/tests/plugins/test_koji_promote.py
+++ b/tests/plugins/test_koji_promote.py
@@ -1456,6 +1456,10 @@ class TestKojiPromote(object):
         assert image.get('modules') == ['eog-f28-20170629213428',
                                         'flatpak-runtime-f28-20170701152209']
         assert image.get('source_modules') == ['eog:f28']
+        assert image.get('odcs') == {
+            'signing_intent': 'unsigned',
+            'signing_intent_overridden': False,
+        }
 
     @pytest.mark.parametrize('logs_return_bytes', [
         True,


### PR DESCRIPTION
Allow the signing intent to be specified as a module parameter or
in the container.yaml, pass that to ODCS.

As compared to resolve_composes, things are simpler since for Flatpaks
we have no koji parent build and only one compose source.