### PR TITLE
pulp_sync: remove unused delete_from_registry param

### DIFF
--- a/atomic_reactor/plugins/post_pulp_sync.py
+++ b/atomic_reactor/plugins/post_pulp_sync.py
@@ -88,7 +88,6 @@ class PulpSyncPlugin(PostBuildPlugin):
     def __init__(self, tasker, workflow,
                  pulp_registry_name=None,
                  docker_registry=None,
-                 delete_from_registry=False,
                  pulp_secret_path=None,
                  registry_secret_path=None,
                  insecure_registry=None,
@@ -104,8 +103,6 @@ class PulpSyncPlugin(PostBuildPlugin):
                specified in /etc/dockpulp.conf
         :param docker_registry: str, URL of docker registry to sync from
                including scheme e.g. https://registry.example.com
-        :param delete_from_registry: bool, whether to delete the image
-               from the docker v2 registry after sync
         :param pulp_secret_path: path to pulp.cer and pulp.key
         :param registry_secret_path: path to .dockercfg for the V2 registry
         :param insecure_registry: True if SSL validation should be skipped
@@ -147,10 +144,6 @@ class PulpSyncPlugin(PostBuildPlugin):
             except (ValueError, TypeError) as ex:
                 self.log.error("Can't set provided log level %r: %r",
                                loglevel, ex)
-
-        if delete_from_registry:
-            self.log.error("will not delete from registry as instructed: "
-                           "not implemented")
 
         self.publish = (publish and
                         not are_plugins_in_order(self.workflow.postbuild_plugins_conf,

--- a/tests/plugins/test_pulp_sync.py
+++ b/tests/plugins/test_pulp_sync.py
@@ -593,42 +593,6 @@ class TestPostPulpSync(object):
         plugin.run()
         assert len(workflow.push_conf.pulp_registries) == 1
 
-    def test_delete_not_implemented(self, caplog, reactor_config_map):  # noqa
-        """
-        Should log an error (but not raise an exception) when
-        delete_from_registry is True.
-        """
-        mockpulp = MockPulp()
-        (flexmock(mockpulp)
-            .should_receive('getRepos')
-            .with_args(['redhat-prod-myrepository'], fields=['id'])
-            .and_return([{'id': 'redhat-prod-myrepository'}])
-            .once()
-            .ordered())
-        (flexmock(mockpulp)
-            .should_receive('syncRepo')
-            .and_return(([], [])))
-        flexmock(dockpulp).should_receive('Pulp').and_return(mockpulp)
-
-        if reactor_config_map:
-            self.workflow.plugin_workspace = {}
-            self.workflow.plugin_workspace[ReactorConfigPlugin.key] = {}
-            self.workflow.plugin_workspace[ReactorConfigPlugin.key][WORKSPACE_CONF_KEY] =\
-                ReactorConfig({'version': 1, 'pulp': {'name': 'pulp'}})
-
-        plugin = PulpSyncPlugin(tasker=None,
-                                workflow=self.workflow(['prod/myrepository']),
-                                pulp_registry_name='pulp',
-                                docker_registry='http://registry.example.com',
-                                delete_from_registry=True)
-        plugin.run()
-
-        errors = [record.getMessage() for record in caplog.records()
-                  if record.levelname == 'ERROR']
-
-        assert [message for message in errors
-                if 'not implemented' in message]
-
     def test_create_missing_repo(self, reactor_config_map):  # noqa
         docker_registry = 'http://registry.example.com'
         docker_repository = 'prod/myrepository'


### PR DESCRIPTION
The delete_from_registry param was added in f83797f to allow v2 images
to be deleted from the registry after syncing. This feature was then
implemented later in a dedicated plugin in 7cd936c.

We are moving towards removal of the post-syncing removal feature, hence, there is no longer need for this non-implemented feature here.