### PR TITLE
Update test requirements

### DIFF
--- a/atomic-reactor.spec
+++ b/atomic-reactor.spec
@@ -18,7 +18,7 @@
 %endif
 
 %if 0%{?fedora}
-# rhel/epel has no flexmock, pytest-capturelog
+# rhel/epel has no flexmock
 %global with_check 1
 %endif
 
@@ -50,7 +50,6 @@ BuildRequires:  python2-devel
 BuildRequires:  python-setuptools
 %if 0%{?with_check}
 BuildRequires:  pytest
-BuildRequires:  python-pytest-capturelog
 BuildRequires:  python-dockerfile-parse >= 0.0.11
 BuildRequires:  python-docker-py
 BuildRequires:  python-flexmock >= 0.10.2
@@ -72,7 +71,6 @@ BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
 %if 0%{?with_check}
 BuildRequires:  python3-pytest
-BuildRequires:  python3-pytest-capturelog
 BuildRequires:  python3-dockerfile-parse >= 0.0.11
 BuildRequires:  python3-docker-py
 BuildRequires:  python3-flexmock >= 0.10.2
@@ -407,6 +405,9 @@ LANG=en_US.utf8 py.test-%{python2_version} -vv tests
 
 
 %changelog
+* Fri Nov 23 2018 Athos Ribeiro <athos@redhat.com>
+- Remove pytest-capturelog dependency
+
 * Thu Nov 22 2018 Robert Cerven <rcerven@redhat.com> - 1.6.36.1-1
 - new upstream release: 1.6.36.1
 

