### PR TITLE
Pass container first label to koji extra metadata

### DIFF
--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -216,6 +216,12 @@ class KojiImportPlugin(ExitPlugin):
         if media_types:
             extra['image']['media_types'] = sorted(list(set(media_types)))
 
+    def set_go_metadata(self, extra):
+        go = self.workflow.source.config.go
+        if go:
+            self.log.debug("Setting Go metadata: %s", go)
+            extra['image']['go'] = go
+
     def remove_unavailable_manifest_digests(self, worker_metadatas):
         try:
             available = get_manifests_in_pulp_repository(self.workflow)
@@ -379,6 +385,7 @@ class KojiImportPlugin(ExitPlugin):
 
         self.set_help(extra, worker_metadatas)
         self.set_media_types(extra, worker_metadatas)
+        self.set_go_metadata(extra)
         self.remove_unavailable_manifest_digests(worker_metadatas)
         self.set_group_manifest_info(extra, worker_metadatas)
 

--- a/atomic_reactor/source.py
+++ b/atomic_reactor/source.py
@@ -54,6 +54,7 @@ class SourceConfig(object):
         self.autorebuild = self.data.get('autorebuild') or {}
         self.flatpak = self.data.get('flatpak')
         self.compose = self.data.get('compose')
+        self.go = self.data.get('go') or {}
         self.image_build_method = meth = self.data.get('image_build_method')
         assert meth is None or meth in CONTAINER_BUILD_METHODS, (
                "unknown build method '{}' specified in {}; also, schema validated it."

--- a/docs/koji.md
+++ b/docs/koji.md
@@ -57,12 +57,20 @@ Data which is placed here includes:
 - `build.extra.image.odcs.signing_intent_overridden` (boolean): Whether or not the signing intent used is different than the one defined in container.yaml
 - `build.extra.submitter` (string): username that submitted the build via content generator API
 - `build.owner` (string or null): username that started the task
+- `build.extra.image.go` (map): information about container first Go modules
+- `build.extra.image.go.modules` (map list): entries with Go modules information
 
 The index map has these entries:
 
 - `pull` (str list): docker pull specifications for the manifest list, by tag and by digest
 - `tags` (str list): tags applied to the manifest list when it was created
 - `digests` (map): a map of media type (such as “application/vnd.docker.distribution.manifest.list.v2+json”) to manifest digest (a string usually starting “sha256:”), for each grouped object; note that this will include manifest lists but not image manifests
+
+The `build.extra.image.go.modules` entries are maps composed of the following entries:
+
+- `module` (str): module name for the top-level Go language package to be built, as in `example.com/go/packagename`
+- `archive` (str): possibly-compressed archive containing full source code including dependencies
+- `path` (str): path to directory containing source code (or its parent), possibly within archive
 
 # Type-specific buildroot metadata:
 

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -98,7 +98,8 @@ class TestSourceConfigSchemaValidation(object):
     SOURCE_CONFIG_EMPTY = {
         'autorebuild': {},
         'flatpak': None,
-        'compose': None
+        'compose': None,
+        'go': {}
     }
 
     def _create_source_config(self, tmpdir, yml_config):
@@ -197,6 +198,32 @@ class TestSourceConfigSchemaValidation(object):
             compose:
             """,
             {}
+        ), (
+            """\
+            go:
+              modules:
+                - module: example.com/go/package
+            """,
+            {'go': {'modules': [{'module': 'example.com/go/package'}]}}
+        ), (
+            """\
+            go:
+              modules:
+                - module: example.com/go/package
+                  archive: foo
+                  path: bar
+            """,
+            {'go': {'modules': [{'module': 'example.com/go/package',
+                                 'archive': 'foo', 'path': 'bar'}]}}
+        ), (
+            """\
+            go:
+              modules:
+                - module: example.com/go/package
+                - module: example.com/go/package2
+            """,
+            {'go': {'modules': [{'module': 'example.com/go/package'},
+                                {'module': 'example.com/go/package2'}]}}
         ),
     ])
     def test_valid_source_config(self, tmpdir, yml_config, attrs_updated):
@@ -238,6 +265,16 @@ class TestSourceConfigSchemaValidation(object):
 
         """\
         compose: not_an_object
+        """,
+        """\
+        go: not_an_object
+        """,
+        """\
+        go:
+          extra_key: not_allowed
+        """,
+        """\
+        go:
         """,
     ])
     def test_invalid_source_config_validation_error(self, tmpdir, yml_config):


### PR DESCRIPTION
We want to allow container first metadata in the container.yaml file to
be forwarded to koji. We do this by copying the whole 'go' key content
to the extra.image.go koji build metadata.