### PR TITLE
Handle 'auth' in dockercfg credentials

### DIFF
--- a/atomic_reactor/core.py
+++ b/atomic_reactor/core.py
@@ -576,7 +576,14 @@ class DockerTasker(LastLogger):
         logger.info("logging in: registry '%s', secret path '%s'", registry, docker_secret_path)
         # Docker-py needs username
         dockercfg = Dockercfg(docker_secret_path)
-        username = dockercfg.get_credentials(registry)['username']
+        credentials = dockercfg.get_credentials(registry)
+        unpacked_auth = dockercfg.unpack_auth_b64(registry)
+        username = credentials.get('username')
+        if unpacked_auth:
+            username = unpacked_auth.username
+        if not username:
+            raise RuntimeError("Failed to extract a username from '%s'" % dockercfg)
+
         logger.info("found username %s for registry %s", username, registry)
 
         response = self.d.login(registry=registry, username=username,

--- a/tests/plugins/test_tag_and_push.py
+++ b/tests/plugins/test_tag_and_push.py
@@ -28,6 +28,7 @@ from tempfile import mkdtemp
 import requests
 import subprocess
 import tarfile
+from base64 import b64encode
 
 if MOCK:
     import docker
@@ -108,6 +109,8 @@ class X(object):
     (TEST_IMAGE_NAME, PUSH_ERROR_LOGS, True, False),
 ])
 @pytest.mark.parametrize(("file_name", "dockerconfig_contents"), [
+    (".dockercfg", {LOCALHOST_REGISTRY: {"email": "test@example.com",
+                                         "auth": b64encode(b'user:mypassword').decode('utf-8')}}),
     (".dockercfg", {LOCALHOST_REGISTRY: {"username": "user",
                                          "email": "test@example.com",
                                          "password": "mypassword"}}),


### PR DESCRIPTION
Allow RegistrySession to set the 'auth' key from the dockerconfig json
file directly in the authorization header, rather than supporting only
the username/password keys combination for authentication.
username/password format is still supported, but when all keys are
present, 'auth' value is used.

* Closes #1143

Signed-off-by: Athos Ribeiro <athos@redhat.com>