### PR TITLE
Fix yum repo handling when URL does not end '.repo' (OSBS-6562)

### DIFF
--- a/atomic_reactor/yum_util.py
+++ b/atomic_reactor/yum_util.py
@@ -36,8 +36,6 @@ REPO_SUFFIX = ".repo"
 
 class YumRepo(object):
     def __init__(self, repourl, content='', dst_repos_dir=YUM_REPOS_DIR, add_hash=True):
-        if not repourl.endswith(REPO_SUFFIX):
-            repourl += REPO_SUFFIX
         self.add_hash = add_hash
         self.repourl = repourl
         self.dst_repos_dir = dst_repos_dir
@@ -55,6 +53,8 @@ class YumRepo(object):
         '''
         urlpath = unquote(urlsplit(self.repourl, allow_fragments=False).path)
         basename = os.path.basename(urlpath)
+        if not basename.endswith(REPO_SUFFIX):
+            basename += REPO_SUFFIX
         if self.add_hash:
             suffix = '-' + md5(self.repourl.encode('utf-8')).hexdigest()[:5]
         else:

--- a/tests/plugins/test_add_filesystem.py
+++ b/tests/plugins/test_add_filesystem.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2016 Red Hat, Inc
+Copyright (c) 2016, 2018 Red Hat, Inc
 All rights reserved.
 
 This software may be modified and distributed under the terms
@@ -428,7 +428,7 @@ def test_image_build_defaults(tmpdir, task_id, reactor_config_map):
                     [fedora-23]
                     baseurl = http://install-tree.com/$basearch/fedora23
                     """))
-    responses.add(responses.GET, 'http://repo.com/fedora/os.repo',
+    responses.add(responses.GET, 'http://repo.com/fedora/os',
                   body=dedent("""\
                     [fedora-os]
                     baseurl = http://repo.com/fedora/$basearch/os
@@ -517,7 +517,7 @@ def test_image_build_overwrites(tmpdir, architectures, architecture, reactor_con
         'http://default-install-tree.com/fedora23',
         'http://default-repo.com/fedora/os.repo',
     ]
-    responses.add(responses.GET, 'http://default-install-tree.com/fedora23.repo',
+    responses.add(responses.GET, 'http://default-install-tree.com/fedora23',
                   body=dedent("""\
                     [fedora-23]
                     baseurl = http://default-install-tree.com/$basearch/fedora23
@@ -593,7 +593,7 @@ def test_extract_base_url_many_base_urls(tmpdir, reactor_config_map):  # noqa
         'http://default-repo.com/fedora/os.repo',
     ]
     architectures = 'x86_64'
-    responses.add(responses.GET, 'http://default-install-tree.com/fedora23.repo',
+    responses.add(responses.GET, 'http://default-install-tree.com/fedora23',
                   body=dedent("""\
                     [fedora-23]
                     baseurl = http://default-install-tree.com/$basearch/fedora23
@@ -628,7 +628,7 @@ def test_extract_base_url_bad_repo_config(tmpdir, reactor_config_map):  # noqa
         'http://default-repo.com/fedora/os.repo',
     ]
     architectures = 'x86_64'
-    responses.add(responses.GET, 'http://default-install-tree.com/fedora23.repo',
+    responses.add(responses.GET, 'http://default-install-tree.com/fedora23',
                   body="This is not right")
     responses.add(responses.GET, 'http://default-repo.com/fedora/os.repo',
                   body="Its not even wrong")

--- a/tests/plugins/test_add_yum_repo_by_url.py
+++ b/tests/plugins/test_add_yum_repo_by_url.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2015 Red Hat, Inc
+Copyright (c) 2015, 2018 Red Hat, Inc
 All rights reserved.
 
 This software may be modified and distributed under the terms
@@ -19,6 +19,7 @@ from atomic_reactor.yum_util import YumRepo
 import requests
 import pytest
 from flexmock import flexmock
+from fnmatch import fnmatch
 import os.path
 from tests.constants import DOCKERFILE_GIT, MOCK
 from tests.stubs import StubInsideBuilder, StubSource
@@ -115,7 +116,7 @@ def test_multiple_repourls(caplog, base_from_scratch, parent_images, inject_prox
 def test_single_repourl_no_suffix(inject_proxy):
     tasker, workflow = prepare()
     url = 'http://example.com/example%20repo'
-    filename = 'example repo-4ca91.repo'
+    pattern = 'example repo-?????.repo'
     runner = PreBuildPluginsRunner(tasker, workflow, [{
         'name': AddYumRepoByUrlPlugin.key,
         'args': {'repourls': [url], 'inject_proxy': inject_proxy}}])
@@ -124,23 +125,27 @@ def test_single_repourl_no_suffix(inject_proxy):
     if inject_proxy:
         repo_content = '%sproxy = %s\n\n' % (repocontent.decode('utf-8'), inject_proxy)
     # next(iter(...)) is for py 2/3 compatibility
-    assert next(iter(workflow.files.keys())) == os.path.join(YUM_REPOS_DIR, filename)
+    assert fnmatch(next(iter(workflow.files.keys())), os.path.join(YUM_REPOS_DIR, pattern))
     assert next(iter(workflow.files.values())) == repo_content
     assert len(workflow.files) == 1
 
 
 @pytest.mark.parametrize('inject_proxy', [None, 'http://proxy.example.com'])
-@pytest.mark.parametrize(('repos', 'filenames'), (
+@pytest.mark.parametrize(('repos', 'patterns'), (
     (['http://example.com/a/b/c/myrepo', 'http://example.com/repo-2.repo'],
-     ['myrepo-d0856.repo', 'repo-2-ba4b3.repo']),
+     ['myrepo-?????.repo', 'repo-2-?????.repo']),
     (['http://example.com/a/b/c/myrepo', 'http://example.com/repo-2'],
-     ['myrepo-d0856.repo', 'repo-2-ba4b3.repo']),
+     ['myrepo-?????.repo', 'repo-2-?????.repo']),
     (['http://example.com/a/b/c/myrepo.repo', 'http://example.com/repo-2'],
-     ['myrepo-d0856.repo', 'repo-2-ba4b3.repo']),
+     ['myrepo-?????.repo', 'repo-2-?????.repo']),
     (['http://example.com/spam/myrepo.repo', 'http://example.com/bacon/myrepo'],
-     ['myrepo-608de.repo', 'myrepo-a1f78.repo']),
+     ['myrepo-?????.repo', 'myrepo-?????.repo']),
+    (['http://example.com/a/b/c/myrepo.repo?blab=bla', 'http://example.com/a/b/c/repo-2?blab=bla'],
+     ['myrepo-?????.repo', 'repo-2-?????.repo']),
+    (['http://example.com/a/b/c/myrepo', 'http://example.com/a/b/c/myrepo.repo'],
+     ['myrepo-?????.repo', 'myrepo-?????.repo']),
 ))
-def test_multiple_repourls_no_suffix(inject_proxy, repos, filenames):
+def test_multiple_repourls_no_suffix(inject_proxy, repos, patterns):
     tasker, workflow = prepare()
     runner = PreBuildPluginsRunner(tasker, workflow, [{
         'name': AddYumRepoByUrlPlugin.key,
@@ -149,31 +154,17 @@ def test_multiple_repourls_no_suffix(inject_proxy, repos, filenames):
     repo_content = repocontent
     if inject_proxy:
         repo_content = '%sproxy = %s\n\n' % (repocontent.decode('utf-8'), inject_proxy)
-
-    for filename in filenames:
-        assert workflow.files[os.path.join(YUM_REPOS_DIR, filename)]
-        assert workflow.files[os.path.join(YUM_REPOS_DIR, filename)] == repo_content
 
     assert len(workflow.files) == 2
-
-
-@pytest.mark.parametrize('inject_proxy', [None, 'http://proxy.example.com'])
-def test_multiple_same_repourls_no_suffix(inject_proxy):
-    tasker, workflow = prepare()
-    repos = ['http://example.com/a/b/c/myrepo', 'http://example.com/a/b/c/myrepo.repo']
-    filename = 'myrepo-d0856.repo'
-    runner = PreBuildPluginsRunner(tasker, workflow, [{
-        'name': AddYumRepoByUrlPlugin.key,
-        'args': {'repourls': repos, 'inject_proxy': inject_proxy}}])
-    runner.run()
-    repo_content = repocontent
-    if inject_proxy:
-        repo_content = '%sproxy = %s\n\n' % (repocontent.decode('utf-8'), inject_proxy)
-
-    assert workflow.files[os.path.join(YUM_REPOS_DIR, filename)]
-    assert workflow.files[os.path.join(YUM_REPOS_DIR, filename)] == repo_content
-
-    assert len(workflow.files) == 1
+    for pattern in patterns:
+        for filename, content in workflow.files.items():
+            if fnmatch(filename, os.path.join(YUM_REPOS_DIR, pattern)):
+                assert content == repo_content  # only because they're all the same
+                del workflow.files[filename]
+                break
+        else:
+            raise RuntimeError("no filename in %s matching pattern %s" %
+                               (list(workflow.files.keys()), pattern))
 
 
 def test_invalid_repourl():

--- a/tests/plugins/test_koji.py
+++ b/tests/plugins/test_koji.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2015 Red Hat, Inc
+Copyright (c) 2015, 2018 Red Hat, Inc
 All rights reserved.
 
 This software may be modified and distributed under the terms
@@ -33,6 +33,7 @@ from atomic_reactor.core import DockerTasker
 from atomic_reactor.inner import DockerBuildWorkflow
 from atomic_reactor.plugin import PreBuildPluginsRunner
 from flexmock import flexmock
+from fnmatch import fnmatch
 import pytest
 from tests.constants import SOURCE, MOCK
 from tests.stubs import StubInsideBuilder, StubSource
@@ -237,9 +238,10 @@ class TestKoji(object):
                 with open(file_path, 'r') as fd:
                     assert fd.read() == expected
 
-        repofile = '/etc/yum.repos.d/target-df7bc.repo'
-        assert repofile in workflow.files
-        content = workflow.files[repofile]
+        repofile = '/etc/yum.repos.d/target-?????.repo'
+        assert len(workflow.files) == 1
+        assert fnmatch(next(iter(workflow.files.keys())), repofile)
+        content = next(iter(workflow.files.values()))
         assert content.startswith("[atomic-reactor-koji-plugin-target]\n")
         assert "gpgcheck=0\n" in content
         assert "enabled=1\n" in content

--- a/tests/test_yum_util.py
+++ b/tests/test_yum_util.py
@@ -8,23 +8,25 @@ of the BSD license. See the LICENSE file for details.
 Very small subset of tests for the YumRepo class. Most testing
 is done in test_add_yum_repo_by_url
 """
+from fnmatch import fnmatch
 import sys
 from atomic_reactor.yum_util import YumRepo
 import pytest
 
 
-@pytest.mark.parametrize(('repourl', 'add_hash', 'filename'), (
-    ('http://example.com/a/b/c/myrepo.repo', True, 'myrepo-d0856.repo'),
-    ('http://example.com/a/b/c/myrepo', True, 'myrepo-d0856.repo'),
-    ('http://example.com/repo-2.repo', True, 'repo-2-ba4b3.repo'),
-    ('http://example.com/repo-2', True, 'repo-2-ba4b3.repo'),
-    ('http://example.com/spam/myrepo.repo', True, 'myrepo-608de.repo'),
-    ('http://example.com/bacon/myrepo', True, 'myrepo-a1f78.repo'),
-    ('http://example.com/spam/myrepo-608de.repo', False, 'myrepo-608de.repo'),
+@pytest.mark.parametrize(('repourl', 'add_hash', 'pattern'), (
+    ('http://example.com/a/b/c/myrepo.repo', True, 'myrepo-?????.repo'),
+    ('http://example.com/a/b/c/myrepo', True, 'myrepo-?????.repo'),
+    ('http://example.com/repo-2.repo', True, 'repo-2-?????.repo'),
+    ('http://example.com/repo-2', True, 'repo-2-?????.repo'),
+    ('http://example.com/spam/myrepo.repo', True, 'myrepo-?????.repo'),
+    ('http://example.com/bacon/myrepo', True, 'myrepo-?????.repo'),
+    ('http://example.com/spam/myrepo-608de.repo', False, 'myrepo-?????.repo'),
 ))
-def test_add_repo_to_url(repourl, add_hash, filename):
+def test_add_repo_to_url(repourl, add_hash, pattern):
     repo = YumRepo(repourl, add_hash=add_hash)
-    assert repo.filename == filename
+    assert repo.repourl == repourl
+    assert fnmatch(repo.filename, pattern)
 
 
 def test_invalid_config():


### PR DESCRIPTION
The URL we use to retrieve the file should be used as-is. Only the filename we inject into the container image should end .repo if it does not already.

Signed-off-by: Tim Waugh <twaugh@redhat.com>