### PR TITLE
Deactivate tests for Fedora 29

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,6 @@ env:
     - OS=fedora
       OS_VERSION=28
       PYTHON_VERSION=3
-    - OS=fedora
-      OS_VERSION=29
-      PYTHON_VERSION=2
-    - OS=fedora
-      OS_VERSION=29
-      PYTHON_VERSION=3
 install:
   - pip install coveralls
 script:


### PR DESCRIPTION
As described in PR #1160 [1] comments, tests are currently failing in
Fedora 29 due to a new Flatpak version which enforces sandboxing when
checking icons. This is not supported in a Fedora environment out of the
box, without further selinux (and docker) configurations. Hence, we
opted to deactivate Fedora 29 tests until this gets fixed in the next
Flatpak version.

[1] https://github.com/projectatomic/atomic-reactor/pull/1160

Signed-off-by: Athos Ribeiro <athos@redhat.com>