### PR TITLE
Extract operators metadata from built image

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -101,6 +101,7 @@ PLUGIN_REMOVE_WORKER_METADATA_KEY = 'remove_worker_metadata'
 PLUGIN_RESOLVE_COMPOSES_KEY = 'resolve_composes'
 PLUGIN_SENDMAIL_KEY = 'sendmail'
 PLUGIN_VERIFY_MEDIA_KEY = 'verify_media'
+PLUGIN_EXPORT_OPERATOR_MANIFESTS_KEY = 'export_operator_manifests'
 
 # some shared dict keys for build metadata that gets recorded with koji.
 # for consistency of metadata in historical builds, these values basically cannot change.
@@ -151,3 +152,6 @@ REPO_CONTAINER_CONFIG = 'container.yaml'
 REPO_CONTENT_SETS_CONFIG = 'content_sets.yml'
 
 DOCKERIGNORE = '.dockerignore'
+
+# Operator manifest constants
+OPERATOR_MANIFESTS_ARCHIVE = 'operator_manifests.zip'

--- a/atomic_reactor/plugins/build_orchestrate_build.py
+++ b/atomic_reactor/plugins/build_orchestrate_build.py
@@ -414,6 +414,9 @@ class OrchestrateBuildPlugin(BuildStepPlugin):
             get_arrangement_version(self.workflow, self.build_kwargs['arrangement_version'])
         self.build_kwargs['parent_images_digests'] =\
             self.workflow.builder.parent_images_digests.to_dict()
