### PR TITLE
support empty package lists in pre_resolve_composes

### DIFF
--- a/atomic_reactor/odcs_util.py
+++ b/atomic_reactor/odcs_util.py
@@ -76,8 +76,8 @@ class ODCSClient(object):
                 'source': source
             }
         }
-        if packages:
-            body['source']['packages'] = packages
+        if source_type == "tag":
+            body['source']['packages'] = packages or []
 
         if sigkeys is not None:
             body['source']['sigkeys'] = sigkeys

--- a/atomic_reactor/plugins/pre_resolve_composes.py
+++ b/atomic_reactor/plugins/pre_resolve_composes.py
@@ -315,6 +315,7 @@ class ComposeConfig(object):
 
     def __init__(self, data, pulp_data, odcs_config, koji_tag=None, arches=None):
         data = data or {}
+        self.use_packages = 'packages' in data
         self.packages = data.get('packages', [])
         self.modules = data.get('modules', [])
         self.pulp = {}
@@ -352,7 +353,7 @@ class ComposeConfig(object):
         self.validate_for_request()
 
         requests = []
-        if self.packages:
+        if self.use_packages:
             requests.append(self.render_packages_request())
         elif self.modules:
             requests.append(self.render_modules_request())
@@ -398,7 +399,7 @@ class ComposeConfig(object):
 
     def validate_for_request(self):
         """Verify enough information is available for requesting compose."""
-        if not self.packages and not self.modules and not self.pulp:
+        if not self.use_packages and not self.modules and not self.pulp:
             raise ValueError("Nothing to compose (no packages, modules, or enabled pulp repos)")
 
         if self.packages and self.modules:

--- a/tests/test_odcs_util.py
+++ b/tests/test_odcs_util.py
@@ -82,12 +82,13 @@ def compose_json(state, state_name, source_type='module', source=MODULE_NSV,
     ['x86_64'],
     ['breakfast', 'lunch'],
 ))
-@pytest.mark.parametrize(('source', 'source_type', 'packages', 'sigkeys'), (
-    (MODULE_NSV, 'module', None, None),
-    ('my-tag', 'tag', ['spam', 'bacon', 'eggs'], None),
-    ('my-tag', 'tag', ['spam', 'bacon', 'eggs'], ['B456', 'R123']),
-    ('my-tag', 'tag', ['spam', 'bacon', 'eggs'], ""),
-    ('my-tag', 'tag', ['spam', 'bacon', 'eggs'], []),
+@pytest.mark.parametrize(('source', 'source_type', 'packages', 'expected_packages', 'sigkeys'), (
+    (MODULE_NSV, 'module', None, None, None),
+    ('my-tag', 'tag', None, [], None),
+    ('my-tag', 'tag', ['spam', 'bacon', 'eggs'], ['spam', 'bacon', 'eggs'], None),
+    ('my-tag', 'tag', ['spam', 'bacon', 'eggs'], ['spam', 'bacon', 'eggs'], ['B456', 'R123']),
+    ('my-tag', 'tag', ['spam', 'bacon', 'eggs'], ['spam', 'bacon', 'eggs'], ""),
+    ('my-tag', 'tag', ['spam', 'bacon', 'eggs'], ['spam', 'bacon', 'eggs'], []),
 ))
 @pytest.mark.parametrize('flags', (
     None,
@@ -101,8 +102,8 @@ def compose_json(state, state_name, source_type='module', source=MODULE_NSV,
     (['breakfast', 'lunch'], ['some', 'random'], ['some', 'random']),
     (['breakfast', 'lunch'], [], MULTILIB_METHOD_DEFAULT)
 ))
-def test_create_compose(odcs_client, source, source_type, packages, sigkeys, arches, flags,
-                        multilib_arches, multilib_method, expected_method):
+def test_create_compose(odcs_client, source, source_type, packages, expected_packages, sigkeys,
+                        arches, flags, multilib_arches, multilib_method, expected_method):
 
     def handle_composes_post(request):
         assert_request_token(request, odcs_client.session)
@@ -115,7 +116,7 @@ def test_create_compose(odcs_client, source, source_type, packages, sigkeys, arc
 
         assert body_json['source']['type'] == source_type
         assert body_json['source']['source'] == source
-        assert body_json['source'].get('packages') == packages
+        assert body_json['source'].get('packages') == expected_packages
         assert body_json['source'].get('sigkeys') == sigkeys
         assert body_json.get('flags') == flags
         assert body_json.get('arches') == arches


### PR DESCRIPTION
ODCS now has support for generating packages based on the koji tag if no package list is provided.

Add support for the same in atomic_reactor.
See also https://github.com/projectatomic/osbs-docs/pull/64