--- a/tests/plugins/test_add_dockerfile.py
+++ b/tests/plugins/test_add_dockerfile.py
@@ -166,7 +166,7 @@ CMD blabla"""
         }]
     )
     runner.run()
-    assert "plugin 'add_dockerfile' raised an exception: ValueError" in caplog.text()
+    assert "plugin 'add_dockerfile' raised an exception: ValueError" in caplog.text
 
 
 def test_adddockerfile_final(tmpdir, docker_tasker):  # noqa

--- a/tests/plugins/test_add_filesystem.py
+++ b/tests/plugins/test_add_filesystem.py
@@ -394,7 +394,8 @@ def test_image_task_failure(tmpdir, build_cancel, error_during_cancel, raise_err
         }]
     )
 
-    with caplog.atLevel(logging.INFO), pytest.raises(PluginFailedException) as exc:
+    with caplog.at_level(logging.INFO,
+                         logger='atomic_reactor'), pytest.raises(PluginFailedException) as exc:
         runner.run()
 
     assert task_result in str(exc)
@@ -403,16 +404,16 @@ def test_image_task_failure(tmpdir, build_cancel, error_during_cancel, raise_err
 
     if build_cancel:
         msg = "Build was canceled, canceling task %s" % FILESYSTEM_TASK_ID
-        assert msg in [x.message for x in caplog.records()]
+        assert msg in [x.message for x in caplog.records]
 
         if error_during_cancel:
             # We're checking last but one message, as the last one is
             # 'plugin 'add_filesystem' raised an exception'
             assert "Exception while canceling a task (ignored): Exception("\
-                in caplog.records()[-2].message
+                in caplog.records[-2].message
         else:
             msg = "task %s canceled" % FILESYSTEM_TASK_ID
-            assert msg in [x.message for x in caplog.records()]
+            assert msg in [x.message for x in caplog.records]
 
 
 # with a task_id is the new standard, None is legacy-mode support

--- a/tests/plugins/test_add_labels.py
+++ b/tests/plugins/test_add_labels.py
@@ -226,7 +226,7 @@ def test_add_labels_plugin(tmpdir, docker_tasker,
         with pytest.raises(PluginFailedException):
             runner.run()
         assert "plugin 'add_labels_in_dockerfile' raised an exception: RuntimeError" \
-            in caplog.text()
+            in caplog.text
 
     else:
         runner.run()
@@ -447,7 +447,7 @@ def test_add_labels_aliases(tmpdir, docker_tasker, caplog,
     assert result_new == exp_new
 
     if exp_log:
-        assert exp_log in caplog.text()
+        assert exp_log in caplog.text
 
 
 @pytest.mark.parametrize('base_l, df_l, expected, expected_log', [  # noqa
@@ -531,7 +531,7 @@ def test_add_labels_equal_aliases(tmpdir, docker_tasker, caplog,
     assert result_snd == expected[1]
 
     if expected_log:
-        assert expected_log in caplog.text()
+        assert expected_log in caplog.text
 
 
 @pytest.mark.parametrize('base_l, df_l, expected, expected_log', [  # noqa
@@ -621,7 +621,7 @@ def test_add_labels_equal_aliases2(tmpdir, docker_tasker, caplog, base_l,
         assert result_trd == expected[2]
 
         if expected_log:
-            assert expected_log in caplog.text()
+            assert expected_log in caplog.text
 
 
 @pytest.mark.parametrize("parent_scope, docker_scope, result_scope, dont_overwrite", [  # noqa
@@ -836,12 +836,12 @@ def test_add_labels_base_image(tmpdir, docker_tasker, parent, should_fail,
     )
 
     if should_fail:
-        with caplog.atLevel(logging.ERROR):
+        with caplog.at_level(logging.ERROR):
             with pytest.raises(PluginFailedException):
                 runner.run()
 
         msg = "base image was not inspected"
-        assert msg in [x.message for x in caplog.records()]
+        assert msg in [x.message for x in caplog.records]
     else:
         runner.run()
         assert df.labels['release'] == '5'
@@ -919,4 +919,4 @@ def test_release_label(tmpdir, docker_tasker, caplog,
     assert result_new == expected_in_df
 
     if expected_log:
-        assert expected_log in caplog.text()
+        assert expected_log in caplog.text

--- a/tests/plugins/test_add_yum_repo_by_url.py
+++ b/tests/plugins/test_add_yum_repo_by_url.py
@@ -99,7 +99,7 @@ def test_multiple_repourls(caplog, base_from_scratch, parent_images, inject_prox
         assert AddYumRepoByUrlPlugin.key is not None
         assert workflow.files == {}
         log_msg = "Skipping add yum repo by url: unsupported for FROM-scratch images"
-        assert log_msg in caplog.text()
+        assert log_msg in caplog.text
     else:
         repo_content = repocontent
         if inject_proxy:

--- a/tests/plugins/test_bump_release.py
+++ b/tests/plugins/test_bump_release.py
@@ -113,7 +113,7 @@ class TestBumpRelease(object):
         plugin = self.prepare(tmpdir, labels={release_label: '1'},
                               reactor_config_map=reactor_config_map)
         plugin.run()
-        assert 'not incrementing' in caplog.text()
+        assert 'not incrementing' in caplog.text
 
     @pytest.mark.parametrize('labels', [
         {'com.redhat.component': 'component'},

--- a/tests/plugins/test_change_from_in_df.py
+++ b/tests/plugins/test_change_from_in_df.py
@@ -112,7 +112,7 @@ def test_update_base_image_inspect_broken(tmpdir, caplog, docker_tasker):
     with pytest.raises(NoIdInspection):
         ChangeFromPlugin(docker_tasker, workflow).run()
     assert dfp.content == df_content  # nothing changed
-    assert "missing in inspection" in caplog.text()
+    assert "missing in inspection" in caplog.text
 
 
 @pytest.mark.parametrize('organization', [None, 'my_organization'])  # noqa

--- a/tests/plugins/test_check_and_set_platforms.py
+++ b/tests/plugins/test_check_and_set_platforms.py
@@ -174,12 +174,12 @@ def test_check_and_set_platforms(tmpdir, caplog, platforms, platform_exclude, pl
     plugin_result = runner.run()
     if platforms:
         koji_msg = "Koji platforms are {0}".format(sorted(platforms.split()))
-        assert koji_msg in caplog.text()
+        assert koji_msg in caplog.text
         assert plugin_result[PLUGIN_CHECK_AND_SET_PLATFORMS_KEY]
         assert plugin_result[PLUGIN_CHECK_AND_SET_PLATFORMS_KEY] == set(result)
     else:
         assert plugin_result[PLUGIN_CHECK_AND_SET_PLATFORMS_KEY] is None
-        assert "No platforms found in koji target" in caplog.text()
+        assert "No platforms found in koji target" in caplog.text
 
 
 @pytest.mark.parametrize(('labels', 'platforms', 'orchestrator_platforms', 'platform_only',
@@ -225,14 +225,14 @@ def test_check_isolated_or_scratch(tmpdir, caplog, labels, platforms,
     plugin_result = runner.run()
     if platforms:
         koji_msg = "Koji platforms are {0}".format(sorted(platforms.split()))
-        assert koji_msg in caplog.text()
+        assert koji_msg in caplog.text
         diffplat = orchestrator_platforms and set(platforms.split()) != set(orchestrator_platforms)
         if labels and diffplat:
             sort_platforms = sorted(orchestrator_platforms)
             user_msg = "Received user specified platforms {0}".format(sort_platforms)
-            assert user_msg in caplog.text()
+            assert user_msg in caplog.text
     else:
-        assert "No platforms found in koji target" in caplog.text()
+        assert "No platforms found in koji target" in caplog.text
 
     if result:
         assert plugin_result[PLUGIN_CHECK_AND_SET_PLATFORMS_KEY]
@@ -270,7 +270,7 @@ def test_check_and_set_platforms_no_koji(tmpdir, caplog, platforms, platform_onl
         no_koji_msg = "No koji platforms. "
         platform_msg = "User specified platforms are {0}".format(sorted(platforms.split()))
         user_msg = no_koji_msg + platform_msg
-        assert user_msg in caplog.text()
+        assert user_msg in caplog.text
         assert plugin_result[PLUGIN_CHECK_AND_SET_PLATFORMS_KEY]
         assert plugin_result[PLUGIN_CHECK_AND_SET_PLATFORMS_KEY] == set(result)
     else:

--- a/tests/plugins/test_check_and_set_rebuild.py
+++ b/tests/plugins/test_check_and_set_rebuild.py
@@ -192,7 +192,7 @@ class TestCheckRebuild(object):
             assert workflow.prebuild_results[CheckAndSetRebuildPlugin.key] is False
             assert not is_rebuild(workflow)
             log_msg = "Skipping check and set rebuild: unsupported for FROM-scratch images"
-            assert log_msg in caplog.text()
+            assert log_msg in caplog.text
         else:
             assert workflow.prebuild_results[CheckAndSetRebuildPlugin.key] is True
             assert is_rebuild(workflow)

--- a/tests/plugins/test_compare_components.py
+++ b/tests/plugins/test_compare_components.py
@@ -158,7 +158,7 @@ def test_compare_components_plugin(tmpdir, caplog, base_from_scratch, mismatch, 
         runner.run()
         if base_from_scratch:
             log_msg = "Skipping comparing components: unsupported for FROM-scratch images"
-            assert log_msg in caplog.text()
+            assert log_msg in caplog.text
 
 
 
@@ -257,9 +257,9 @@ def test_mismatch_reporting(tmpdir, caplog, mismatch):
 
         for entry in log_entries:
             # component mismatch must be reported only once
-            assert caplog.text().count(entry) == 1
+            assert caplog.text.count(entry) == 1
     else:
         # no mismatch, no failure, no log entries
         runner.run()
         for entry in log_entries:
-            assert entry not in caplog.text()
+            assert entry not in caplog.text

--- a/tests/plugins/test_compress.py
+++ b/tests/plugins/test_compress.py
@@ -82,4 +82,4 @@ class TestCompress(object):
         assert metadata['type'] == IMAGE_TYPE_DOCKER_ARCHIVE
         assert 'uncompressed_size' in metadata
         assert isinstance(metadata['uncompressed_size'], integer_types)
-        assert ", ratio: " in caplog.text()
+        assert ", ratio: " in caplog.text

--- a/tests/plugins/test_distribution_scope.py
+++ b/tests/plugins/test_distribution_scope.py
@@ -56,6 +56,7 @@ class TestDistributionScope(object):
     ])
     def test_distribution_scope_allowed(self, tmpdir, base_from_scratch, parent_scope,
                                         current_scope, allowed, caplog):
+        caplog.set_level(logging.ERROR, logger='atomic_reactor')
         plugin = self.instantiate_plugin(tmpdir,
                                          {'distribution-scope': parent_scope},
                                          current_scope,
@@ -63,48 +64,48 @@ class TestDistributionScope(object):
         if base_from_scratch:
             allowed = True
         if allowed:
-            with caplog.atLevel(logging.ERROR):
+            with caplog.at_level(logging.ERROR):
                 plugin.run()
 
             # No errors logged
-            assert not caplog.records()
+            assert not caplog.records
             if base_from_scratch:
-                "no distribution scope set for" in caplog.text()
+                "no distribution scope set for" in caplog.text
         else:
             with pytest.raises(DisallowedDistributionScope):
                 plugin.run()
 
             # Should log something at ERROR
-            assert caplog.records()
+            assert caplog.records
 
     @pytest.mark.parametrize('current_scope', [None, 'private'])
     def test_imported_parent_distribution_scope(self, tmpdir, caplog, current_scope):
         plugin = self.instantiate_plugin(tmpdir, None, current_scope)
-        with caplog.atLevel(logging.ERROR):
+        with caplog.at_level(logging.ERROR, logger='atomic_reactor'):
             plugin.run()
 
         # No errors logged
-        assert not caplog.records()
+        assert not caplog.records
 
     @pytest.mark.parametrize('current_scope', [None, 'private'])
     def test_invalid_parent_distribution_scope(self, tmpdir, caplog, current_scope):
         plugin = self.instantiate_plugin(tmpdir,
                                          {'distribution-scope': 'invalid-choice'},
                                          current_scope)
-        with caplog.atLevel(logging.WARNING):
+        with caplog.at_level(logging.WARNING, logger='atomic_reactor'):
             plugin.run()
 
             if current_scope:
                 # Warning logged (if we get as far as checking parent scope)
-                assert 'invalid label' in caplog.text()
+                assert 'invalid label' in caplog.text
 
     @pytest.mark.parametrize('parent_scope', [None, 'private'])
     def test_invalid_current_distribution_scope(self, tmpdir, caplog, parent_scope):
         plugin = self.instantiate_plugin(tmpdir,
                                          {'distribution-scope': parent_scope},
                                          'invalid-choice')
-        with caplog.atLevel(logging.WARNING):
+        with caplog.at_level(logging.WARNING, logger='atomic_reactor'):
             plugin.run()
 
             # Warning logged
-            assert 'invalid label' in caplog.text()
+            assert 'invalid label' in caplog.text

--- a/tests/plugins/test_koji.py
+++ b/tests/plugins/test_koji.py
@@ -225,7 +225,7 @@ class TestKoji(object):
 
         if base_from_scratch and not parent_images:
             log_msg = "from scratch single stage can't add repos from koji target"
-            assert log_msg in caplog.text()
+            assert log_msg in caplog.text
             return
         if not expect_success:
             return

--- a/tests/plugins/test_koji_import.py
+++ b/tests/plugins/test_koji_import.py
@@ -733,14 +733,14 @@ class TestKojiImport(object):
         assert isinstance(extra, dict)
 
         if expect_success:
-            assert "Koji Task ID {}".format(koji_task_id) in caplog.text()
+            assert "Koji Task ID {}".format(koji_task_id) in caplog.text
 
             assert 'container_koji_task_id' in extra
             extra_koji_task_id = extra['container_koji_task_id']
             assert isinstance(extra_koji_task_id, int)
             assert extra_koji_task_id == koji_task_id
         else:
-            assert "invalid task ID" in caplog.text()
+            assert "invalid task ID" in caplog.text
             assert 'container_koji_task_id' not in extra
 
     @pytest.mark.parametrize('params', [
@@ -1052,7 +1052,7 @@ class TestKojiImport(object):
         with pytest.raises(PluginFailedException):
             runner.run()
 
-        assert 'metadata:' in caplog.text()
+        assert 'metadata:' in caplog.text
 
     @pytest.mark.parametrize(('parent_id', 'expect_success', 'expect_error'), [
         (1234, True, False),
@@ -1088,7 +1088,7 @@ class TestKojiImport(object):
         assert isinstance(extra, dict)
 
         if expect_error:
-            assert 'invalid koji parent id' in caplog.text()
+            assert 'invalid koji parent id' in caplog.text
         if expect_success:
             image = extra['image']
             assert isinstance(image, dict)
@@ -1172,7 +1172,7 @@ class TestKojiImport(object):
             assert isinstance(filesystem_koji_task_id, int)
             assert filesystem_koji_task_id == task_id
         else:
-            assert 'invalid task ID' in caplog.text()
+            assert 'invalid task ID' in caplog.text
             assert 'filesystem_koji_task_id' not in extra
 
     def test_koji_import_filesystem_koji_task_id_missing(self, tmpdir, os_env, caplog,  # noqa
@@ -1197,7 +1197,7 @@ class TestKojiImport(object):
         extra = build['extra']
         assert isinstance(extra, dict)
         assert 'filesystem_koji_task_id' not in extra
-        assert AddFilesystemPlugin.key in caplog.text()
+        assert AddFilesystemPlugin.key in caplog.text
 
     @pytest.mark.parametrize('blocksize', (None, 1048576))
     @pytest.mark.parametrize(('apis',

--- a/tests/plugins/test_koji_promote.py
+++ b/tests/plugins/test_koji_promote.py
@@ -552,14 +552,14 @@ class TestKojiPromote(object):
         assert isinstance(extra, dict)
 
         if expect_success:
-            assert "Koji Task ID {}".format(koji_task_id) in caplog.text()
+            assert "Koji Task ID {}".format(koji_task_id) in caplog.text
 
             assert 'container_koji_task_id' in extra
             extra_koji_task_id = extra['container_koji_task_id']
             assert isinstance(extra_koji_task_id, int)
             assert extra_koji_task_id == koji_task_id
         else:
-            assert "invalid task ID" in caplog.text()
+            assert "invalid task ID" in caplog.text
             assert 'container_koji_task_id' not in extra
 
     @pytest.mark.parametrize('params', [
@@ -932,7 +932,7 @@ class TestKojiPromote(object):
         with pytest.raises(PluginFailedException):
             runner.run()
 
-        assert 'metadata:' in caplog.text()
+        assert 'metadata:' in caplog.text
 
     @pytest.mark.parametrize('task_states', [
         ['FREE', 'ASSIGNED', 'FAILED'],
@@ -989,7 +989,7 @@ class TestKojiPromote(object):
             assert isinstance(filesystem_koji_task_id, int)
             assert filesystem_koji_task_id == task_id
         else:
-            assert 'invalid task ID' in caplog.text()
+            assert 'invalid task ID' in caplog.text
             assert 'filesystem_koji_task_id' not in extra
 
     def test_koji_promote_filesystem_koji_task_id_missing(self, tmpdir, os_env,
@@ -1014,7 +1014,7 @@ class TestKojiPromote(object):
         extra = build['extra']
         assert isinstance(extra, dict)
         assert 'filesystem_koji_task_id' not in extra
-        assert AddFilesystemPlugin.key in caplog.text()
+        assert AddFilesystemPlugin.key in caplog.text
 
     @pytest.mark.parametrize('additional_tags', [
         None,

--- a/tests/plugins/test_koji_upload.py
+++ b/tests/plugins/test_koji_upload.py
@@ -872,7 +872,7 @@ class TestKojiUpload(object):
         with pytest.raises(PluginFailedException):
             runner.run()
 
-        assert 'metadata:' in caplog.text()
+        assert 'metadata:' in caplog.text
 
     @pytest.mark.parametrize('additional_tags', [
         None,

--- a/tests/plugins/test_orchestrate_build.py
+++ b/tests/plugins/test_orchestrate_build.py
@@ -438,7 +438,7 @@ def test_orchestrate_build(tmpdir, caplog, config_kwargs,
     build_info = get_worker_build_info(workflow, 'x86_64')
     assert build_info.osbs
 
-    for record in caplog.records():
+    for record in caplog.records:
         if not record.name.startswith("atomic_reactor"):
             continue
 
@@ -1204,8 +1204,8 @@ def test_orchestrate_override_content_versions(tmpdir, caplog, enable_v1, conten
     build_result = runner.run()
     if will_fail:
         assert build_result.is_failed()
-        assert 'failed to create worker build' in caplog.text()
-        assert 'content_versions is empty' in caplog.text()
+        assert 'failed to create worker build' in caplog.text
+        assert 'content_versions is empty' in caplog.text
     else:
         assert not build_result.is_failed()
 
@@ -1705,4 +1705,4 @@ def test_orchestrate_build_validate_arrangements(tmpdir, caplog, version, warnin
         runner.run()
 
     if warning:
-        assert warning in caplog.text()
+        assert warning in caplog.text

--- a/tests/plugins/test_pull_base_image.py
+++ b/tests/plugins/test_pull_base_image.py
@@ -276,7 +276,7 @@ def test_pull_base_library(reactor_config_map, caplog):  # noqa
         )
     assert "not found" in str(exc.value)
     assert "RetryGeneratorException" in str(exc.value)
-    assert "trying" not in caplog.text()  # don't retry with "library/library-only:latest"
+    assert "trying" not in caplog.text  # don't retry with "library/library-only:latest"
 
 
 def test_pull_base_base_parse(reactor_config_map, inspect_only):  # noqa
@@ -426,7 +426,7 @@ class TestValidateBaseImage(object):
                                     inspect_only=False,
                                     workflow_callback=self.prepare,
                                     check_platforms=True)
-        assert log_message in caplog.text()
+        assert log_message in caplog.text
 
     def test_expected_platforms_unknown(self, caplog):
 
@@ -442,7 +442,7 @@ class TestValidateBaseImage(object):
                                     inspect_only=False,
                                     workflow_callback=workflow_callback,
                                     check_platforms=True)
-        assert log_message in caplog.text()
+        assert log_message in caplog.text
 
     def test_single_platform_build(self, caplog):
 
@@ -457,7 +457,7 @@ class TestValidateBaseImage(object):
                                     inspect_only=False,
                                     workflow_callback=workflow_callback,
                                     check_platforms=True)
-        assert log_message in caplog.text()
+        assert log_message in caplog.text
 
     def test_registry_undefined(self, caplog):
         def workflow_callback(workflow):
@@ -472,7 +472,7 @@ class TestValidateBaseImage(object):
                                     inspect_only=False,
                                     workflow_callback=workflow_callback,
                                     check_platforms=True)
-        assert log_message in caplog.text()
+        assert log_message in caplog.text
 
     def test_platform_descriptors_undefined(self, caplog):
         def workflow_callback(workflow):
@@ -487,7 +487,7 @@ class TestValidateBaseImage(object):
                                     inspect_only=False,
                                     workflow_callback=workflow_callback,
                                     check_platforms=True)
-        assert log_message in caplog.text()
+        assert log_message in caplog.text
 
     def test_manifest_list_with_no_response(self, caplog):
         def workflow_callback(workflow):
@@ -658,8 +658,8 @@ class TestValidateBaseImage(object):
         new_image = "'registry.example.com/busybox@sha256:654321'"
         pulling_msg = "pulling image " + new_image + " from registry"
         tagging_msg = "tagging image " + new_image + " as '" + UNIQUE_ID
-        assert pulling_msg in caplog.text()
-        assert tagging_msg in caplog.text()
+        assert pulling_msg in caplog.text
+        assert tagging_msg in caplog.text
 
     def prepare(self, workflow):
         # Setup expected platforms

--- a/tests/plugins/test_pulp.py
+++ b/tests/plugins/test_pulp.py
@@ -338,9 +338,9 @@ def test_pulp_publish_only_without_sync(before_name, after_name, publish,
     plugin.run()
 
     if should_publish:
-        assert 'to be published' in caplog.text()
+        assert 'to be published' in caplog.text
     else:
-        assert 'publishing deferred' in caplog.text()
+        assert 'publishing deferred' in caplog.text
 
 
 @pytest.mark.skipif(dockpulp is None,

--- a/tests/plugins/test_pulp_publish.py
+++ b/tests/plugins/test_pulp_publish.py
@@ -168,7 +168,7 @@ def test_pulp_publish_success(caplog, reactor_config_map):
 
     crane_images = plugin.run()
 
-    assert 'to be published' in caplog.text()
+    assert 'to be published' in caplog.text
     images = [i.to_str() for i in crane_images]
     assert "registry.example.com/image-name1:latest" in images
     assert "registry.example.com/image-name1:2" in images
@@ -208,6 +208,6 @@ def test_pulp_publish_delete(worker_builds_created, v1_image_ids,
 
     assert crane_images == []
     if expected and worker_builds_created:
-        assert msg in caplog.text()
+        assert msg in caplog.text
     else:
-        assert msg not in caplog.text()
+        assert msg not in caplog.text

--- a/tests/plugins/test_pulp_pull.py
+++ b/tests/plugins/test_pulp_pull.py
@@ -538,7 +538,7 @@ class TestPostPulpPull(object):
             expected_media_types.append(MEDIA_TYPE_DOCKER_V2_SCHEMA1)
             expected_media_types.append(MEDIA_TYPE_DOCKER_V2_SCHEMA2)
         else:
-            assert "Only V2 schema 2 manifest list is expected, " in caplog.text()
+            assert "Only V2 schema 2 manifest list is expected, " in caplog.text
         assert set(media_types) == set(expected_media_types)
 
     @responses.activate
@@ -649,7 +649,7 @@ class TestPostPulpPull(object):
                 with pytest.raises(Exception):
                     plugin.run()
                 if manifest_list_warn:
-                    assert "Expected schema 2 manifest list" in caplog.text()
+                    assert "Expected schema 2 manifest list" in caplog.text
         else:
             if expect_success:
                 media_types = plugin.run()
@@ -657,17 +657,17 @@ class TestPostPulpPull(object):
                 with pytest.raises(Exception):
                     plugin.run()
                 if manifest_list_warn:
-                    assert "Expected schema 2 manifest list" in caplog.text()
+                    assert "Expected schema 2 manifest list" in caplog.text
                 elif manifest2_warn:
-                    assert "Expected schema 2 manifest" in caplog.text()
+                    assert "Expected schema 2 manifest" in caplog.text
 
         if media_types:
             expected_media_types = [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]
             if not manifest_list_only:
                 expected_media_types.append(MEDIA_TYPE_DOCKER_V2_SCHEMA1)
                 expected_media_types.append(MEDIA_TYPE_DOCKER_V2_SCHEMA2)
-                assert "V2 schema 2 digest found, leaving image ID unchanged" in caplog.text()
+                assert "V2 schema 2 digest found, leaving image ID unchanged" in caplog.text
             else:
-                assert "Only V2 schema 2 manifest list is expected, " in caplog.text()
+                assert "Only V2 schema 2 manifest list is expected, " in caplog.text
 
             assert set(media_types) == set(expected_media_types)

--- a/tests/plugins/test_pulp_sync.py
+++ b/tests/plugins/test_pulp_sync.py
@@ -525,7 +525,7 @@ class TestPostPulpSync(object):
                                 dockpulp_loglevel=loglevel)
         plugin.run()
 
-        errors = [record.getMessage() for record in caplog.records()
+        errors = [record.getMessage() for record in caplog.records
                   if record.levelname == 'ERROR']
 
         if fail:
@@ -725,7 +725,7 @@ class TestPostPulpSync(object):
                                 workflow=workflow,
                                 **kwargs)
         plugin.run()
-        log_messages = [l.getMessage() for l in caplog.records()]
+        log_messages = [l.getMessage() for l in caplog.records]
 
         for image in workflow.tag_conf.images:
             expected_log = 'image available at %s' % image.to_str()

--- a/tests/plugins/test_pulp_tag.py
+++ b/tests/plugins/test_pulp_tag.py
@@ -200,9 +200,9 @@ def test_pulp_tag_basic(tmpdir, monkeypatch, v1_image_ids, should_raise, caplog,
 
     results = runner.run()
     if msg:
-        assert msg in caplog.text()
+        assert msg in caplog.text
     else:
-        assert "tagging v1-image-id" not in caplog.text()
+        assert "tagging v1-image-id" not in caplog.text
     assert results['pulp_tag'] == expected_results
 
 
@@ -236,7 +236,7 @@ def test_pulp_tag_source_secret(tmpdir, monkeypatch, caplog, reactor_config_map)
                                                   'auth': {'ssl_certs_dir': str(tmpdir)}}})
 
     results = runner.run()
-    assert msg in caplog.text()
+    assert msg in caplog.text
     assert results['pulp_tag'] == expected_results
 
 
@@ -272,5 +272,5 @@ def test_pulp_tag_service_account_secret(tmpdir, monkeypatch, caplog, reactor_co
                                     'auth': {'ssl_certs_dir': str(tmpdir)}}})
 
     results = runner.run()
-    assert msg in caplog.text()
+    assert msg in caplog.text
     assert results['pulp_tag'] == expected_results

--- a/tests/plugins/test_reactor_config.py
+++ b/tests/plugins/test_reactor_config.py
@@ -177,10 +177,10 @@ class TestReactorConfigPlugin(object):
 
         tasker, workflow = self.prepare()
         plugin = ReactorConfigPlugin(tasker, workflow, config_path=str(tmpdir))
-        with caplog.atLevel(logging.ERROR), pytest.raises(Exception):
+        with caplog.at_level(logging.ERROR), pytest.raises(Exception):
             plugin.run()
 
-        captured_errs = [x.message for x in caplog.records()]
+        captured_errs = [x.message for x in caplog.records]
         assert "unable to extract JSON schema, cannot validate" in captured_errs
 
     @pytest.mark.parametrize('schema', [
@@ -207,10 +207,10 @@ class TestReactorConfigPlugin(object):
 
         tasker, workflow = self.prepare()
         plugin = ReactorConfigPlugin(tasker, workflow, config_path=str(tmpdir))
-        with caplog.atLevel(logging.ERROR), pytest.raises(Exception):
+        with caplog.at_level(logging.ERROR), pytest.raises(Exception):
             plugin.run()
 
-        captured_errs = [x.message for x in caplog.records()]
+        captured_errs = [x.message for x in caplog.records]
         assert any("cannot validate" in x for x in captured_errs)
 
     @pytest.mark.parametrize(('config', 'errors'), [
@@ -310,11 +310,11 @@ class TestReactorConfigPlugin(object):
         tasker, workflow = self.prepare()
         plugin = ReactorConfigPlugin(tasker, workflow, config_path=str(tmpdir))
 
-        with caplog.atLevel(logging.ERROR), pytest.raises(ValidationError):
+        with caplog.at_level(logging.ERROR), pytest.raises(ValidationError):
             plugin.run()
 
         os.environ.pop('REACTOR_CONFIG', None)
-        captured_errs = [x.message for x in caplog.records()]
+        captured_errs = [x.message for x in caplog.records]
         for error in errors:
             try:
                 # Match regexp

--- a/tests/plugins/test_remove_worker_metadata.py
+++ b/tests/plugins/test_remove_worker_metadata.py
@@ -126,6 +126,6 @@ def test_remove_worker_plugin(tmpdir, caplog, names, fragment_key):
 
     for name in names:
         if name:
-            assert "ConfigMap {} deleted".format(name) in caplog.text()
+            assert "ConfigMap {} deleted".format(name) in caplog.text
         else:
-            assert "Failed to delete ConfigMap None" in caplog.text()
+            assert "Failed to delete ConfigMap None" in caplog.text

--- a/tests/plugins/test_resolve_composes.py
+++ b/tests/plugins/test_resolve_composes.py
@@ -902,22 +902,22 @@ class TestResolveComposes(object):
     def test_abort_when_odcs_config_missing(self, tmpdir, caplog, workflow, reactor_config_map):
         # Clear out default reactor config
         mock_reactor_config(workflow, tmpdir, data='')
-        with caplog.atLevel(logging.INFO):
+        with caplog.at_level(logging.INFO):
             self.run_plugin_with_args(workflow, reactor_config_map=reactor_config_map)
 
         msg = 'Aborting plugin execution: ODCS config not found'
-        assert msg in (x.message for x in caplog.records())
+        assert msg in (x.message for x in caplog.records)
 
     def test_abort_when_compose_config_missing(self, caplog, workflow, reactor_config_map):
         # Clear out default git repo config
         mock_repo_config(workflow._tmpdir, '')
         # Ensure no compose_ids are passed to plugin
         plugin_args = {'compose_ids': tuple()}
-        with caplog.atLevel(logging.INFO):
+        with caplog.at_level(logging.INFO):
             self.run_plugin_with_args(workflow, plugin_args, reactor_config_map=reactor_config_map)
 
         msg = 'Aborting plugin execution: "compose" config not set and compose_ids not given'
-        assert msg in (x.message for x in caplog.records())
+        assert msg in (x.message for x in caplog.records)
 
     def test_invalid_koji_build_target(self, workflow, reactor_config_map):
         plugin_args = {
@@ -938,11 +938,11 @@ class TestResolveComposes(object):
     def test_parameters_ignored_for_autorebuild(self, caplog, workflow, plugin_args, msg,
                                                 reactor_config_map):
         flexmock(pre_check_and_set_rebuild).should_receive('is_rebuild').and_return(True)
-        with caplog.atLevel(logging.INFO):
+        with caplog.at_level(logging.INFO):
             self.run_plugin_with_args(workflow, plugin_args,
                                       reactor_config_map=reactor_config_map)
 
-        assert msg in (x.message for x in caplog.records())
+        assert msg in (x.message for x in caplog.records)
 
     def run_plugin_with_args(self, workflow, plugin_args=None,
                              expect_error=None, reactor_config_map=False,

--- a/tests/plugins/test_rpmqa.py
+++ b/tests/plugins/test_rpmqa.py
@@ -91,7 +91,7 @@ def test_rpmqa_plugin(caplog, docker_tasker, base_from_scratch, remove_container
     results = runner.run()
     if base_from_scratch:
         log_msg = "from scratch can't run rpmqa"
-        assert log_msg in caplog.text()
+        assert log_msg in caplog.text
         assert results[PostBuildRPMqaPlugin.key] is None
         assert workflow.image_components is None
     else:

--- a/tests/plugins/test_sendmail.py
+++ b/tests/plugins/test_sendmail.py
@@ -1106,7 +1106,7 @@ class TestSendMailPlugin(object):
                                                                            ['foo/bar:baz',
                                                                             'foo/bar:spam']))
         p.run()
-        assert 'no valid addresses in requested addresses. Doing nothing' in caplog.text()
+        assert 'no valid addresses in requested addresses. Doing nothing' in caplog.text
 
     def test_run_does_nothing_if_conditions_not_met(self, reactor_config_map):  # noqa
         class WF(object):

--- a/tests/plugins/test_store_metadata.py
+++ b/tests/plugins/test_store_metadata.py
@@ -639,7 +639,7 @@ CMD blabla"""
         .and_raise(OsbsResponseException('/', 'failed', 0)))
     with pytest.raises(PluginFailedException):
         runner.run()