+        # All platforms should generate the same operator manifests. We can use any of them
+        if self.platforms:
+            self.build_kwargs['operator_manifests_extract_platform'] = list(self.platforms)[0]
 
     def validate_arrangement_version(self):
         """Validate if the arrangement_version is supported

--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -42,7 +42,7 @@ except ImportError:
 from atomic_reactor.constants import (
     PLUGIN_KOJI_IMPORT_PLUGIN_KEY, PLUGIN_PULP_PULL_KEY, PLUGIN_PULP_SYNC_KEY,
     PLUGIN_FETCH_WORKER_METADATA_KEY, PLUGIN_GROUP_MANIFESTS_KEY, PLUGIN_RESOLVE_COMPOSES_KEY,
-    PLUGIN_VERIFY_MEDIA_KEY, METADATA_TAG)
+    PLUGIN_VERIFY_MEDIA_KEY, METADATA_TAG, OPERATOR_MANIFESTS_ARCHIVE)
 from atomic_reactor.util import (Output, get_build_json,
                                  df_parser, ImageName, get_primary_images,
                                  get_manifest_media_type,
@@ -222,6 +222,13 @@ class KojiImportPlugin(ExitPlugin):
             self.log.debug("Setting Go metadata: %s", go)
             extra['image']['go'] = go
 
+    def set_operators_metadata(self, extra, worker_metadatas):
+        for platform, metadata in worker_metadatas.items():
+            for output in metadata['output']:
+                if output.get('filename') == OPERATOR_MANIFESTS_ARCHIVE:
+                    extra['operator_manifests_archive'] = OPERATOR_MANIFESTS_ARCHIVE
+                    break
+
     def remove_unavailable_manifest_digests(self, worker_metadatas):
         try:
             available = get_manifests_in_pulp_repository(self.workflow)
@@ -388,6 +395,7 @@ class KojiImportPlugin(ExitPlugin):
         self.set_help(extra, worker_metadatas)
         self.set_media_types(extra, worker_metadatas)
         self.set_go_metadata(extra)
+        self.set_operators_metadata(extra, worker_metadatas)
         self.remove_unavailable_manifest_digests(worker_metadatas)
         self.set_group_manifest_info(extra, worker_metadatas)
 

--- a/atomic_reactor/plugins/post_export_operator_manifests.py
+++ b/atomic_reactor/plugins/post_export_operator_manifests.py
@@ -1,0 +1,141 @@
+"""
+Copyright (c) 2019 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+import os
+import shutil
+import tarfile
+import tempfile
+import zipfile
+
+from atomic_reactor.constants import (PLUGIN_EXPORT_OPERATOR_MANIFESTS_KEY,
+                                      OPERATOR_MANIFESTS_ARCHIVE)
+from atomic_reactor.plugin import PostBuildPlugin
+from atomic_reactor.util import df_parser, is_scratch_build, get_platforms
+from docker.errors import APIError
+from osbs.utils import Labels
+from platform import machine
+
+MANIFESTS_DIR_NAME = 'manifests'
+
+
+class ExportOperatorManifestsPlugin(PostBuildPlugin):
+    """
+    Export operator manifest files
+
+    Fetch and archive operator manifest files from image so they can be
+    uploaded to koji.
+    """
+
+    key = PLUGIN_EXPORT_OPERATOR_MANIFESTS_KEY
+    is_allowed_to_fail = False
+
+    def __init__(self, tasker, workflow, operator_manifests_extract_platform=None, platform=None):
+        super(ExportOperatorManifestsPlugin, self).__init__(tasker, workflow)
+
+        self.operator_manifests_extract_platform = operator_manifests_extract_platform
+        if platform:
+            self.platform = platform
+        else:
+            self.platform = machine()
+
+    def has_operator_manifest(self):
+        """
+        Check if Dockerfile sets the operator manifest label
+
+        :return: bool
+        """
+        dockerfile = df_parser(self.workflow.builder.df_path, workflow=self.workflow)
+        labels = Labels(dockerfile.labels)
+        try:
+            _, operator_label = labels.get_name_and_value(Labels.LABEL_TYPE_OPERATOR_MANIFESTS)
+        except KeyError:
+            operator_label = 'false'
+        return operator_label.lower() == 'true'
+
+    def is_orchestrator(self):
+        """
+        Check if the plugin is running in orchestrator.
+
+        :return: bool
+        """
+        if get_platforms(self.workflow):
+            return True
+        return False
+
+    def should_run(self):
+        """
+        Check if the plugin should run or skip execution.
+
+        :return: bool, False if plugin should skip execution
+        """
+        if self.is_orchestrator():
+            self.log.warning("%s plugin set to run on orchestrator. Skipping", self.key)
+            return False
+        if self.operator_manifests_extract_platform != self.platform:
+            self.log.info("Only platform [%s] will upload operators metadata. Skipping",
+                          self.operator_manifests_extract_platform)
+            return False
+        if is_scratch_build():
+            self.log.info("Scratch build. Skipping")
+            return False
+        if not self.has_operator_manifest():
+            self.log.info("Operator manifests label not set in Dockerfile. Skipping")
+            return False
+        return True
+
+    def run(self):
+        """
+        Run the plugin.
+
+        This plugin extracts the operator manifest files from an image, saves
+        them as a zip archive, and returns its path
+
+        :return: str, path to operator manifests zip file
+        """
+        if not self.should_run():
+            return
+
+        manifests_archive_dir = tempfile.mkdtemp()
+        image = self.workflow.image
+        # As in flatpak_create_oci, we specify command to prevent possible docker daemon errors.
+        container_dict = self.tasker.d.create_container(image, command=['/bin/bash'])
+        container_id = container_dict['Id']
+        try:
+            bits, stat = self.tasker.d.get_archive(container_id,
+                                                   os.path.join('/', MANIFESTS_DIR_NAME))
+        except APIError as ex:
+            self.log.error('Could not extract operator manifest files: %s', ex)
+            raise RuntimeError('Could not extract operator manifest files: %s' % ex)
+        finally:
+            self.tasker.d.remove_container(container_id)
+
+        with tempfile.NamedTemporaryFile() as extracted_file:
+            for chunk in bits:
+                extracted_file.write(chunk)
+            extracted_file.flush()
+            tar_archive = tarfile.TarFile(extracted_file.name)
+
+        tar_archive.extractall(manifests_archive_dir)
+        manifests_path = os.path.join(manifests_archive_dir, MANIFESTS_DIR_NAME)
+
+        manifests_zipfile_path = os.path.join(manifests_archive_dir, OPERATOR_MANIFESTS_ARCHIVE)
+        with zipfile.ZipFile(manifests_zipfile_path, 'w') as archive:
+            for root, _, files in os.walk(manifests_path):
+                for f in files:
+                    filedir = os.path.relpath(root, manifests_path)
+                    filepath = os.path.join(filedir, f)
+                    archive.write(os.path.join(root, f), filepath)
+            manifest_files = archive.namelist()
+            if not manifest_files:
+                self.log.error('Empty operator manifests directory')
+                raise RuntimeError('Empty operator manifests directory')
+            self.log.debug("Archiving operator manifests: %s", manifest_files)
+
+        shutil.rmtree(manifests_path)
+
+        return manifests_zipfile_path

--- a/atomic_reactor/schemas/user_params.json
+++ b/atomic_reactor/schemas/user_params.json
@@ -56,6 +56,7 @@
       "uniqueItems": true,
       "additionalProperties": false
     },
