### PR TITLE
Flatpak: pass compose ids to the worker builds correctly

### DIFF
--- a/atomic_reactor/plugins/pre_flatpak_create_dockerfile.py
+++ b/atomic_reactor/plugins/pre_flatpak_create_dockerfile.py
@@ -26,7 +26,6 @@ from atomic_reactor.constants import DOCKERFILE_FILENAME, YUM_REPOS_DIR
 from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.plugins.pre_reactor_config import get_flatpak_base_image
 from atomic_reactor.plugins.pre_resolve_module_compose import get_compose_info
-from atomic_reactor.plugins.build_orchestrate_build import override_build_kwarg
 from atomic_reactor.rpm_util import rpm_qf_args
 from atomic_reactor.util import render_yum_repo, split_module_spec
 from atomic_reactor.yum_util import YumRepo
@@ -183,5 +182,3 @@ class FlatpakCreateDockerfilePlugin(PreBuildPlugin):
 
         path = YumRepo(os.path.join(YUM_REPOS_DIR, repo_name)).dst_filename
         self.workflow.files[path] = render_yum_repo(repo, escape_dollars=False)
-
-        override_build_kwarg(self.workflow, 'module_compose_id', compose_info.compose_id)

--- a/atomic_reactor/plugins/pre_resolve_module_compose.py
+++ b/atomic_reactor/plugins/pre_resolve_module_compose.py
@@ -35,6 +35,7 @@ from gi.repository import Modulemd
 from atomic_reactor.koji_util import get_koji_module_build
 from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.util import get_platforms, split_module_spec
+from atomic_reactor.plugins.build_orchestrate_build import override_build_kwarg
 from atomic_reactor.plugins.pre_reactor_config import (get_config,
                                                        get_koji_session, get_odcs_session,
                                                        get_odcs, NO_FALLBACK)
@@ -233,3 +234,4 @@ class ResolveModuleComposePlugin(PreBuildPlugin):
 
         compose_info = self._resolve_compose()
         set_compose_info(self.workflow, compose_info)
+        override_build_kwarg(self.workflow, 'compose_ids', [compose_info.compose_id])


### PR DESCRIPTION
When the module_compose_id build kwargs was replaced with compose_ids,
the override that is done by the orchestrator wasn't adjusted, meaning
that worker builds were individually triggering composes.

Move the override to pre_resolve_module_compose to make the connection
more obvious and harder to accidentally break.