### PR TITLE
Do not use v1-only registries for tests

### DIFF
--- a/tests/constants.py
+++ b/tests/constants.py
@@ -133,7 +133,7 @@ registries:
 - url: https://container-registry.example.com/v2
   auth:
       cfg_path: /var/run/secrets/atomic-reactor/v2-registry-dockercfg
-- url: https://v1-container-registry.example.com/v1
+- url: https://another-container-registry.example.com
   insecure: True
 - url: https://better-container-registry.example.com/v2
   expected_media_types:

--- a/tests/plugins/test_group_manifests.py
+++ b/tests/plugins/test_group_manifests.py
@@ -432,7 +432,6 @@ def test_group_manifests(tmpdir, test_name,
     }
 
     all_registry_conf = {
-        REGISTRY_V1: {'version': 'v1', 'insecure': True},
         REGISTRY_V2: {'version': 'v2', 'insecure': True},
         OTHER_V2: {'version': 'v2', 'insecure': False},
     }

--- a/tests/plugins/test_input_osv3.py
+++ b/tests/plugins/test_input_osv3.py
@@ -14,6 +14,7 @@ from textwrap import dedent
 
 from atomic_reactor.plugins.input_osv3 import OSv3InputPlugin
 from osbs.api import OSBS
+from osbs.exceptions import OsbsValidationException
 from tests.constants import REACTOR_CONFIG_MAP
 from atomic_reactor.constants import (PLUGIN_BUMP_RELEASE_KEY,
                                       PLUGIN_DELETE_FROM_REG_KEY,
@@ -284,7 +285,7 @@ def test_remove_v1_pulp_and_exit_delete():
         ]
 
 
-def test_remove_v2_pulp():
+def test_invalid_v1_registry():
     plugins_json = {
         'build_json_dir': 'inputs',
         'build_type': 'orchestrator',
@@ -302,6 +303,7 @@ def test_remove_v2_pulp():
             {'name': 'after', },
         ],
     }
+    # v1 registry URL is no longer supported
     minimal_config = dedent("""\
         version: 1
         pulp:
@@ -328,11 +330,8 @@ def test_remove_v2_pulp():
     enable_plugins_configuration(plugins_json)
 
     plugin = OSv3InputPlugin()
-    plugins = plugin.run()
-    assert plugins['postbuild_plugins'] == [
-        {'name': 'before', },
-        {'name': 'after', },
-    ]
+    with pytest.raises(OsbsValidationException):
+        plugin.run()
 
 
 @pytest.mark.parametrize(('override', 'valid'), [

--- a/tests/plugins/test_reactor_config.py
+++ b/tests/plugins/test_reactor_config.py
@@ -30,6 +30,7 @@ import atomic_reactor.odcs_util
 import osbs.conf
 import osbs.api
 from osbs.utils import RegistryURI
+from osbs.exceptions import OsbsValidationException
 from atomic_reactor.plugins.pre_reactor_config import (ReactorConfig,
                                                        ReactorConfigPlugin,
                                                        get_config, WORKSPACE_CONF_KEY,
@@ -77,12 +78,12 @@ class TestReactorConfigPlugin(object):
         ("""\
             version: 1
             registries:
-            - url: https://old-container-registry.example.com/v1
-              auth:
-                  cfg_path: /var/run/secrets/atomic-reactor/v1-registry-dockercfg
             - url: https://container-registry.example.com/v2
               auth:
                   cfg_path: /var/run/secrets/atomic-reactor/v2-registry-dockercfg
+            - url: https://another-container-registry.example.com/
+              auth:
+                  cfg_path: /var/run/secrets/atomic-reactor/another-registry-dockercfg
          """,
          True),
         ("""\
@@ -131,7 +132,7 @@ class TestReactorConfigPlugin(object):
                 with pytest.raises(KeyError):
                     get_docker_registry(workflow, docker_fallback)
             else:
-                with pytest.raises(RuntimeError):
+                with pytest.raises(OsbsValidationException):
                     get_docker_registry(workflow, docker_fallback)
 
     def test_no_config(self):


### PR DESCRIPTION
osbs-client dropped v1-only registry API support on 491ff3a.