-    assert 'annotations:' in caplog.text()
+    assert 'annotations:' in caplog.text
 
 
 @pytest.mark.parametrize('koji_plugin', (PLUGIN_KOJI_IMPORT_PLUGIN_KEY,
@@ -666,7 +666,7 @@ def test_store_metadata_fail_update_labels(tmpdir, caplog, koji_plugin, reactor_
         .and_raise(OsbsResponseException('/', 'failed', 0)))
     with pytest.raises(PluginFailedException):
         runner.run()
-    assert 'labels:' in caplog.text()
+    assert 'labels:' in caplog.text
 
 
 @pytest.mark.parametrize(('pulp_registries', 'docker_registries', 'prefixes'), [

--- a/tests/plugins/test_tag_and_push.py
+++ b/tests/plugins/test_tag_and_push.py
@@ -512,14 +512,14 @@ def test_tag_and_push_plugin_oci(
         }]
     )
 
-    with caplog.atLevel(logging.DEBUG):
+    with caplog.at_level(logging.DEBUG):
         if fail_push:
             with pytest.raises(PluginFailedException):
                 output = runner.run()
         else:
             output = runner.run()
 
-    for r in caplog.records():
+    for r in caplog.records:
         assert 'mypassword' not in r.getMessage()
 
     if not fail_push:

--- a/tests/plugins/test_verify_media_types.py
+++ b/tests/plugins/test_verify_media_types.py
@@ -523,7 +523,7 @@ class TestVerifyImageTypes(object):
         plugin = VerifyMediaTypesPlugin(tasker, workflow)
         results = plugin.run()
         assert not results
-        assert "pulp registry configure, verify_media_types should not run" in caplog.text()
+        assert "pulp registry configure, verify_media_types should not run" in caplog.text
 
     """
     Build was unsuccessful, return an empty list

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,7 @@
 flexmock
 ordereddict
 responses>=0.9.0
-pytest==3.2.5
-pytest-capturelog==0.7
-pytest-cov==2.5.1
+pytest==4.0.*
+pytest-cov==2.6.*
+six>=1.10.0 # required by pytest-cov
 flake8

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -322,4 +322,4 @@ def test_parent_images_to_str(tmpdir, caplog):
         "fedora:latest": "spam:latest"
     }
     assert b.parent_images_to_str() == expected_results
-    assert "None in: base bacon has parent None" in caplog.text()
+    assert "None in: base bacon has parent None" in caplog.text

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -194,12 +194,12 @@ class TestCLISuite(object):
             "--verbose",
             "inside-build",
         ]
-        with caplog.atLevel(logging.INFO):
+        with caplog.at_level(logging.INFO):
             with pytest.raises(RuntimeError):
                 self.exec_cli(command)
 
         # first message should be 'log encoding: <encoding>'
-        match = caplog.records()[0].message.split(':')
+        match = caplog.records[0].message.split(':')
         if not match:
             raise RuntimeError
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -192,11 +192,11 @@ def test_verify_required_plugins_before_first_run(caplog, tmpdir, docker_tasker,
         with pytest.raises(PluginFailedException):
             runner = runner_type(*params)
             runner.run()
-        assert all(expected_log_message not in l.getMessage() for l in caplog.records())
+        assert all(expected_log_message not in l.getMessage() for l in caplog.records)
     else:
         runner = runner_type(*params)
         runner.run()
-        assert any(expected_log_message in l.getMessage() for l in caplog.records())
+        assert any(expected_log_message in l.getMessage() for l in caplog.records)
 
 
 def test_check_no_reload(caplog, tmpdir, docker_tasker):
@@ -210,13 +210,13 @@ def test_check_no_reload(caplog, tmpdir, docker_tasker):
                            workflow,
                            [{"name": "MyBsPlugin1"}],
                            plugin_files=[this_file])
-    assert any(expected_log_message in l.getMessage() for l in caplog.records())
-    log_len = len(caplog.records())
+    assert any(expected_log_message in l.getMessage() for l in caplog.records)
+    log_len = len(caplog.records)
     BuildStepPluginsRunner(docker_tasker,
                            workflow,
                            [{"name": "MyBsPlugin1"}],
                            plugin_files=[this_file])
-    assert all(expected_log_message not in l.getMessage() for l in caplog.records()[log_len:])
+    assert all(expected_log_message not in l.getMessage() for l in caplog.records[log_len:])
 
 @pytest.mark.parametrize('success1', [True, False])  # noqa
 @pytest.mark.parametrize('success2', [True, False])
@@ -254,7 +254,7 @@ def test_buildstep_phase_build_plugin(caplog, tmpdir, docker_tasker, success1, s
     else:
         runner.run()
         expected_log_message = "stopping further execution of plugins after first successful plugin"
-        assert expected_log_message in [l.getMessage() for l in caplog.records()]
+        assert expected_log_message in [l.getMessage() for l in caplog.records]
 
 
 @pytest.mark.parametrize('success1', [True, False])  # noqa
@@ -287,7 +287,7 @@ def test_buildstep_phase_build_plugin_failing_exception(tmpdir, caplog, docker_t
     else:
         runner.run()
         expected_log_message = "stopping further execution of plugins after first successful plugin"
-        assert expected_log_message in [l.getMessage() for l in caplog.records()]
+        assert expected_log_message in [l.getMessage() for l in caplog.records]
 
 
 def test_non_buildstep_phase_raises_InappropriateBuildStepError(caplog, tmpdir, docker_tasker):  # noqa

--- a/tests/test_pulp_util.py
+++ b/tests/test_pulp_util.py
@@ -260,6 +260,7 @@ def test_ensure_repos(auto_publish, unsupported):
 ])
 def test_upload(unsupported, caplog):
     log = logging.getLogger("tests.test_pulp_util")
+    caplog.set_level(logging.DEBUG, logger='tests.test_pulp_util')
     pulp_registry_name = 'registry.example.com'
     testfile = 'foo'
     upload_file = 'test_file'
@@ -292,11 +293,11 @@ def test_upload(unsupported, caplog):
 
     handler.upload(upload_file, repo_id)
 
-    assert "Uploading %s to %s" % (upload_file, repo_id) in caplog.text()
+    assert "Uploading %s to %s" % (upload_file, repo_id) in caplog.text
 
     if unsupported:
         assert "Falling back to uploading %s to redhat-everything repo" %\
-               upload_file in caplog.text()
+               upload_file in caplog.text
 
 
 class TestLockedPulpRepository(object):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -120,9 +120,9 @@ def test_image_name_format():
 def test_image_name_parse_image_name(caplog):
     warning = 'Attempting to parse ImageName test:latest as an ImageName'
     test = ImageName.parse("test")
-    assert warning not in caplog.text()
+    assert warning not in caplog.text
     image_test = ImageName.parse(test)
-    assert warning in caplog.text()
+    assert warning in caplog.text
     assert test is image_test
 
 
@@ -610,7 +610,7 @@ def test_get_manifest_digests(tmpdir, caplog, image, registry, insecure, creds,
         expected_result['v2_list'] = True
 
     # Only capture errors, since we want to be sure none are reported
-    with caplog.atLevel(logging.ERROR):
+    with caplog.at_level(logging.ERROR, logger='atomic_reactor'):
         if expected_versions:
             actual_digests = get_manifest_digests(**kwargs)
 
@@ -628,7 +628,7 @@ def test_get_manifest_digests(tmpdir, caplog, image, registry, insecure, creds,
             get_manifest_digests(**kwargs)
 
     # there should be no errors reported
-    assert not caplog.records()
+    assert not caplog.records
 
 
 @pytest.mark.parametrize('has_content_type_header', [
@@ -958,7 +958,7 @@ def test_df_parser_parent_env_wf(tmpdir, caplog, env_arg):
 
     if isinstance(env_arg, list) and ('=' not in env_arg[0]):
         expected_log_message = "Unable to parse all of Parent Config ENV"
-        assert expected_log_message in [l.getMessage() for l in caplog.records()]
+        assert expected_log_message in [l.getMessage() for l in caplog.records]
     elif isinstance(env_arg, dict):
         assert df.labels.get('label') == ('foobar ' + env_arg['test_env'])
     else:
@@ -1445,7 +1445,7 @@ def test_get_platforms_in_limits(tmpdir, platforms, config_dict, result, valid, 
         workflow = MockWorkflow(str(tmpdir))
         final_platforms = get_platforms_in_limits(workflow, platforms)
         if configured_same_not_and_only(config_dict):
-            assert 'only and not platforms are the same' in caplog.text()
+            assert 'only and not platforms are the same' in caplog.text
         assert final_platforms == set(result)
     elif valid:
         workflow = MockWorkflow(str(tmpdir))


### PR DESCRIPTION
The test requirements have been frozen to avoid unexpected failures due
to test package upgrades. They should be manually upgraded from time to
time. The issues below had to be addressed for this upgrade.

* pytest 3.3 removed backwards compatibility with pytest-capturelog and
merged pytest-catchlog into the core.
* pytest 4.0.0 fails if fixtures are called implicitly.

Signed-off-by: Athos Ribeiro <athos@redhat.com>