### PR TITLE
custom base images: return early from plugins that can't handle them

### DIFF
--- a/atomic_reactor/build.py
+++ b/atomic_reactor/build.py
@@ -18,7 +18,7 @@ import docker.errors
 import atomic_reactor.util
 from atomic_reactor.core import DockerTasker, LastLogger
 from atomic_reactor.util import (ImageName, print_version_of_tools, df_parser,
-                                 base_image_is_scratch, DigestCollector)
+                                 base_image_is_scratch, DigestCollector, base_image_is_custom)
 from atomic_reactor.constants import DOCKERFILE_FILENAME
 
 logger = logging.getLogger(__name__)
@@ -157,6 +157,7 @@ class InsideBuilder(LastLogger, BuilderStateMachine):
         self.built_image_info = None
         self.image = ImageName.parse(image)
         self.base_from_scratch = False
+        self.custom_base_image = False
 
         # get info about base image from dockerfile
         build_file_path, build_file_dir = self.source.get_build_file_path()
@@ -233,6 +234,8 @@ class InsideBuilder(LastLogger, BuilderStateMachine):
 
     def set_base_image(self, base_image, parents_pulled=True, insecure=False):
         self.base_from_scratch = base_image_is_scratch(base_image)
+        if not self.custom_base_image:
+            self.custom_base_image = base_image_is_custom(base_image)
         self.base_image = ImageName.parse(base_image)
         self.original_base_image = self.original_base_image or self.base_image
         self.recreate_parent_images()

--- a/atomic_reactor/plugins/pre_add_filesystem.py
+++ b/atomic_reactor/plugins/pre_add_filesystem.py
@@ -366,7 +366,7 @@ class AddFilesystemPlugin(PreBuildPlugin):
 
     def run(self):
         base_image = self.workflow.builder.base_image
-        if base_image.namespace != 'koji' or base_image.repo != 'image-build':
+        if not self.workflow.builder.custom_base_image:
             self.log.info('Base image not supported: %s', base_image)
             return
 

--- a/atomic_reactor/plugins/pre_check_and_set_rebuild.py
+++ b/atomic_reactor/plugins/pre_check_and_set_rebuild.py
@@ -79,6 +79,9 @@ class CheckAndSetRebuildPlugin(PreBuildPlugin):
         if self.workflow.builder.base_from_scratch:
             self.log.info("Skipping check and set rebuild: unsupported for FROM-scratch images")
             return False
+        if self.workflow.builder.custom_base_image:
+            self.log.info("Skipping check and set rebuild: unsupported for custom base images")
+            return False
 
         metadata = get_build_json().get("metadata", {})
         self.build_labels = metadata.get("labels", {})

--- a/atomic_reactor/plugins/pre_inject_parent_image.py
+++ b/atomic_reactor/plugins/pre_inject_parent_image.py
@@ -71,6 +71,9 @@ class InjectParentImage(PreBuildPlugin):
         if self.workflow.builder.base_from_scratch:
             self.log.info("from scratch can't inject parent image")
             return
+        if self.workflow.builder.custom_base_image:
+            self.log.info("custom base image builds can't inject parent image")
+            return
 
         self.find_repositories()
         self.select_new_parent_image()

--- a/atomic_reactor/plugins/pre_koji_parent.py
+++ b/atomic_reactor/plugins/pre_koji_parent.py
@@ -73,7 +73,7 @@ class KojiParentPlugin(PreBuildPlugin):
         self._poll_start = None
 
     def run(self):
-        if not self.workflow.builder.base_from_scratch:
+        if not (self.workflow.builder.base_from_scratch or self.workflow.builder.custom_base_image):
             nvr = self._base_image_nvr = self.detect_parent_image_nvr(
                 self.workflow.builder.base_image,
                 inspect_data=self.workflow.builder.base_image_inspect,

--- a/atomic_reactor/plugins/pre_pull_base_image.py
+++ b/atomic_reactor/plugins/pre_pull_base_image.py
@@ -69,6 +69,10 @@ class PullBaseImagePlugin(PreBuildPlugin):
         """
         Pull parent images and retag them uniquely for this build.
         """
+        if self.workflow.builder.custom_base_image:
+            self.log.info("custom base image builds can't retag parent images")
+            return
+
         build_json = get_build_json()
         current_platform = platform.processor() or 'x86_64'
         self.manifest_list_cache = {}

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -652,6 +652,10 @@ def base_image_is_scratch(base_image_name):
     return SCRATCH_FROM == base_image_name
 
 
+def base_image_is_custom(base_image_name):
+    return bool(re.match('^koji/image-build(:.*)?$', base_image_name))
+
+
 def get_orchestrator_platforms(workflow):
     for plugin in workflow.buildstep_plugins_conf or []:
         if plugin['name'] == PLUGIN_BUILD_ORCHESTRATE_KEY:

--- a/tests/plugins/test_add_filesystem.py
+++ b/tests/plugins/test_add_filesystem.py
@@ -82,6 +82,7 @@ class MockSource(object):
 class X(object):
     image_id = "xxx"
     base_image = ImageName.parse("koji/image-build")
+    custom_base_image = True
     set_base_image = flexmock()
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -44,6 +44,7 @@ from atomic_reactor.util import (ImageName, wait_for_command, clone_git_repo,
                                  get_manifest_list, get_all_manifests,
                                  get_inspect_for_image,
                                  get_build_json, is_scratch_build, is_isolated_build, df_parser,
+                                 base_image_is_custom,
                                  are_plugins_in_order, LabelFormatter,
                                  guess_manifest_media_type,
                                  get_manifest_media_type,
@@ -869,6 +870,18 @@ def test_is_scratch_build(build_json, scratch):
             is_scratch_build()
     else:
         assert is_scratch_build() == scratch
+
+
+@pytest.mark.parametrize(('base_image', 'is_custom'), [
+    ('fedora', False),
+    ('fedora:latest', False),
+    ('koji/image-build', True),
+    ('koji/image-build:spam.conf', True),
+    ('koji/image-build:latest', True),
+    ('scratch', False),
+])
+def test_is_custom_base_build(base_image, is_custom):
+    assert base_image_is_custom(base_image) == is_custom
 
 
 @pytest.mark.parametrize(('build_json', 'isolated'), [


### PR DESCRIPTION
add a utility function to detect a custom base image and stash whether
the base image is a custom base in the Builder.

In pre_add_filesystem, check if the base image is a custom base and
return immediately if it isn't.  In the other 4 plugins, return
immediately if the base image is a custom base image.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>