### PR TITLE
Prevent race conditions cause by floating tags

### DIFF
--- a/atomic_reactor/build.py
+++ b/atomic_reactor/build.py
@@ -18,7 +18,7 @@ import docker.errors
 import atomic_reactor.util
 from atomic_reactor.core import DockerTasker, LastLogger
 from atomic_reactor.util import (ImageName, print_version_of_tools, df_parser,
-                                 base_image_is_scratch)
+                                 base_image_is_scratch, DigestCollector)
 from atomic_reactor.constants import DOCKERFILE_FILENAME
 
 logger = logging.getLogger(__name__)
@@ -152,6 +152,7 @@ class InsideBuilder(LastLogger, BuilderStateMachine):
         self.parent_images = {}  # dockerfile ImageName => locally available ImageName
         self._parent_images_inspect = {}  # locally available image => inspect
         self.parents_ordered = []
+        self.parent_images_digests = DigestCollector()
         self.image_id = None
         self.built_image_info = None
         self.image = ImageName.parse(image)

--- a/atomic_reactor/plugins/build_orchestrate_build.py
+++ b/atomic_reactor/plugins/build_orchestrate_build.py
@@ -412,6 +412,8 @@ class OrchestrateBuildPlugin(BuildStepPlugin):
     def adjust_build_kwargs(self):
         self.build_kwargs['arrangement_version'] =\
             get_arrangement_version(self.workflow, self.build_kwargs['arrangement_version'])
+        self.build_kwargs['parent_images_digests'] =\
+            self.workflow.builder.parent_images_digests.to_dict()
 
     def validate_arrangement_version(self):
         """Validate if the arrangement_version is supported

--- a/atomic_reactor/plugins/pre_pull_base_image.py
+++ b/atomic_reactor/plugins/pre_pull_base_image.py
@@ -181,6 +181,16 @@ class PullBaseImagePlugin(PreBuildPlugin):
                     )
 
     def _get_image_for_different_arch(self, image, platform):
+        """Get image from random arch
+
+        This is a workaround for aarch64 platform, because orchestrator cannot
+        get this arch from manifests lists so we have to provide digest of a
+        random platform to get image metadata for orchestrator.
+
+        For standard platforms like x86_64, ppc64le, ... this method returns
+        the corresponding digest
+
+        """
         new_image = None
         parents_digests = self.workflow.builder.parent_images_digests
         try:

--- a/atomic_reactor/schemas/user_params.json
+++ b/atomic_reactor/schemas/user_params.json
@@ -31,6 +31,26 @@
     "koji_task_id": {"type": "integer"},
     "koji_upload_dir": {"type": "string"},
     "name": {"type": "string"},
+    "parent_images_digests": {
+      "type": "object",
+      "patternProperties": {
+        "^.+:.+$": {
+          "description": "Image with tags",
+          "type": "object",
+          "patternProperties": {
+            "^.": {
+              "description": "Platform specific image",
+              "type": "string",
+              "pattern": "@.+:"
+            }
+          },
+          "uniqueItems": true,
+          "additionalProperties": false
+        }
+      },
+      "uniqueItems": true,
+      "additionalProperties": false
+    },
     "platform": {"type": "string"},
     "platforms": {
       "type": "array",

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -1579,3 +1579,108 @@ def dump_stacktraces(sig, frame):
 
 def setup_introspection_signal_handler():
     signal.signal(signal.SIGUSR1, dump_stacktraces)
+
+
+class DigestCollector(object):
+    """Collect platform specific digests of images"""
+
+    def __init__(self, images_digests=None):
+        self._images_digests = images_digests or {}
+
+    def __repr__(self):
+        return "DigestCollector(images_digests={!r})".format(self._images_digests)
+
+    def _key(self, image):
+        """
+        :param ImageName image:
+        :rtype: str
+        :return: image name in format name:tag
+        """
+        return image.to_str(tag=True)
+
+    def __contains__(self, image):
+        """Check if collector contains digests of the specified image
+
+        :param ImageName image: image
+        :rtype: bool
+        :return: True if collector contains digests of the specified image
+        """
+        image_name_tag = self._key(image)
+        return image_name_tag in self._images_digests
+
+    def __bool__(self):
+        """Non-emptiness test
+
+        :rtype: bool
+        :return: True if object contains data otherwise False
+        """
+        return bool(self._images_digests)
+
+    if PY2:
+        def __nonzero__(self):  # pylint: disable=nonzero-method
+            return self.__bool__()
+
+    def update_image_digest(self, image, platform, digest):
+        """Update parent image digest for specific platform
+
+        :param ImageName image: image
+        :param str platform: name of the platform/arch (x86_64, ppc64le, ...)
+        :param str digest: digest of the specified image (sha256:...)
+        """
+        image_name_tag = self._key(image)
+
+        image_name = image.to_str(tag=False)
+        name_digest = '{}@{}'.format(image_name, digest)
+
+        image_digests = self._images_digests.setdefault(image_name_tag, {})
+        image_digests[platform] = name_digest
+
+    def get_image_digests(self, image):
+        """Get platform digests of specified image
+
+        :param ImageName image: image
+        :raises KeyError: when image is not found
+        :rtype: dict
+        :return: mapping platform:digest of the specified image
+        """
+        image_name_tag = self._key(image)
+        image_digests = self._images_digests.get(image_name_tag)
+        if image_digests is None:
+            raise KeyError('Image {} has no digest records'.format(image_name_tag))
+        return image_digests
+
+    def get_image_platform_digest(self, image, platform):
+        """Get digest of specified image and platform
+
+        :param ImageName image: image
+        :param str platform: name of the platform/arch (x86_64, ppc64le, ...)
+        :raises KeyError: when digest is not found
+        :rtype: str
+        :return: digest of the specified image (fedora@sha256:...)
+        """
+        image_digests = self.get_image_digests(image)
+        digest = image_digests.get(platform)
+        if digest is None:
+            raise KeyError(
+                'Image {} has no digest record for platform {}'.format(image, platform)
+            )
+
+        return digest
+
+    def update_from_dict(self, source):
+        """Update records of the digests of images from a dictionary
+        (no validation is performed)
+
+        :param dict source: data
+        """
+        assert isinstance(source, dict)
+        source_copy = deepcopy(source)  # no mutable side effects
+        self._images_digests.update(source_copy)
+
+    def to_dict(self):
+        """Return collected digests
+
+        :rtype: dict
+        :return: Collected images and digests
+        """
+        return deepcopy(self._images_digests)


### PR DESCRIPTION
Image tags are floating so builds can end up in inconsistent state where
orchestrator/workers may end up in using different image.

To avoid such issue we must switch to image digests. Orchestrator
will provide digests to be used at workers to eliminite race condition.

To keep BW compatibility, if orchestrator doesn't provide information
about digests only warning is logged.

Jira: OSBS-5674

Signed-off-by: Martin Bašti <mbasti@redhat.com>