### PR TITLE
Commit branch: fix user param key

### DIFF
--- a/atomic_reactor/source.py
+++ b/atomic_reactor/source.py
@@ -116,7 +116,7 @@ class GitSource(Source):
         super(GitSource, self).__init__(provider, uri, dockerfile_path,
                                         provider_params, tmpdir)
         self.git_commit = self.provider_params.get('git_commit', None)
-        branch = self.provider_params.get('git_commit', None)
+        branch = self.provider_params.get('git_branch', None)
         depth = self.provider_params.get('git_commit_depth', None)
         self.lg = util.LazyGit(self.uri, self.git_commit, self.source_path, branch=branch,
                                depth=depth)


### PR DESCRIPTION
Commit branch was taken from 'git_commit' instead of 'git_branch' user
param.

* OSBS-6599

Signed-off-by: Martin Bašti <mbasti@redhat.com>