### PR TITLE
Freeze more-itertools version for centOS tests

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -88,6 +88,10 @@ if [[ $OS == centos && $OS_VERSION == 7 ]]; then
   # Older versions of setuptools don't understand the environment
   # markers used by docker-squash's requirements
   $RUN $PIP install -U setuptools
+  # Newer versions of more-itertools do not support python 2. And
+  # centos7 version of pip does not parse requires_python metadata
+  # https://github.com/pytest-dev/pytest/issues/4770#issuecomment-462630885
+  $RUN $PIP install more-itertools==5.0.0
 fi
 
 # Install other dependencies for tests


### PR DESCRIPTION
more-itertools is a pytest dependency. It dropped python 2 support since
version 6.0.0. New pip versions will parse the requires_python metadata
and avoid installing new versions of this package on python 2
environments. This is not the case for CentOS version of pip. To avoid
breakage, we pre-install the last more-itertools version with python 2
support when running tests on CentOS.

We could also freeze the version in our test requirements, but the issue is **only** manifested in CentOS7 environments. Note that this does not affect our centos RPM packages, since we do not run the %check section due to issues with other dependencies.

* https://github.com/erikrose/more-itertools/blob/master/docs/versions.rst
* https://github.com/pytest-dev/pytest/issues/4770#issuecomment-462630885