### PR TITLE
resolve_module_compose: Start the compose with the correct architectures

### DIFF
--- a/atomic_reactor/plugins/pre_resolve_module_compose.py
+++ b/atomic_reactor/plugins/pre_resolve_module_compose.py
@@ -34,7 +34,7 @@ from gi.repository import Modulemd
 
 from atomic_reactor.koji_util import get_koji_module_build
 from atomic_reactor.plugin import PreBuildPlugin
-from atomic_reactor.util import split_module_spec
+from atomic_reactor.util import get_platforms, split_module_spec
 from atomic_reactor.plugins.pre_reactor_config import (get_config,
                                                        get_koji_session, get_odcs_session,
                                                        get_odcs, NO_FALLBACK)
@@ -196,9 +196,11 @@ class ResolveModuleComposePlugin(PreBuildPlugin):
         signing_intent = odcs_config.get_signing_intent_by_name(signing_intent_name)
 
         if self.compose_id is None:
+            arches = sorted(get_platforms(self.workflow))
             self.compose_id = odcs_client.start_compose(source_type='module',
                                                         source=noprofile_spec,
-                                                        sigkeys=signing_intent['keys'])['id']
+                                                        sigkeys=signing_intent['keys'],
+                                                        arches=arches)['id']
 
         compose_info = odcs_client.wait_for_compose(self.compose_id)
         if compose_info['state_name'] != "done":

--- a/tests/plugins/test_resolve_module_compose.py
+++ b/tests/plugins/test_resolve_module_compose.py
@@ -28,7 +28,7 @@ from atomic_reactor.plugins.pre_reactor_config import (ReactorConfigPlugin,
                                                        ReactorConfig)
 from atomic_reactor.source import VcsInfo, SourceConfig
 from atomic_reactor.util import ImageName
-from atomic_reactor.constants import REPO_CONTAINER_CONFIG
+from atomic_reactor.constants import REPO_CONTAINER_CONFIG, PLUGIN_CHECK_AND_SET_PLATFORMS_KEY
 
 try:
     import koji
@@ -90,6 +90,7 @@ def mock_workflow(tmpdir):
     setattr(workflow, 'builder', MockBuilder())
     workflow.builder.source = mock_source
     flexmock(workflow, source=mock_source)
+    workflow.prebuild_results[PLUGIN_CHECK_AND_SET_PLATFORMS_KEY] = set(['x86_64', 'ppc64le'])
 
     setattr(workflow.builder, 'df_dir', str(tmpdir))
 
@@ -243,6 +244,7 @@ def test_resolve_module_compose(tmpdir, docker_tasker, compose_ids, modules,
         assert body_json['source']['type'] == 'module'
         assert body_json['source']['source'] == module
         assert body_json['source']['sigkeys'] == sigkeys
+        assert body_json['arches'] == ['ppc64le', 'x86_64']
         return (200, {}, compose_json(0, 'wait'))
 
     responses.add_callback(responses.POST, ODCS_URL + '/composes/',


### PR DESCRIPTION
We need to pass the correct set of architectures to ODCS for starting the compose
(the compose is always started by the orchestrator, and the compose_id passed
to worker builds.)

<hr>

Found in testing on Fedora now that Fedora is setting up multi-arch OSBS