### PR TITLE
resolve_composes: add support for modular_koji_tags

### DIFF
--- a/atomic_reactor/odcs_util.py
+++ b/atomic_reactor/odcs_util.py
@@ -45,7 +45,8 @@ class ODCSClient(object):
         self.session = session
 
     def start_compose(self, source_type, source, packages=None, sigkeys=None, arches=None,
-                      flags=None, multilib_arches=None, multilib_method=None):
+                      flags=None, multilib_arches=None, multilib_method=None,
+                      modular_koji_tags=None):
         """Start a new ODCS compose
 
         :param source_type: str, the type of compose to request (tag, module, pulp)
@@ -67,6 +68,9 @@ class ODCSClient(object):
                         be included in a multilib compose. Defaults to none, but the value
                         of ['devel', 'runtime] will be passed to ODCS if multilib_arches is
                         not empty and no mulitlib_method value is provided.
+        :param modular_koji_tags: list<str>, the koji tags which are tagged to builds from the
+                        modular Koji Content Generator.  Builds with matching tags will be
+                        included in the compose.
 
         :return: dict, status of compose being created by request.
         """
@@ -91,6 +95,9 @@ class ODCSClient(object):
         if multilib_arches:
             body['multilib_arches'] = multilib_arches
             body['multilib_method'] = multilib_method or MULTILIB_METHOD_DEFAULT
+
+        if source_type == "module" and modular_koji_tags:
+            body['modular_koji_tags'] = modular_koji_tags
 
         logger.info("Starting compose: %s", body)
         response = self.session.post('{}composes/'.format(self.url),

--- a/atomic_reactor/plugins/pre_resolve_composes.py
+++ b/atomic_reactor/plugins/pre_resolve_composes.py
@@ -368,6 +368,7 @@ class ComposeConfig(object):
         self.arches = arches or []
         self.multilib_arches = []
         self.multilib_method = None
+        self.modular_tags = data.get('modular_koji_tags', [])
 
         if data.get('pulp_repos'):
             for arch in pulp_data or {}:
@@ -431,6 +432,8 @@ class ComposeConfig(object):
         }
         if self.arches:
             request['arches'] = self.arches
+        if self.modular_tags:
+            request['modular_koji_tags'] = self.modular_tags
         return request
 
     def render_pulp_request(self, arch):

--- a/atomic_reactor/schemas/container.json
+++ b/atomic_reactor/schemas/container.json
@@ -83,6 +83,24 @@
           "description": "enable inheritance of yum repourls and composes from baseimage build (disabled by default)",
           "type": "boolean"
         },
+        "include_unpublished_pulp_repos": {
+          "description": "include unpublished repos in pulp input content-sets",
+          "type": "boolean"
+        },
+        "multilib_method": {
+          "description": "list of options to decide if a package is multilib",
+          "type": ["array", "null"],
+          "items": {
+              "enum": ["none", "iso", "runtime", "devel", "all"]
+          }
+        },
+        "multilib_arches": {
+          "description": "list of arches which will get multilib composes",
+          "type": ["array", "null"],
+          "items": {
+              "type": "string"
+          }
+        },
         "modular_koji_tags": {
           "description": "tags of modular Koji content to include in the build",
           "type": ["array", "null"],
@@ -91,7 +109,7 @@
           }
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     },
     "flatpak": {
       "type": ["object", "null"]

--- a/atomic_reactor/schemas/container.json
+++ b/atomic_reactor/schemas/container.json
@@ -82,6 +82,13 @@
         "inherit": {
           "description": "enable inheritance of yum repourls and composes from baseimage build (disabled by default)",
           "type": "boolean"
+        },
+        "modular_koji_tags": {
+          "description": "tags of modular Koji content to include in the build",
+          "type": ["array", "null"],
+          "items": {
+              "type": "string"
+          }
         }
       },
       "additionalProperties": true

