### PR TITLE
input_osv3: use git_commit_depth from user_params

### DIFF
--- a/atomic_reactor/schemas/user_params.json
+++ b/atomic_reactor/schemas/user_params.json
@@ -5,6 +5,10 @@
 
   "type": ["object", "null"],
   "properties": {
+    "additional_tags": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
     "arrangement_version": {"type": "integer"},
     "base_image": {"type": "string"},
     "build_from": {"type": "string"},
@@ -21,6 +25,7 @@
     "filesystem_koji_task_id": {"type": "integer"},
     "flatpak": {"type": "boolean"},
     "git_branch": {"type": "string"},
+    "git_commit_depth": {"type": "integer"},
     "git_ref": {"type": "string"},
     "git_uri": {"type": "string"},
     "image_tag": {"type": "string"},
@@ -61,6 +66,7 @@
     "release": {"type": "string"},
     "scratch": {"type": "boolean"},
     "signing_intent": {"type": "string"},
+    "tags_from_yaml": {"type": "boolean"},
     "trigger_imagestreamtag": {"type": "string"},
     "user": {"type": "string"},
     "yum_repourls": {

--- a/atomic_reactor/source.py
+++ b/atomic_reactor/source.py
@@ -115,7 +115,10 @@ class GitSource(Source):
         super(GitSource, self).__init__(provider, uri, dockerfile_path,
                                         provider_params, tmpdir)
         self.git_commit = self.provider_params.get('git_commit', None)
-        self.lg = util.LazyGit(self.uri, self.git_commit, self.source_path)
+        branch = self.provider_params.get('git_commit', None)
+        depth = self.provider_params.get('git_commit_depth', None)
+        self.lg = util.LazyGit(self.uri, self.git_commit, self.source_path, branch=branch,
+                               depth=depth)
 
     @property
     def commit_id(self):

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -314,7 +314,7 @@ class LazyGit(object):
         lazy_git = LazyGit(git_url="...", tmpdir=tmp_dir)
         lazy_git.git_path
     """
-    def __init__(self, git_url, commit=None, tmpdir=None):
+    def __init__(self, git_url, commit=None, tmpdir=None, branch=None, depth=None):
         self.git_url = git_url
         # provided commit ID/reference to check out
         self.commit = commit
@@ -322,7 +322,8 @@ class LazyGit(object):
         self._commit_id = None
         self.provided_tmpdir = tmpdir
         self._git_path = None
-        self._git_depth = None
+        self._branch = branch
+        self._git_depth = depth
 
     @property
     def _tmpdir(self):
@@ -335,7 +336,8 @@ class LazyGit(object):
     @property
     def git_path(self):
         if self._git_path is None:
-            repo_data = clone_git_repo(self.git_url, self._tmpdir, self.commit)
+            repo_data = clone_git_repo(self.git_url, self._tmpdir, self.commit,
+                                       branch=self._branch, depth=self._git_depth)
             self._commit_id = repo_data.commit_id
             self._git_path = repo_data.repo_path
             self._git_depth = repo_data.commit_depth


### PR DESCRIPTION
Now that osbs-client passes the git commit depth and container.yaml from the git repo, read those values from user_params and pass them back through provider_params.

LazyGit will attempt to do a single branch, shallow clone if a branch or commit depth is provided in provider_params.

Depends on https://github.com/projectatomic/osbs-client/pull/845

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>