### PR TITLE
Update plugin config param types in docstrings

### DIFF
--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -330,14 +330,15 @@ class DockerBuildWorkflow(object):
         """
         :param source: dict, where/how to get source code to put in image
         :param image: str, tag for built image ([registry/]image_name[:tag])
-        :param prebuild_plugins: dict, arguments for pre-build plugins
-        :param prepublish_plugins: dict, arguments for test-build plugins
-        :param postbuild_plugins: dict, arguments for post-build plugins
+        :param prebuild_plugins: list of dicts, arguments for pre-build plugins
+        :param prepublish_plugins: list of dicts, arguments for test-build plugins
+        :param postbuild_plugins: list of dicts, arguments for post-build plugins
+        :param exit_plugins: list of dicts, arguments for exit plugins
         :param plugin_files: list of str, load plugins also from these files
         :param openshift_build_selflink: str, link to openshift build (if we're actually running
             on openshift) without the actual hostname/IP address
         :param client_version: str, osbs-client version used to render build json
-        :param buildstep_plugins: dict, arguments for build-step plugins
+        :param buildstep_plugins: list of dicts, arguments for build-step plugins
         """
         self.source = get_source_instance_for(source, tmpdir=tempfile.mkdtemp())
         self.image = image

--- a/atomic_reactor/plugin.py
+++ b/atomic_reactor/plugin.py
@@ -114,7 +114,7 @@ class PluginsRunner(object):
         constructor
 
         :param plugin_class_name: str, name of plugin class to filter (e.g. 'PreBuildPlugin')
-        :param plugins_conf: dict, configuration for plugins
+        :param plugins_conf: list of dicts, configuration for plugins
         """
         self.plugins_results = getattr(self, "plugins_results", {})
         self.plugins_conf = plugins_conf or []
@@ -319,7 +319,7 @@ class BuildPluginsRunner(PluginsRunner):
         :param dt: DockerTasker instance
         :param workflow: DockerBuildWorkflow instance
         :param plugin_class_name: str, name of plugin class to filter (e.g. 'PreBuildPlugin')
-        :param plugins_conf: dict, configuration for plugins
+        :param plugins_conf: list of dicts, configuration for plugins
         """
         self.dt = dt
         self.workflow = workflow

--- a/atomic_reactor/plugins/prepub_squash.py
+++ b/atomic_reactor/plugins/prepub_squash.py
@@ -39,7 +39,7 @@ class PrePublishSquashPlugin(PrePublishPlugin):
             "dont_load": false
           }
         }
-      }
+      ]
     ```
 
     The `tag` argument specifes the tag under which the new squashed image will


### PR DESCRIPTION
In 15c6790, plugin configurations changed from being passed as dicts to
lists. Some docstrings still refer to those params as being dicts.

Signed-off-by: Athos Ribeiro <athos@redhat.com>