### PR TITLE
Set archive metadata based based on pulp presence

### DIFF
--- a/atomic_reactor/plugins/post_koji_upload.py
+++ b/atomic_reactor/plugins/post_koji_upload.py
@@ -19,11 +19,11 @@ from atomic_reactor.plugin import PostBuildPlugin
 from atomic_reactor.plugins.post_rpmqa import PostBuildRPMqaPlugin
 from atomic_reactor.plugins.pre_reactor_config import (get_openshift_session,
                                                        get_prefer_schema1_digest,
-                                                       get_koji_session, get_registries)
+                                                       get_koji_session)
 from atomic_reactor.constants import PROG, PLUGIN_KOJI_UPLOAD_PLUGIN_KEY
 from atomic_reactor.util import (get_version_of_tools, get_checksums,
                                  get_build_json, get_docker_architecture,
-                                 get_image_upload_filename, check_digest_availability,
+                                 get_image_upload_filename,
                                  get_manifest_media_type, ImageName, is_scratch_build)
 from atomic_reactor.rpm_util import parse_rpm_output, rpm_qf_args
 from osbs.exceptions import OsbsException
@@ -334,18 +334,12 @@ class KojiUploadPlugin(PostBuildPlugin):
         """
         digests = {}  # image -> digests
         typed_digests = {}  # media_type -> digests
-        registries_conf = copy.deepcopy(get_registries(self.workflow, {}))
         for registry in self.workflow.push_conf.docker_registries:
-            registry_conf = registries_conf.get(registry.uri, {})
-            secret = registry_conf.get('secret', None)
             for image in self.workflow.tag_conf.images:
                 image_str = image.to_str()
                 if image_str in registry.digests:
                     image_digests = registry.digests[image_str]
-                    if (self.report_multiple_digests and
-                        check_digest_availability(image, registry.uri, image_digests,
-                                                  insecure=registry.insecure,
-                                                  dockercfg_path=secret)):
+                    if self.report_multiple_digests:
                         digest_list = [digest for digest in (image_digests.v1,
                                                              image_digests.v2)
                                        if digest]

--- a/atomic_reactor/plugins/post_koji_upload.py
+++ b/atomic_reactor/plugins/post_koji_upload.py
@@ -339,7 +339,7 @@ class KojiUploadPlugin(PostBuildPlugin):
                 image_str = image.to_str()
                 if image_str in registry.digests:
                     image_digests = registry.digests[image_str]
-                    if self.report_multiple_digests:
+                    if self.report_multiple_digests and self.workflow.push_conf.pulp_registries:
                         digest_list = [digest for digest in (image_digests.v1,
                                                              image_digests.v2)
                                        if digest]
@@ -348,6 +348,8 @@ class KojiUploadPlugin(PostBuildPlugin):
                     digests[image.to_str(registry=False)] = digest_list
                     for digest_version in image_digests.content_type:
                         if digest_version not in image_digests:
+                            continue
+                        if not self.workflow.push_conf.pulp_registries and digest_version == 'v1':
                             continue
                         digest_type = get_manifest_media_type(digest_version)
                         typed_digests[digest_type] = image_digests[digest_version]

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -941,35 +941,6 @@ def get_manifest(image, registry_session, version):
     return response, saved_not_found
 
 
-def check_digest_availability(image, registry, digests, versions=('v1', 'v2'),
-                              insecure=False, dockercfg_path=None):
-    """Return whether image manifests can be fetched by digest for the given schema versions.
-
-    :param image: ImageName, the remote image to inspect
-    :param registry: str, URI for registry
-    :param digests: dict, maps a tag (str) to a ManifestDigest instance
-    :param versions: tuple, manifest schema versions to be tested
-    :param insecure: bool, when True registry's cert is not verified
-    :param dockercfg_path: str, dirname of .dockercfg location
-
-    :return: bool, False if any of the manifest schema versions could not be retrieved
-    """
-    if not digests:
-        raise ValueError("No 'digests' provided")
-
-    registry_session = RegistrySession(registry, insecure=insecure, dockercfg_path=dockercfg_path)
-    for version in versions:
-        try:
-            query_registry(registry_session, image, getattr(digests, version), version=version)
-        except (HTTPError, RetryError) as ex:
-            if ex.response.status_code == requests.codes.not_found:
-                logger.debug("%s manifest for %s cannot be fetched from registry by digest %s",
-                             version, image.to_str(), getattr(digests, version))
-                return False
-            raise
-    return True
-
-
 def get_manifest_digests(image, registry, insecure=False, dockercfg_path=None,
                          versions=('v1', 'v2', 'v2_list', 'oci', 'oci_index'), require_digest=True):
     """Return manifest digest for image.

--- a/docs/koji.md
+++ b/docs/koji.md
@@ -97,7 +97,7 @@ The docker map has these entries:
 - `config` (map): the [v2 schema 2 'config' object](https://docs.docker.com/registry/spec/manifest-v2-2/#image-manifest-field-descriptions) but with the 'container_config' entry removed
 - `tags` (string list): the image tags (i.e. the part after the ":") applied to this image when it was tagged and pushed
 - `layer_sizes` (map list): the image layer uncompressed sizes, the oldest layer first (the size information comes from docker history command)
-- `digests` (map): a map of media type (such as “application/vnd.docker.distribution.manifest.v2+json”) to manifest digest (a string usually starting “sha256:”), for each available media type for which a digest is available.
+- `digests` (map): a map of media type (such as “application/vnd.docker.distribution.manifest.v2+json”) to manifest digest (a string usually starting “sha256:”), for each available media type which can be retrieved by digest (media types only reachable by tag are not included).
 
 ## Example
 

--- a/docs/koji.md
+++ b/docs/koji.md
@@ -97,7 +97,7 @@ The docker map has these entries:
 - `config` (map): the [v2 schema 2 'config' object](https://docs.docker.com/registry/spec/manifest-v2-2/#image-manifest-field-descriptions) but with the 'container_config' entry removed
 - `tags` (string list): the image tags (i.e. the part after the ":") applied to this image when it was tagged and pushed
 - `layer_sizes` (map list): the image layer uncompressed sizes, the oldest layer first (the size information comes from docker history command)
-- `digests` (map): a map of media type (such as “application/vnd.docker.distribution.manifest.v2+json”) to manifest digest (a string usually starting “sha256:”), for each available media type which can be retrieved by digest (media types only reachable by tag are not included).
+- `digests` (map): a map of media type (such as “application/vnd.docker.distribution.manifest.v2+json”) to manifest digest (a string usually starting “sha256:”), for each available media type for which a digest is available.
 
 ## Example
 


### PR DESCRIPTION
We cannot query pulp registries in build time to verify the presence of
v1 and v2 manifests. Therefore, we assemble the archive metadata,
deciding whether v1 digests should be included, based on the presence of
pulp registries. We do this by reverting the changes introduced in
5a70132 and introducing the approach described.

* Reverts commit 5a701322ac2025e88768ea09536931d287cf3a75
* OSBS-6849

Signed-off-by: Athos Ribeiro <athos@redhat.com>