### PR TITLE
Verify manifest is available

### DIFF
--- a/docs/koji.md
+++ b/docs/koji.md
@@ -97,7 +97,7 @@ The docker map has these entries:
 - `config` (map): the [v2 schema 2 'config' object](https://docs.docker.com/registry/spec/manifest-v2-2/#image-manifest-field-descriptions) but with the 'container_config' entry removed
 - `tags` (string list): the image tags (i.e. the part after the ":") applied to this image when it was tagged and pushed
 - `layer_sizes` (map list): the image layer uncompressed sizes, the oldest layer first (the size information comes from docker history command)
-- `digests` (map): a map of media type (such as “application/vnd.docker.distribution.manifest.v2+json”) to manifest digest (a string usually starting “sha256:”), for each available media type for which a digest is available.
+- `digests` (map): a map of media type (such as “application/vnd.docker.distribution.manifest.v2+json”) to manifest digest (a string usually starting “sha256:”), for each available media type which can be retrieved by digest (media types only reachable by tag are not included).
 
 ## Example
 

--- a/tests/plugins/test_koji_upload.py
+++ b/tests/plugins/test_koji_upload.py
@@ -17,7 +17,7 @@ try:
     import koji
 except ImportError:
     import inspect
-    import sys
+    import sys  # noqa: F811
 
     # Find our mocked koji module
     import tests.koji as koji
@@ -39,7 +39,7 @@ from atomic_reactor.plugins.pre_reactor_config import (ReactorConfigPlugin,
 from atomic_reactor.plugin import PostBuildPluginsRunner, PluginFailedException
 
 from atomic_reactor.inner import DockerBuildWorkflow, TagConf, PushConf
-from atomic_reactor.util import ImageName, ManifestDigest
+from atomic_reactor.util import ImageName, ManifestDigest, RegistrySession
 from atomic_reactor.rpm_util import parse_rpm_output
 from atomic_reactor.source import GitSource
 from atomic_reactor.build import BuildResult
@@ -52,6 +52,7 @@ from tests.docker_mock import mock_docker
 import subprocess
 from osbs.api import OSBS
 from osbs.exceptions import OsbsException
+from requests.exceptions import HTTPError
 from six import string_types
 
 NAMESPACE = 'mynamespace'
@@ -177,6 +178,19 @@ class MockedClientSession(object):
             pass
 
         return self.tag_task_state in ['CLOSED', 'FAILED', 'CANCELED', None]
+
+
+class MockedResponse(object):
+    def __init__(self, status_code=200):
+        self.history = []
+        self.url = ''
+        self.headers = ''
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code != 200:
+            raise HTTPError(response=self)
+        return None
 
 
 FAKE_SIGMD5 = b'0' * 32
@@ -1128,10 +1142,20 @@ class TestKojiUpload(object):
             assert images[0].endswith(platform + ".tar.xz")
 
     @pytest.mark.parametrize('multiple', [False, True])
-    def test_koji_upload_multiple_digests(self, tmpdir, os_env,
-                                          multiple, reactor_config_map):
+    @pytest.mark.parametrize('manifest_available_with_digest', [False, True])
+    def test_koji_upload_multiple_digests(self, tmpdir, os_env, multiple,
+                                          manifest_available_with_digest, reactor_config_map):
+        if manifest_available_with_digest:
+            status_code = 200
+        else:
+            status_code = 404
+
         server = MockedOSBS()
         session = MockedClientSession('')
+        (flexmock(RegistrySession)
+            .should_receive('get')
+            .and_return(MockedResponse(status_code))
+            .and_return(MockedResponse()))
         tasker, workflow = mock_environment(tmpdir,
                                             session=session,
                                             name='name',
@@ -1152,7 +1176,7 @@ class TestKojiUpload(object):
         repositories = output['extra']['docker']['repositories']
         pullspecs = [pullspec for pullspec in repositories
                      if '@' in pullspec]
-        if multiple:
+        if multiple and manifest_available_with_digest:
             assert len(pullspecs) > 1
         else:
             assert len(pullspecs) == 1


### PR DESCRIPTION
~~This is a work in progress. Before working on tests, I would appreciate some feedback here. Is there a better way to make sure the manifests are available through digests other than querying the registry like this?~~
**EDIT:** Based on IRC feedback, querying the registries seems to be a valid approach.

- [x] tests
- [x] forward dockercfg and insecure params
- [x] update/create docstrings

Before uploading archive metadata on image manifests for
extra.docker.digests to koji, we query the registry to make sure the
manifests can indeed be fetched through its digest.

* OSBS-6849