--- a/tests/test_odcs_util.py
+++ b/tests/test_odcs_util.py
@@ -82,13 +82,16 @@ def compose_json(state, state_name, source_type='module', source=MODULE_NSV,
     ['x86_64'],
     ['breakfast', 'lunch'],
 ))
-@pytest.mark.parametrize(('source', 'source_type', 'packages', 'expected_packages', 'sigkeys'), (
-    (MODULE_NSV, 'module', None, None, None),
-    ('my-tag', 'tag', None, [], None),
-    ('my-tag', 'tag', ['spam', 'bacon', 'eggs'], ['spam', 'bacon', 'eggs'], None),
-    ('my-tag', 'tag', ['spam', 'bacon', 'eggs'], ['spam', 'bacon', 'eggs'], ['B456', 'R123']),
-    ('my-tag', 'tag', ['spam', 'bacon', 'eggs'], ['spam', 'bacon', 'eggs'], ""),
-    ('my-tag', 'tag', ['spam', 'bacon', 'eggs'], ['spam', 'bacon', 'eggs'], []),
+@pytest.mark.parametrize(('source', 'source_type', 'packages', 'expected_packages', 'sigkeys',
+                          'modular_koji_tags', 'expected_koji_tags'), (
+    (MODULE_NSV, 'module', None, None, None, [], None),
+    (MODULE_NSV, 'module', None, None, None, ['release'], ['release']),
+    ('my-tag', 'tag', None, [], None, ['release'], None),
+    ('my-tag', 'tag', ['spam', 'bacon', 'eggs'], ['spam', 'bacon', 'eggs'], None, None, None),
+    ('my-tag', 'tag', ['spam', 'bacon', 'eggs'], ['spam', 'bacon', 'eggs'], ['B456', 'R123'],
+     ['release'], None),
+    ('my-tag', 'tag', ['spam', 'bacon', 'eggs'], ['spam', 'bacon', 'eggs'], "", None, None),
+    ('my-tag', 'tag', ['spam', 'bacon', 'eggs'], ['spam', 'bacon', 'eggs'], [], ['release'], None),
 ))
 @pytest.mark.parametrize('flags', (
     None,
@@ -103,6 +106,7 @@ def compose_json(state, state_name, source_type='module', source=MODULE_NSV,
     (['breakfast', 'lunch'], [], MULTILIB_METHOD_DEFAULT)
 ))
 def test_create_compose(odcs_client, source, source_type, packages, expected_packages, sigkeys,
+                        modular_koji_tags, expected_koji_tags,
                         arches, flags, multilib_arches, multilib_method, expected_method):
 
     def handle_composes_post(request):
@@ -121,6 +125,7 @@ def test_create_compose(odcs_client, source, source_type, packages, expected_pac
         assert body_json.get('flags') == flags
         assert body_json.get('arches') == arches
         assert body_json.get('multilib_arches') == multilib_arches
+        assert body_json.get('modular_koji_tags') == expected_koji_tags
         if expected_method is not None:
             assert sorted(body_json.get('multilib_method')) == sorted(expected_method)
         else:
@@ -133,7 +138,8 @@ def test_create_compose(odcs_client, source, source_type, packages, expected_pac
 
     odcs_client.start_compose(source_type=source_type, source=source, packages=packages,
                               sigkeys=sigkeys, arches=arches, flags=flags,
-                              multilib_arches=multilib_arches, multilib_method=multilib_method)
+                              multilib_arches=multilib_arches, multilib_method=multilib_method,
+                              modular_koji_tags=modular_koji_tags)
 
 
 @responses.activate

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -190,9 +190,9 @@ class TestSourceConfigSchemaValidation(object):
         ), (
             """\
             compose:
-              extra_key: allowed
+              include_unpublished_pulp_repos: true
             """,
-            {'compose': {'extra_key': 'allowed'}}
+            {'compose': {'include_unpublished_pulp_repos': True}}
         ), (
             """\
             compose:


### PR DESCRIPTION
fixes osbs6833

Add support to pre_resolve_composes to parse modular_koji_tags and pass that on to the ODCS engine.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>