### PR TITLE
flatpak_create_dockerfile: Initialize /etc/os-release in the installroot

### DIFF
--- a/atomic_reactor/plugins/pre_flatpak_create_dockerfile.py
+++ b/atomic_reactor/plugins/pre_flatpak_create_dockerfile.py
@@ -32,6 +32,11 @@ from atomic_reactor.util import render_yum_repo, split_module_spec
 from atomic_reactor.yum_util import YumRepo
 
 
+# /var/tmp/flatpak-build is the final image we'll turn into a Flaptak
+# In order for 'dnf module enable' to work correctly, we need an
+# /etc/os-release in the install root with the correct PLATFORM_ID
+# for our base package set. To make that work, we install system-release
+# into a *different* install root and copy /etc/os-release over.
 DOCKERFILE_TEMPLATE = '''FROM {base_image}
 
 LABEL name="{name}"
@@ -45,16 +50,18 @@ RUN mkdir -p /var/tmp/flatpak-build/dev && \
     for i in null zero random urandom ; do cp -a /dev/$i /var/tmp/flatpak-build/dev ; done
 
 RUN cat /tmp/atomic-reactor-includepkgs >> /etc/dnf/dnf.conf && \\
+    INSTALLDIR=/var/tmp/flatpak-build && \\
+    DNF='\\
     dnf -y --nogpgcheck \\
     --disablerepo=* \\
     --enablerepo=atomic-reactor-koji-plugin-* \\
     --enablerepo=atomic-reactor-module-* \\
-    --installroot=/var/tmp/flatpak-build module enable {modules} && \\
-    dnf -y --nogpgcheck \\
-    --disablerepo=* \\
-    --enablerepo=atomic-reactor-koji-plugin-* \\
-    --enablerepo=atomic-reactor-module-* \\
-    --installroot=/var/tmp/flatpak-build install {packages}
+    ' && \\
+    $DNF --installroot=$INSTALLDIR-init install system-release && \\
+    mkdir -p $INSTALLDIR/etc/ && \\
+    cp $INSTALLDIR-init/etc/os-release $INSTALLDIR/etc/os-release && \\
+    $DNF --installroot=$INSTALLDIR module enable {modules} && \\
+    $DNF --installroot=$INSTALLDIR install {packages}
 RUN rpm --root=/var/tmp/flatpak-build {rpm_qf_args} > /var/tmp/flatpak-build.rpm_qf
 COPY cleanup.sh /var/tmp/flatpak-build/tmp/
 RUN chroot /var/tmp/flatpak-build/ /bin/sh /tmp/cleanup.sh


### PR DESCRIPTION
Recent versions of DNF look for a PLATFORM_ID in /etc/os-release to figure
out a module name for the base package set (e.g. platform:f29.) This is
looked up in the installroot, so we need to create it there. To get the
*correct* /etc/os-release, we install 'system-release' into a separate
installroot, then copy /etc/os-release over. Installing this package into
the final installroot as an early step doesn't work because once we do
that, the DNF configuration is no longer read from outside the installroot.

Some shell variables are added to reduce rampant duplication.