### PR TITLE
WrappedDocker: Work around export inefficiency in older docker-python

### DIFF
--- a/tests/plugins/test_flatpak_create_oci.py
+++ b/tests/plugins/test_flatpak_create_oci.py
@@ -730,14 +730,15 @@ def test_flatpak_create_oci(tmpdir, docker_tasker, config_name, breakage, mock_f
 
     export_generator = stream_to_generator(export_stream)
 
+    (flexmock(docker_tasker.d)
+     .should_receive('export')
+     .with_args(CONTAINER_ID)
+     .and_return(export_generator))
+
     (flexmock(docker_tasker.d.wrapped)
      .should_receive('create_container')
      .with_args(workflow.image, command=["/bin/bash"])
      .and_return({'Id': CONTAINER_ID}))
-    (flexmock(docker_tasker.d.wrapped)
-     .should_receive('export')
-     .with_args(CONTAINER_ID)
-     .and_return(export_generator))
     (flexmock(docker_tasker.d.wrapped)
      .should_receive('remove_container')
      .with_args(CONTAINER_ID))

--- a/tests/test_tasker.py
+++ b/tests/test_tasker.py
@@ -318,6 +318,27 @@ def test_get_info():
     assert isinstance(response, dict)
 
 
+@pytest.mark.parametrize('no_container', (False, True))
+def test_export(no_container):
+    if MOCK:
+        mock_docker()
+
+    t = DockerTasker()
+    container_dict = t.d.create_container(INPUT_IMAGE, command=["/bin/bash"])
+    container_id = container_dict['Id']
+
+    try:
+        if no_container:
+            with pytest.raises(docker.errors.APIError):
+                t.d.export('NOT_THERE')
+        else:
+            export_generator = t.d.export(container_id)
+            for chunk in export_generator:
+                pass
+    finally:
+        t.d.remove_container(container_id)
+
+
 def test_get_version():
     if MOCK:
         mock_docker()


### PR DESCRIPTION
Exporting a container with older docker-python is very slow, because the
contents are returned in chunks of a few dozen bytes. Hack around this
by going right to the requests iter_content() API to pass in a better
chunk size (we use the same 2MB as the default as recent docker-python.)

This cuts the time to export a 70MB image from many minutes to 2 sends.

<hr>

Note: it might look more natural to do this in DockerTasker rather than in WrappedDocker, but I found it worked better in WrappedDocker when trying to get exception/retry handling right. In WrappedDocker it can also be dropped with minimal effort if the docker-python requirement is increased appropriately.
