### PR TITLE
pre_pull_base_image: add support for source_registry with auth

### DIFF
--- a/atomic_reactor/build.py
+++ b/atomic_reactor/build.py
@@ -248,7 +248,7 @@ class InsideBuilder(LastLogger, BuilderStateMachine):
             parent_images[key] = val
         self.parent_images = parent_images
 
-    def set_base_image(self, base_image, parents_pulled=True, insecure=False):
+    def set_base_image(self, base_image, parents_pulled=True, insecure=False, dockercfg_path=None):
         self.base_from_scratch = base_image_is_scratch(base_image)
         if not self.custom_base_image:
             self.custom_base_image = base_image_is_custom(base_image)
@@ -260,6 +260,7 @@ class InsideBuilder(LastLogger, BuilderStateMachine):
             self.parent_images[self.original_base_image] = self.base_image
         self.parents_pulled = parents_pulled
         self.base_image_insecure = insecure
+        self.base_image_dockercfg_path = dockercfg_path
         logger.info("set base image to '%s' with original base '%s'", self.base_image,
                     self.original_base_image)
 
@@ -287,7 +288,8 @@ class InsideBuilder(LastLogger, BuilderStateMachine):
                 self._base_image_inspect =\
                     atomic_reactor.util.get_inspect_for_image(self.base_image,
                                                               self.base_image.registry,
-                                                              self.base_image_insecure)
+                                                              self.base_image_insecure,
+                                                              self.base_image_dockercfg_path)
 
             base_image_str = str(self.base_image)
             if base_image_str not in self._parent_images_inspect:
@@ -309,7 +311,8 @@ class InsideBuilder(LastLogger, BuilderStateMachine):
                 self._parent_images_inspect[image_name] =\
                     atomic_reactor.util.get_inspect_for_image(image_name,
                                                               image_name.registry,
-                                                              self.base_image_insecure)
+                                                              self.base_image_insecure,
+                                                              self.base_image_dockercfg_path)
 
         return self._parent_images_inspect[image_name]
 

--- a/atomic_reactor/core.py
+++ b/atomic_reactor/core.py
@@ -519,17 +519,21 @@ class DockerTasker(LastLogger):
         logger.debug("%d matching images found", len(images))
         return images
 
-    def pull_image(self, image, insecure=False):
+    def pull_image(self, image, insecure=False, dockercfg_path=None):
         """
         pull provided image from registry
 
         :param image_name: ImageName, image to pull
         :param insecure: bool, allow connecting to registry over plain http
+        :param dockercfg_path: str, path to dockercfg
         :return: str, image (reg.om/img:v1)
         """
         logger.info("pulling image '%s' from registry", image)
         logger.debug("image = '%s', insecure = '%s'", image, insecure)
         tag = image.tag
