### PR TITLE
October 2018 janitor work: clean up flake8, pycodestyle errors

### DIFF
--- a/atomic_reactor/cli/main.py
+++ b/atomic_reactor/cli/main.py
@@ -17,7 +17,7 @@ import locale
 from atomic_reactor import set_logging
 from atomic_reactor.api import (build_image_here, build_image_in_privileged_container,
                                 build_image_using_hosts_docker)
-from atomic_reactor.constants import CONTAINER_BUILD_JSON_PATH, DESCRIPTION, PROG
+from atomic_reactor.constants import DESCRIPTION, PROG
 from atomic_reactor.buildimage import BuildImageBuilder
 from atomic_reactor.inner import build_inside, BuildResults
 from atomic_reactor.util import process_substitutions, setup_introspection_signal_handler

--- a/atomic_reactor/plugins/input_osv3.py
+++ b/atomic_reactor/plugins/input_osv3.py
@@ -106,7 +106,6 @@ class OSv3InputPlugin(InputPlugin):
         phases = ('postbuild_plugins', 'exit_plugins')
         pulp_registry = self.get_value('pulp')
         koji_hub = self.get_value('koji', {}).get('hub_url')
-        has_pulp_pull = False
         for phase in phases:
             if not (pulp_registry and koji_hub):
                 self.remove_plugin(phase, PLUGIN_PULP_PULL_KEY, 'no pulp or koji available')

--- a/atomic_reactor/plugins/pre_check_and_set_rebuild.py
+++ b/atomic_reactor/plugins/pre_check_and_set_rebuild.py
@@ -12,9 +12,6 @@ from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.plugins.pre_reactor_config import get_openshift_session
 from atomic_reactor.util import get_build_json
 
-import os
-import yaml
-
 
 def is_rebuild(workflow):
     return (CheckAndSetRebuildPlugin.key in workflow.prebuild_results and

--- a/tests/plugins/test_add_dockerfile.py
+++ b/tests/plugins/test_add_dockerfile.py
@@ -8,7 +8,6 @@ of the BSD license. See the LICENSE file for details.
 
 from __future__ import unicode_literals
 
-from flexmock import flexmock
 from atomic_reactor.inner import DockerBuildWorkflow
 from atomic_reactor.plugin import PreBuildPluginsRunner
 from atomic_reactor.plugins.pre_add_dockerfile import AddDockerfilePlugin

--- a/tests/plugins/test_check_and_set_rebuild.py
+++ b/tests/plugins/test_check_and_set_rebuild.py
@@ -24,7 +24,6 @@ from osbs.api import OSBS
 import osbs.conf
 from flexmock import flexmock
 from tests.constants import MOCK, MOCK_SOURCE
-from textwrap import dedent
 if MOCK:
     from tests.docker_mock import mock_docker
 

--- a/tests/plugins/test_input_osv3.py
+++ b/tests/plugins/test_input_osv3.py
@@ -32,8 +32,7 @@ from atomic_reactor.constants import (PLUGIN_BUMP_RELEASE_KEY,
                                       PLUGIN_PULP_SYNC_KEY,
                                       PLUGIN_PULP_TAG_KEY,
                                       PLUGIN_RESOLVE_COMPOSES_KEY,
-                                      PLUGIN_SENDMAIL_KEY,
-                                      PLUGIN_VERIFY_MEDIA_KEY)
+                                      PLUGIN_SENDMAIL_KEY)
 import pytest
 from flexmock import flexmock
 from jsonschema import ValidationError

--- a/tests/plugins/test_koji_tag_build.py
+++ b/tests/plugins/test_koji_tag_build.py
@@ -286,7 +286,7 @@ class TestKojiPromote(object):
         result = runner.run()
         assert result[KojiTagBuildPlugin.key] == 'images-candidate'
 
-    @pytest.mark.parametrize('use_import', [ # noqa
+    @pytest.mark.parametrize('use_import', [  # noqa
         (True, False)
     ])
     def test_koji_tag_build_success_no_args(self, tmpdir, use_import, reactor_config_map):

--- a/tests/plugins/test_pull_base_image.py
+++ b/tests/plugins/test_pull_base_image.py
@@ -71,6 +71,7 @@ class MockBuilder(object):
             parent_images[key] = val
         self.parent_images = parent_images
 
+
 @pytest.fixture(autouse=True)
 def set_build_json(monkeypatch):
     monkeypatch.setenv("BUILD", json.dumps({
@@ -271,6 +272,7 @@ def test_pull_base_library(reactor_config_map, caplog):  # noqa
     assert "not found" in str(exc.value)
     assert "RetryGeneratorException" in str(exc.value)
     assert "trying" not in caplog.text()  # don't retry with "library/library-only:latest"
+
 
 def test_pull_base_base_parse(reactor_config_map, inspect_only):  # noqa
     flexmock(ImageName).should_receive('parse').and_raise(AttributeError)

--- a/tests/plugins/test_rpmqa.py
+++ b/tests/plugins/test_rpmqa.py
@@ -16,7 +16,6 @@ from atomic_reactor.inner import DockerBuildWorkflow
 from atomic_reactor.plugin import PostBuildPluginsRunner, PluginFailedException
 from atomic_reactor.plugins.post_rpmqa import PostBuildRPMqaPlugin
 from atomic_reactor.rpm_util import parse_rpm_output
-from atomic_reactor.util import ImageName
 from tests.constants import DOCKERFILE_GIT
 from tests.docker_mock import mock_docker
 from tests.stubs import StubInsideBuilder

--- a/tests/plugins/test_squash.py
+++ b/tests/plugins/test_squash.py
@@ -59,10 +59,7 @@ class MockInsideBuilder(object):
 
     @property
     def base_image_inspect(self):
-        try:
-            return self.tasker.inspect_image(self.base_image)
-        except:
-            raise KeyError()
+        return self.tasker.inspect_image(self.base_image)
 
 
 class TestSquashPlugin(object):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1531,19 +1531,17 @@ def test_get_inspect_for_image(insecure, found_versions, type_in_list, will_rais
      .and_return(return_list)
      .once())
 
-    if (found_versions and ('v2' in found_versions or 'v2_list' in found_versions)
-            and not will_raise):
-        (flexmock(atomic_reactor.util)
-         .should_receive('get_config_and_id_from_registry')
-         .and_return(inspect_data, config_digest)
-         .once())
-
     if will_raise:
         with pytest.raises(raise_exception) as e:
             get_inspect_for_image(image, image.registry, insecure)
         assert error_msg in str(e)
 
     else:
+        if found_versions and ('v2' in found_versions or 'v2_list' in found_versions):
+            (flexmock(atomic_reactor.util)
+             .should_receive('get_config_and_id_from_registry')
+             .and_return(inspect_data, config_digest)
+             .once())
         inspected = get_inspect_for_image(image, image.registry, insecure)
         assert inspected == expect_inspect
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -39,5 +39,6 @@ def has_connection():
     except requests.ConnectionError:
         return False
 
+
 # In case we run tests in an environment without internet connection.
 requires_internet = pytest.mark.skipif(not has_connection(), reason="requires internet connection")


### PR DESCRIPTION
fix a collection of minor flake8 or pycodestyle errors, mostly whitespace
or unnecessary imports.

minor code structure change in tests/plugins/test_squash.py to remove an
unnecessary try/except.

minor code structure change in tests/test_util.py to re-order an if
statement to shorten the line length.