+    "operator_manifests_extract_platform": {"type": "string"},
     "platform": {"type": "string"},
     "platforms": {
       "type": "array",

--- a/tests/plugins/test_export_operator_manifests.py
+++ b/tests/plugins/test_export_operator_manifests.py
@@ -1,0 +1,159 @@
+"""
+Copyright (c) 2019 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+
+import os
+import pytest
+import tarfile
+import zipfile
+from atomic_reactor import util
+from atomic_reactor.constants import (
+    PLUGIN_EXPORT_OPERATOR_MANIFESTS_KEY,
+    PLUGIN_CHECK_AND_SET_PLATFORMS_KEY)
+from atomic_reactor.inner import DockerBuildWorkflow
+from atomic_reactor.plugins.post_export_operator_manifests import ExportOperatorManifestsPlugin
+from atomic_reactor.plugin import PostBuildPluginsRunner, PluginFailedException
+from docker.errors import NotFound
+from flexmock import flexmock
+from functools import partial
+from platform import machine
+from tests.constants import TEST_IMAGE
+from tests.stubs import StubInsideBuilder, StubSource
+from requests import Response
+
+
+CONTAINER_ID = 'mocked'
+
+
+def mock_dockerfile(tmpdir, has_label=True, label=True):
+    base = 'From fedora:30'
+    cmd = 'CMD /bin/cowsay moo'
+    operator_label = ''
+    if has_label:
+        operator_label = 'LABEL com.redhat.delivery.appregistry={}'.format(str(label).lower())
+    data = '\n'.join([base, operator_label, cmd])
+    tmpdir.join('Dockerfile').write(data)
+
+
+def mock_workflow(tmpdir):
+    workflow = DockerBuildWorkflow({"provider": "git", "uri": "asd"}, TEST_IMAGE)
+    workflow.source = StubSource()
+    builder = StubInsideBuilder().for_workflow(workflow)
+    builder.set_df_path(str(tmpdir))
+    builder.tasker = flexmock()
+    workflow.builder = flexmock(builder)
+    return workflow
+
+
+def generate_archive(tmpdir, empty=False):
+    archive_path = os.path.join(str(tmpdir), 'temp.tar')
+    archive_tar = tarfile.open(archive_path, 'w')
+    manifests_dir = os.path.join(str(tmpdir), 'manifests')
+    os.mkdir(manifests_dir)
+    another_dir = os.path.join(manifests_dir, 'another_dir')
+    os.mkdir(another_dir)
+    if not empty:
+        open(os.path.join(manifests_dir, 'stub.yml'), 'w').close()
+        open(os.path.join(another_dir, 'yayml.yml'), 'w').close()
+    archive_tar.add(manifests_dir, arcname='manifests')
+    archive_tar.close()
+    f = open(archive_path, 'rb')
+    for block in iter(partial(f.read, 8), b''):
+        yield block
+    f.close()
+    os.unlink(archive_path)
+
+
+def mock_env(tmpdir, docker_tasker, has_label=True, label=True, has_archive=True,
+             scratch=False, orchestrator=False, selected_platform=True, empty_archive=False):
+    build_json = {'metadata': {'labels': {'scratch': scratch}}}
+    flexmock(util).should_receive('get_build_json').and_return(build_json)
+    mock_dockerfile(tmpdir, has_label, label)
+    workflow = mock_workflow(tmpdir)
+    workflow.prebuild_results[PLUGIN_CHECK_AND_SET_PLATFORMS_KEY] = orchestrator
+    mock_stream = generate_archive(tmpdir, empty_archive)
+    plugin_conf = [{'name': ExportOperatorManifestsPlugin.key}]
+    if selected_platform:
+        plugin_conf[0]['args'] = {'operator_manifests_extract_platform': machine(),
+                                  'platform': machine()}
+    runner = PostBuildPluginsRunner(docker_tasker, workflow, plugin_conf)
+
+    (flexmock(docker_tasker.d.wrapped)
+     .should_receive('create_container')
+     .with_args(workflow.image, command=["/bin/bash"])
+     .and_return({'Id': CONTAINER_ID}))
+
+    (flexmock(docker_tasker.d.wrapped)
+     .should_receive('remove_container')
+     .with_args(CONTAINER_ID))
+
+    if has_archive:
+        (flexmock(docker_tasker.d.wrapped)
+         .should_receive('get_archive')
+         .with_args(CONTAINER_ID, '/manifests')
+         .and_return(mock_stream, {}))
+    else:
+        response = Response()
+        response.status_code = 404
+        (flexmock(docker_tasker.d.wrapped)
+         .should_receive('get_archive')
+         .with_args(CONTAINER_ID, '/manifests')
+         .and_raise(NotFound('Not found', response=response)))
+
+    return runner
+
+
+class TestExportOperatorManifests(object):
+    @pytest.mark.parametrize('scratch', [True, False])
+    @pytest.mark.parametrize('has_label', [True, False])
+    @pytest.mark.parametrize('label', [True, False])
+    @pytest.mark.parametrize('orchestrator', [True, False])
+    @pytest.mark.parametrize('selected_platform', [True, False])
+    def test_skip(self, docker_tasker, tmpdir, caplog, scratch, has_label,
+                  label, orchestrator, selected_platform):
+
+        runner = mock_env(tmpdir, docker_tasker, has_label=has_label, label=label, scratch=scratch,
+                          orchestrator=orchestrator, selected_platform=selected_platform)
+        result = runner.run()
+        if any([not has_label, not label, scratch, orchestrator, not selected_platform]):
+            assert 'Skipping' in caplog.text
+            assert result[PLUGIN_EXPORT_OPERATOR_MANIFESTS_KEY] is None
+
+    def test_export_archive(self, docker_tasker, tmpdir):
+        runner = mock_env(tmpdir, docker_tasker)
+        result = runner.run()
+        archive = result[PLUGIN_EXPORT_OPERATOR_MANIFESTS_KEY]
+        assert archive
+        assert archive.split('/')[-1] == 'operator_manifests.zip'
+        assert zipfile.is_zipfile(archive)
+        expected = ['stub.yml', 'another_dir/yayml.yml']
+        with zipfile.ZipFile(archive, 'r') as z:
+            assert len(z.namelist()) == len(expected)
+            assert sorted(z.namelist()) == sorted(expected)
+
+    @pytest.mark.parametrize('has_archive', [True, False])
+    def test_no_archive(self, docker_tasker, tmpdir, caplog, has_archive):
+        runner = mock_env(tmpdir, docker_tasker, has_archive=has_archive)
+        if has_archive:
+            runner.run()
+        else:
+            with pytest.raises(PluginFailedException) as exc:
+                runner.run()
+                assert 'Could not extract operator manifest files' in caplog.text
+                assert 'Could not extract operator manifest files' in str(exc)
+
+    @pytest.mark.parametrize('empty_archive', [True, False])
+    def test_emty_manifests_dir(self, docker_tasker, tmpdir, caplog, empty_archive):
+        runner = mock_env(tmpdir, docker_tasker, empty_archive=empty_archive)
+        if empty_archive:
+            with pytest.raises(PluginFailedException) as exc:
+                runner.run()
+                assert 'Empty operator manifests directory' in caplog.text
+                assert 'Empty operator manifests directory' in str(exc)
+        else:
+            runner.run()

--- a/tests/plugins/test_orchestrate_build.py
+++ b/tests/plugins/test_orchestrate_build.py
@@ -1057,6 +1057,7 @@ def test_orchestrate_build_worker_build_kwargs(tmpdir, caplog, is_auto):
         'release': '10',
         'arrangement_version': 6,
         'parent_images_digests': {},
+        'operator_manifests_extract_platform': 'x86_64',
     }
 
     reactor_config_override = mock_reactor_config(tmpdir)
@@ -1107,6 +1108,7 @@ def test_orchestrate_override_build_kwarg(tmpdir, overrides):
         'release': '4242',
         'arrangement_version': 6,
         'parent_images_digests': {},
+        'operator_manifests_extract_platform': 'x86_64',
     }
     reactor_config_override = mock_reactor_config(tmpdir)
     reactor_config_override['openshift'] = {
@@ -1162,6 +1164,7 @@ def test_orchestrate_override_content_versions(tmpdir, caplog, enable_v1, conten
         'release': '10',
         'arrangement_version': 6,
         'parent_images_digests': {},
+        'operator_manifests_extract_platform': 'x86_64',
     }
     add_config = {
         'platform_descriptors': [{
@@ -1733,6 +1736,7 @@ def test_parent_images_digests(tmpdir, caplog):
         'release': '10',
         'arrangement_version': 6,
         'parent_images_digests': PARENT_IMAGES_DATA,
+        'operator_manifests_extract_platform': 'x86_64',
     }
 
     reactor_config_override = mock_reactor_config(tmpdir)


### PR DESCRIPTION
Add new export_operator_manifests plugin to extract operators metadata and upload it to Koji.

* OSBS-6686

Depends on https://github.com/projectatomic/osbs-client/pull/849
