### PR TITLE
 Request registry push access when grouping manifests

### DIFF
--- a/atomic_reactor/plugins/post_group_manifests.py
+++ b/atomic_reactor/plugins/post_group_manifests.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2017 Red Hat, Inc
+Copyright (c) 2017, 2018 Red Hat, Inc
 All rights reserved.
 
 This software may be modified and distributed under the terms
@@ -358,7 +358,9 @@ class GroupManifestsPlugin(PostBuildPlugin):
         insecure = registry_conf.get('insecure', False)
         secret_path = registry_conf.get('secret')
 
-        return RegistrySession(registry, insecure=insecure, dockercfg_path=secret_path)
+        return RegistrySession(registry, insecure=insecure,
+                               dockercfg_path=secret_path,
+                               access=('pull', 'push'))
 
     def run(self):
         digests = dict()

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2015 Red Hat, Inc
+Copyright (c) 2015, 2018 Red Hat, Inc
 All rights reserved.
 
 This software may be modified and distributed under the terms
@@ -738,7 +738,7 @@ class Dockercfg(object):
 
 
 class RegistrySession(object):
-    def __init__(self, registry, insecure=False, dockercfg_path=None):
+    def __init__(self, registry, insecure=False, dockercfg_path=None, access=None):
         self.registry = registry
         self._resolved = None
         self.insecure = insecure
@@ -750,7 +750,7 @@ class RegistrySession(object):
 
             username = dockercfg.get('username')
             password = dockercfg.get('password')
-        self.auth = HTTPRegistryAuth(username, password)
+        self.auth = HTTPRegistryAuth(username, password, access=access)
 
         self._fallback = None
         if re.match('http(s)?://', self.registry):


### PR DESCRIPTION
For OAuth2-aware registries we need to request push access when obtaining a bearer token we intend to use to create manifest list objects.