### PR TITLE
flatpak: allow overriding the name and com.redhat.component labels

### DIFF
--- a/atomic_reactor/plugins/pre_flatpak_create_dockerfile.py
+++ b/atomic_reactor/plugins/pre_flatpak_create_dockerfile.py
@@ -40,7 +40,7 @@ from atomic_reactor.yum_util import YumRepo
 DOCKERFILE_TEMPLATE = '''FROM {base_image}
 
 LABEL name="{name}"
-LABEL com.redhat.component="{name}"
+LABEL com.redhat.component="{component}"
 LABEL version="{stream}"
 LABEL release="{version}"
 
@@ -141,9 +141,13 @@ class FlatpakCreateDockerfilePlugin(PreBuildPlugin):
 
         install_packages_str = ' '.join(builder.get_install_packages())
 
+        name = source.flatpak_yaml.get('name', module_info.name)
+        component = source.flatpak_yaml.get('component', module_info.name)
+
         df_path = os.path.join(self.workflow.builder.df_dir, DOCKERFILE_FILENAME)
         with open(df_path, 'w') as fp:
-            fp.write(DOCKERFILE_TEMPLATE.format(name=module_info.name,
+            fp.write(DOCKERFILE_TEMPLATE.format(name=name,
+                                                component=component,
                                                 stream=module_info.stream.replace('-', '_'),
                                                 version=module_info.version,
                                                 base_image=self.base_image,

--- a/docs/flatpak.md
+++ b/docs/flatpak.md
@@ -31,6 +31,10 @@ The `flatpak` section of container.yaml contains extra information needed to cre
 
 **id**: (required) The ID of the application or runtime
 
+**name**: (optional). `name` label in generated Dockerfile. Used for the repository when pushing to a registry. Defaults to the module name.
+
+**component**: (optional). `com.redhat.component` label in generated Dockerfile. Used to name the build when uploading to Koji. Defaults to the module name.
+
 **branch**: (required) The branch of the application or runtime. In many cases, this will match the stream name of the module.
 
 **cleanup-commands**: (optional, runtime only). A shell script that is run after installing all packages.

--- a/tests/flatpak.py
+++ b/tests/flatpak.py
@@ -214,6 +214,7 @@ compose:
     - flatpak-runtime:f28
 flatpak:
     id: org.fedoraproject.Platform
+    component: flatpak-runtime-container
     branch: f28
     sdk: org.fedoraproject.Sdk
     cleanup-commands: >
@@ -228,6 +229,8 @@ compose:
     - flatpak-runtime:f28/sdk
 flatpak:
     id: org.fedoraproject.Sdk
+    name: flatpak-sdk
+    component: flatpak-sdk-container
     branch: f28
     runtime: org.fedoraproject.Platform
     cleanup-commands: >
@@ -259,6 +262,8 @@ APP_CONFIG = {
         },
     },
     'container_yaml': FLATPAK_APP_CONTAINER_YAML,
+    'name': 'eog',
+    'component': 'eog',
 }
 
 RUNTIME_CONFIG = {
@@ -278,6 +283,8 @@ RUNTIME_CONFIG = {
         },
     },
     'container_yaml': FLATPAK_RUNTIME_CONTAINER_YAML,
+    'name': 'flatpak-runtime',
+    'component': 'flatpak-runtime-container',
 }
 
 SDK_CONFIG = {
@@ -298,6 +305,8 @@ SDK_CONFIG = {
         },
     },
     'container_yaml': FLATPAK_SDK_CONTAINER_YAML,
+    'name': 'flatpak-sdk',
+    'component': 'flatpak-sdk-container',
 }
 
 

--- a/tests/plugins/test_flatpak_create_dockerfile.py
+++ b/tests/plugins/test_flatpak_create_dockerfile.py
@@ -150,6 +150,8 @@ def test_flatpak_create_dockerfile(tmpdir, docker_tasker, config_name, breakage,
             df = f.read()
 
         assert "FROM " + base_image in df
+        assert 'name="{}"'.format(config['name']) in df
+        assert 'com.redhat.component="{}"'.format(config['component']) in df
 
         m = re.search(r'module enable\s*(.*?)\s*&&', df)
         assert m


### PR DESCRIPTION
atomic-reactor uses:
 name label => repository name when uploading to a registry
 com.redhat.component => name when uploading to Koji

Generally these names don't matter a lot for a Flatpak - the reverse-DNS ID is
the important things, but there are some reasons we might need to override them -
to match conventions for containers, for example, and, in particular, to distinguish
multiple Flatpaks being generated from different profiles of the same module.

Allow specifying name/component in the flatpak: section of container.yaml to
override the labels in the generated Dockerfile.
<hr>
Suggestions for alternative names for the keys in container.yaml or ways of representing this information accepted. I think this way is functional but a little obscure.