### PR TITLE
allow atomic-reactor-repo directory in .dockerignore file,

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -149,3 +149,5 @@ MEDIA_TYPE_OCI_V1_INDEX = "application/vnd.oci.image.index.v1+json"
 
 REPO_CONTAINER_CONFIG = 'container.yaml'
 REPO_CONTENT_SETS_CONFIG = 'content_sets.yml'
+
+DOCKERIGNORE = '.dockerignore'

--- a/atomic_reactor/plugins/build_docker_api.py
+++ b/atomic_reactor/plugins/build_docker_api.py
@@ -9,7 +9,7 @@ from __future__ import print_function, unicode_literals
 
 import docker
 from atomic_reactor.plugin import BuildStepPlugin
-from atomic_reactor.util import wait_for_command
+from atomic_reactor.util import wait_for_command, allow_repo_dir_in_dockerignore
 from atomic_reactor.build import BuildResult
 
 
@@ -38,6 +38,7 @@ class DockerApiPlugin(BuildStepPlugin):
         """
         builder = self.workflow.builder
 
+        allow_repo_dir_in_dockerignore(builder.df_dir)
         logs_gen = self.tasker.build_image_from_path(builder.df_dir,
                                                      builder.image)
 

--- a/atomic_reactor/plugins/build_imagebuilder.py
+++ b/atomic_reactor/plugins/build_imagebuilder.py
@@ -11,7 +11,7 @@ import subprocess
 from six import PY2
 import os
 
-from atomic_reactor.util import get_exported_image_metadata
+from atomic_reactor.util import get_exported_image_metadata, allow_repo_dir_in_dockerignore
 from atomic_reactor.plugin import BuildStepPlugin
 from atomic_reactor.build import BuildResult
 from atomic_reactor.constants import CONTAINER_IMAGEBUILDER_BUILD_METHOD
@@ -42,6 +42,8 @@ class ImagebuilderPlugin(BuildStepPlugin):
         encoding_params = dict(encoding='utf-8', errors='replace')
         if not PY2:
             kwargs.update(encoding_params)
+
+        allow_repo_dir_in_dockerignore(builder.df_dir)
         ib_process = subprocess.Popen(['imagebuilder', '-t', image, builder.df_dir], **kwargs)
 
         self.log.debug('imagebuilder build has begun; waiting for it to finish')

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -48,7 +48,8 @@ from atomic_reactor.constants import (DOCKERFILE_FILENAME, REPO_CONTAINER_CONFIG
                                       PLUGIN_KOJI_PARENT_KEY,
                                       PARENT_IMAGE_BUILDS_KEY, PARENT_IMAGES_KOJI_BUILDS,
                                       BASE_IMAGE_KOJI_BUILD, BASE_IMAGE_BUILD_ID_KEY,
-                                      PARENT_IMAGES_KEY, SCRATCH_FROM)
+                                      PARENT_IMAGES_KEY, SCRATCH_FROM, RELATIVE_REPOS_PATH,
+                                      DOCKERIGNORE)
 from atomic_reactor.auth import HTTPRegistryAuth
 
 from dockerfile_parse import DockerfileParser
@@ -1289,6 +1290,15 @@ def read_yaml(yaml_data, schema):
         raise
 
     return data
+
+
+def allow_repo_dir_in_dockerignore(build_path):
+    docker_ignore = os.path.join(str(build_path), DOCKERIGNORE)
+
+    if os.path.isfile(docker_ignore):
+        with open(docker_ignore, "a") as f:
+            f.write("\n!%s\n" % RELATIVE_REPOS_PATH)
+        logger.debug("Allowing %s in %s", RELATIVE_REPOS_PATH, DOCKERIGNORE)
 
 
 class LabelFormatter(string.Formatter):


### PR DESCRIPTION
when it exists

* OSBS-6920

Signed-off-by: Robert Cerven <rcerven@redhat.com>