### PR TITLE
Use logger for warnings

### DIFF
--- a/atomic_reactor/plugins/build_orchestrate_build.py
+++ b/atomic_reactor/plugins/build_orchestrate_build.py
@@ -10,7 +10,6 @@ from __future__ import unicode_literals, division
 from collections import namedtuple
 from copy import deepcopy
 from multiprocessing.pool import ThreadPool
-import warnings
 
 import json
 import os
@@ -432,8 +431,8 @@ class OrchestrateBuildPlugin(BuildStepPlugin):
 
         if arrangement_version <= 5:
             # TODO: raise as ValueError in release 1.6.38+
-            warnings.warn("arrangement_version <= 5 is deprecated and will be removed"
-                          " in release 1.6.38", DeprecationWarning)
+            self.log.warning("arrangement_version <= 5 is deprecated and will be removed"
+                             " in release 1.6.38")
 
     def get_current_builds(self, osbs):
         field_selector = ','.join(['status!={status}'.format(status=status.capitalize())

--- a/tests/plugins/test_orchestrate_build.py
+++ b/tests/plugins/test_orchestrate_build.py
@@ -1673,7 +1673,7 @@ def test_no_platforms(tmpdir):
     (5, "arrangement_version <= 5 is deprecated and will be removed in release 1.6.38", None),
     (6, None, None),
 ))
-def test_orchestrate_build_validate_arrangements(tmpdir, recwarn, version, warning, exception):
+def test_orchestrate_build_validate_arrangements(tmpdir, caplog, version, warning, exception):
     workflow = mock_workflow(tmpdir)
     mock_osbs()  # Current builds is a constant 2
     mock_manifest_list()
@@ -1700,4 +1700,4 @@ def test_orchestrate_build_validate_arrangements(tmpdir, recwarn, version, warni
         runner.run()
 
     if warning:
-        assert warning in str(recwarn.pop(DeprecationWarning))
+        assert warning in caplog.text()


### PR DESCRIPTION
Koji doesn't collect stderr/stdout. Only logger is collected, so warning.warn() output
is not shown in collected logs.

Signed-off-by: Martin Bašti <mbasti@redhat.com>