### PR TITLE
resolve_composes: allow package and module composess in the same yaml

### DIFF
--- a/atomic_reactor/plugins/pre_resolve_composes.py
+++ b/atomic_reactor/plugins/pre_resolve_composes.py
@@ -355,7 +355,7 @@ class ComposeConfig(object):
         requests = []
         if self.use_packages:
             requests.append(self.render_packages_request())
-        elif self.modules:
+        if self.modules:
             requests.append(self.render_modules_request())
 
         for arch in self.pulp:
@@ -404,9 +404,6 @@ class ComposeConfig(object):
         """Verify enough information is available for requesting compose."""
         if not self.use_packages and not self.modules and not self.pulp:
             raise ValueError("Nothing to compose (no packages, modules, or enabled pulp repos)")
-
-        if self.packages and self.modules:
-            raise ValueError('Compose config cannot contain both packages and modules')
 
         if self.packages and not self.koji_tag:
             raise ValueError('koji_tag is required when packages are used')

--- a/tests/plugins/test_resolve_composes.py
+++ b/tests/plugins/test_resolve_composes.py
@@ -322,6 +322,13 @@ class TestResolveComposes(object):
                        packages=None,
                        arches=['x86_64'])
             .and_return(ODCS_COMPOSE))
+        (flexmock(ODCSClient)
+            .should_receive('start_compose')
+            .with_args(source_type='module',
+                       source='spam_modules bacon_modules eggs_modules',
+                       sigkeys=['R123'],
+                       arches=['x86_64'])
+            .and_return(ODCS_COMPOSE))
 
         self.run_plugin_with_args(workflow, reactor_config_map=reactor_config_map)
 
@@ -807,14 +814,6 @@ class TestResolveComposes(object):
             compose:
                 pulp_repos: true
             """), 'Nothing to compose'),
-
-        (dedent("""\
-            compose:
-                packages:
-                - pkg1
-                modules:
-                - module1
-            """), 'cannot contain both'),
     ))
     def test_invalid_compose_request(self, workflow, config, error_message,
                                      reactor_config_map):


### PR DESCRIPTION
Fixes OSBS-6823

There is no technical reason why resolve_composes can't support
package and module composes in the same yaml, so remove the
logic that prevents them.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>