### PR TITLE
get_koji_module_build: fix handling of streams with dashes

### DIFF
--- a/atomic_reactor/koji_util.py
+++ b/atomic_reactor/koji_util.py
@@ -228,7 +228,7 @@ def get_koji_module_build(session, module_spec):
         # The easy case - we can build the koji "name-version-release" out of the
         # module spec.
         koji_nvr = "{}-{}-{}.{}".format(module_spec.name,
-                                        module_spec.stream,
+                                        module_spec.stream.replace("-", "_"),
                                         module_spec.version,
                                         module_spec.context)
         logger.info("Looking up module build %s in Koji", koji_nvr)

--- a/tests/test_koji_util.py
+++ b/tests/test_koji_util.py
@@ -326,12 +326,12 @@ class TestGetKojiModuleBuild(object):
              ]))
 
     def test_with_context(self):
-        module = 'eog:master:20180821163756:775baa8e'
-        module_koji_nvr = 'eog-master-20180821163756.775baa8e'
+        module = 'eog:my-stream:20180821163756:775baa8e'
+        module_koji_nvr = 'eog-my_stream-20180821163756.775baa8e'
         koji_return = {
             'build_id': 1138198,
             'name': 'eog',
-            'version': 'master',
+            'version': 'my_stream',
             'release': '20180821163756.775baa8e',
             'extra': {
                 'typeinfo': {


### PR DESCRIPTION
When the module build service stores information about a build into Koji,
it creates the version from the stream name by replacing '-' with '_'