+
+        if dockercfg_path:
+            self.login(registry=image.registry, docker_secret_path=dockercfg_path)
         try:
             command_result = self.retry_generator(self.d.pull,
                                                   image.to_str(tag=False),

--- a/atomic_reactor/plugins/pre_reactor_config.py
+++ b/atomic_reactor/plugins/pre_reactor_config.py
@@ -280,10 +280,14 @@ def get_source_registry(workflow, fallback=NO_FALLBACK):
             return fallback
         raise
 
-    return {
+    regdict = {
         'uri': RegistryURI(source_registry['url']),
-        'insecure': source_registry.get('insecure', False)
+        'insecure': source_registry.get('insecure', False),
+        'dockercfg_path': None
     }
+    if source_registry.get('auth'):
+        regdict['dockercfg_path'] = source_registry['auth']['cfg_path']
+    return regdict
 
 
 def get_sources_command(workflow, fallback=NO_FALLBACK):

--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -452,6 +452,18 @@
             "insecure": {
                 "description": "Don't check SSL certificate for url",
                 "type": "boolean"
+            },
+            "auth": {
+                "description": "Authentication information",
+                "type": "object",
+                   "properties": {
+                    "cfg_path": {
+                        "description": "Path to directory  containing .dockercfg for registry auth",
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": false,
+                "required": ["cfg_path"]
             }
         },
         "additionalProperties": false,

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -145,6 +145,9 @@ registries:
 source_registry:
     url: https://registry.private.example.com
     insecure: True
+    auth:
+        cfg_path: /var/run/secrets/atomic-reactor/private-registry-dockercfg
+
 
 sources_command: "fedpkg sources"
 

--- a/tests/plugins/test_pull_base_image.py
+++ b/tests/plugins/test_pull_base_image.py
@@ -66,7 +66,7 @@ class MockBuilder(object):
     def __init__(self):
         self.parent_images_digests = DigestCollector()
 
-    def set_base_image(self, base_image, parents_pulled=True, insecure=False):
+    def set_base_image(self, base_image, parents_pulled=True, insecure=False, dockercfg_path=None):
         self.base_from_scratch = base_image_is_scratch(base_image)
         if not self.custom_base_image:
             self.custom_base_image = base_image_is_custom(base_image)
@@ -168,6 +168,7 @@ def test_pull_base_image_special(add_another_parent, special_image, change_base,
     for df, tagged in workflow.builder.parent_images.items():
         assert tagged is not None, "Did not tag parent image " + str(df)
     assert len(set(workflow.builder.parent_images.values())) == len(workflow.builder.parent_images)
+
 
 @pytest.mark.parametrize(('parent_registry',
                           'df_base',       # unique ID is always expected
@@ -636,7 +637,8 @@ class TestValidateBaseImage(object):
             manifest_image = base_image_result.copy()
             (flexmock(atomic_reactor.util)
              .should_receive('get_manifest_list')
-             .with_args(image=manifest_image, registry=manifest_image.registry, insecure=True)
+             .with_args(image=manifest_image, registry=manifest_image.registry, insecure=True,
+                        dockercfg_path=None)
              .and_return(None)
              .once())
             return workflow
@@ -678,13 +680,15 @@ class TestValidateBaseImage(object):
             if sha_is_manifest_list:
                 (flexmock(atomic_reactor.util)
                  .should_receive('get_manifest_list')
-                 .with_args(image=manifest_image, registry=manifest_image.registry, insecure=True)
+                 .with_args(image=manifest_image, registry=manifest_image.registry, insecure=True,
+                            dockercfg_path=None)
                  .and_return(flexmock(json=lambda: manifest_list))
                  .once())
             else:
                 (flexmock(atomic_reactor.util)
                  .should_receive('get_manifest_list')
-                 .with_args(image=manifest_image, registry=manifest_image.registry, insecure=True)
+                 .with_args(image=manifest_image, registry=manifest_image.registry, insecure=True,
+                            dockercfg_path=None)
                  .and_return(None)
                  .once()
                  .ordered())
@@ -697,7 +701,8 @@ class TestValidateBaseImage(object):
                 manifest_image = base_image_result.copy()
                 (flexmock(atomic_reactor.util)
                  .should_receive('get_manifest_list')
-                 .with_args(image=manifest_image, registry=manifest_image.registry, insecure=True)
+                 .with_args(image=manifest_image, registry=manifest_image.registry, insecure=True,
+                            dockercfg_path=None)
                  .and_return(flexmock(json=lambda: manifest_list))
                  .once()
                  .ordered())
@@ -733,7 +738,8 @@ class TestValidateBaseImage(object):
 
             (flexmock(atomic_reactor.util)
              .should_receive('get_manifest_list')
-             .with_args(image=manifest_image, registry=manifest_image.registry, insecure=True)
+             .with_args(image=manifest_image, registry=manifest_image.registry, insecure=True,
+                        dockercfg_path=None)
              .and_return(flexmock(json=lambda: manifest_list))
              .once())
             return workflow


### PR DESCRIPTION
fixes OSBS-6625 "Unable to use private quay.io org/repo directly"

With the introduction of quay support, there are private source registries that require auth.  Add support for retrieving their auth from REACTOR_CONFIG and passing it to the relevant functions.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>