### PR TITLE
Return first error

### DIFF
--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -551,8 +551,13 @@ def build_inside(input_method, input_args=None, substitutions=None):
         raise RuntimeError("Input plugin did not return valid build json: {}".format(build_json))
 
     dbw = DockerBuildWorkflow(**build_json)
-    build_result = dbw.build_docker_image()
-    if not build_result or build_result.is_failed():
-        raise RuntimeError("no image built")
+    try:
+        build_result = dbw.build_docker_image()
+    except Exception as e:
+        logger.error('image build failed: %s', e)
+        raise
     else:
-        logger.info("build has finished successfully \\o/")
+        if not build_result or build_result.is_failed():
+            raise RuntimeError("no image built")
+        else:
+            logger.info("build has finished successfully \\o/")


### PR DESCRIPTION
Exit plugins may hide original exception and replace it with theirs own
which may be caused by different issue or just part of domino effect
(i.e. it hides root cause of failure and makes UX and debugging harder)

Related to jira: OSBS-6444

Signed-off-by: Martin Bašti <mbasti@redhat.com>

- [x]  unittests
- [x]  manual test