### PR TITLE
squash image from imagebuilder when last parent is scratch, because i…

### DIFF
--- a/atomic_reactor/plugins/prepub_squash.py
+++ b/atomic_reactor/plugins/prepub_squash.py
@@ -89,7 +89,8 @@ class PrePublishSquashPlugin(PrePublishPlugin):
         self.save_archive = save_archive
 
     def run(self):
-        if self.workflow.build_result.skip_layer_squash:
+        if (self.workflow.build_result.skip_layer_squash and
+                not self.workflow.builder.base_from_scratch):
             return  # enable build plugins to prevent unnecessary squashes
         if self.save_archive:
             output_path = os.path.join(self.workflow.source.workdir, EXPORTED_SQUASHED_IMAGE_NAME)


### PR DESCRIPTION
when using imagebuilder and last/only parent is 'scratch', it produces 2 layers, from which 1 of them is empty, so we have to actually run squash even for imagebuilder in that case

Signed-off-by: Robert Cerven <rcerven@redhat.com>