### PR TITLE
verify media types plugin reworked, returns list of found types,

### DIFF
--- a/tests/plugins/test_verify_media_types.py
+++ b/tests/plugins/test_verify_media_types.py
@@ -94,7 +94,7 @@ class TestVerifyImageTypes(object):
               status_code=requests.codes.ok,
               json=get_response_config_json(DIGEST_V1),
               headers={
-                'Content-Type': 'application/json'
+                'Content-Type': MEDIA_TYPE_DOCKER_V1
               }))
     config_response_config_v1 = requests.Response()
     (flexmock(config_response_config_v1,
@@ -102,7 +102,7 @@ class TestVerifyImageTypes(object):
               status_code=requests.codes.ok,
               json=get_response_config_json(MEDIA_TYPE_DOCKER_V2_SCHEMA1),
               headers={
-                'Content-Type': 'application/vnd.docker.distribution.manifest.v1+json',
+                'Content-Type': MEDIA_TYPE_DOCKER_V2_SCHEMA1,
                 'Docker-Content-Digest': DIGEST_V1
               }))
     config_response_config_v2 = requests.Response()
@@ -111,7 +111,7 @@ class TestVerifyImageTypes(object):
               status_code=requests.codes.ok,
               json=get_response_config_json(MEDIA_TYPE_DOCKER_V2_SCHEMA2),
               headers={
-                'Content-Type': 'application/vnd.docker.distribution.manifest.v2+json',
+                'Content-Type': MEDIA_TYPE_DOCKER_V2_SCHEMA2,
                 'Docker-Content-Digest': DIGEST_V2
               }))
     config_response_config_v2_list = requests.Response()
@@ -120,12 +120,27 @@ class TestVerifyImageTypes(object):
               status_code=requests.codes.ok,
               json=get_response_config_json(MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST),
               headers={
-                'Content-Type': 'application/vnd.docker.distribution.manifest.list.v2+json',
+                'Content-Type': MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST,
+              }))
+    config_response_config_oci_v1 = requests.Response()
+    (flexmock(config_response_config_oci_v1,
+              raise_for_status=lambda: None,
+              status_code=requests.codes.ok,
+              json=get_response_config_json(MEDIA_TYPE_OCI_V1),
+              headers={
+                'Content-Type': MEDIA_TYPE_OCI_V1,
+              }))
+    config_response_config_oci_v1_index = requests.Response()
+    (flexmock(config_response_config_oci_v1_index,
+              raise_for_status=lambda: None,
+              status_code=requests.codes.ok,
+              json=get_response_config_json(MEDIA_TYPE_OCI_V1_INDEX),
+              headers={
+                'Content-Type': MEDIA_TYPE_OCI_V1_INDEX,
               }))
 
     def workflow(self, build_process_failed=False, registries=None, registry_types=None,
-                 platforms=None, platform_descriptors=None, group=True, no_amd64=False,
-                 fail=False):
+                 platforms=None, platform_descriptors=None, group=True, fail=False):
         tag_conf = TagConf()
         tag_conf.add_unique_image(self.TEST_UNIQUE_IMAGE)
 
@@ -140,10 +155,16 @@ class TestVerifyImageTypes(object):
 
         if platforms is None:
             platforms = [descriptor['platform'] for descriptor in platform_descriptors]
+        no_amd64 = 'x86_64' not in platforms
+
+        keep_types = False
+        if registries or registry_types:
+            keep_types = True
 
         if registries is None and registry_types is None:
             registry_types = [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_SCHEMA1,
-                              MEDIA_TYPE_DOCKER_V2_SCHEMA2, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]
+                              MEDIA_TYPE_DOCKER_V2_SCHEMA2, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST,
+                              MEDIA_TYPE_OCI_V1, MEDIA_TYPE_OCI_V1_INDEX]
 
         if registries is None:
             registries = [{
@@ -181,7 +202,7 @@ class TestVerifyImageTypes(object):
             expected_types = registry.get('expected_media_types', [])
             if fail == "bad_results":
                 response_types = [MEDIA_TYPE_DOCKER_V1]
-            elif no_amd64:
+            elif not keep_types and no_amd64:
                 response_types = [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]
             else:
                 response_types = expected_types
@@ -196,6 +217,8 @@ class TestVerifyImageTypes(object):
             actual_v1_url = urlbase + "/v1/repositories/foo/tags/unique-tag"
 
             v1_response = self.config_response_none
+            v1_oci_response = self.config_response_none
+            v1_oci_index_response = self.config_response_none
             v2_response = self.config_response_none
             v2_list_response = self.config_response_none
             if MEDIA_TYPE_DOCKER_V2_SCHEMA1 in response_types:
@@ -204,6 +227,13 @@ class TestVerifyImageTypes(object):
                 v2_response = self.config_response_config_v2
             if MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST in response_types:
                 v2_list_response = self.config_response_config_v2_list
+            if MEDIA_TYPE_OCI_V1 in response_types:
+                v1_oci_response = self.config_response_config_oci_v1
+            if MEDIA_TYPE_OCI_V1_INDEX in response_types:
+                v1_oci_index_response = self.config_response_config_oci_v1_index
+
+
+
             v2_header_v1 = {'Accept': MEDIA_TYPE_DOCKER_V2_SCHEMA1}
             v2_header_v2 = {'Accept': MEDIA_TYPE_DOCKER_V2_SCHEMA2}
             manifest_header = {'Accept': MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST}
@@ -222,12 +252,12 @@ class TestVerifyImageTypes(object):
                 .should_receive('get')
                 .with_args(actual_v2_url, headers={'Accept': MEDIA_TYPE_OCI_V1},
                            auth=mock_auth, verify=False)
-                .and_return(self.config_response_none))
+                .and_return(v1_oci_response))
             (flexmock(requests.Session)
                 .should_receive('get')
                 .with_args(actual_v2_url, headers={'Accept': MEDIA_TYPE_OCI_V1_INDEX},
                            auth=mock_auth, verify=False)
-                .and_return(self.config_response_none))
+                .and_return(v1_oci_index_response))
             (flexmock(requests.Session)
                 .should_receive('get')
                 .with_args(actual_v2_url, headers=manifest_header,
@@ -240,6 +270,19 @@ class TestVerifyImageTypes(object):
                     .with_args(actual_v1_url, headers={'Accept': MEDIA_TYPE_DOCKER_V1},
                                auth=mock_auth, verify=False)
                     .and_return(self.config_response_v1))
+            else:
+                headers = {'Content-Type': 'application/invalid+json',
+                           'Docker-Content-Digest': "12"}
+
+                def mock_raise_v1(*args):
+                    raise Exception
+                (flexmock(requests.Session)
+                    .should_receive('get')
+                    .with_args(actual_v1_url, headers={'Accept': MEDIA_TYPE_DOCKER_V1},
+                               auth=mock_auth, verify=False)
+                    .and_return(flexmock(status_code=404, ok=False, history=[],
+                                         url=actual_v1_url, headers=headers,
+                                         raise_for_status=mock_raise_v1)))
 
         digests = {'digest': None} if group else {}
         prebuild_results = {PLUGIN_CHECK_AND_SET_PLATFORMS_KEY: platforms}
@@ -272,78 +315,75 @@ class TestVerifyImageTypes(object):
 
         assert results == sorted([MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_SCHEMA1,
                                   MEDIA_TYPE_DOCKER_V2_SCHEMA2,
-                                  MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST])
+                                  MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST,
+                                  MEDIA_TYPE_OCI_V1,
+                                  MEDIA_TYPE_OCI_V1_INDEX])
 
     @responses.activate
     @pytest.mark.parametrize(('registry_types', 'platform_descriptors',
-                              'group', 'no_amd64', 'expected_results'), [
+                              'group', 'expected_results'), [
         ([],
          [{'platform': 'arm64', 'architecture': 'arm64'}],
-         True, False, []),
+         True, [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
         # If group manifests ran, non-x86-64 builds can only produce
         # MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST
         ([MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST],
          [{'platform': 'arm64', 'architecture': 'arm64'}],
-         True, True, [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+         True, [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
         ([MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST],
          [{'platform': 'arm64', 'architecture': 'arm64'}],
-         True, True, [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+         True, [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
         ([MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_SCHEMA1,
           MEDIA_TYPE_DOCKER_V2_SCHEMA2, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST],
          [{'platform': 'arm64', 'architecture': 'arm64'}],
-         True, True, [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
-        ([MEDIA_TYPE_DOCKER_V1],
-         [{'platform': 'arm64', 'architecture': 'arm64'}],
-         True, True, [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+         True, [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
         ([MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST],
          [{'platform': 'x86_64', 'architecture': 'amd64'},
           {'platform': 'arm64', 'architecture': 'arm64'}],
-         True, False, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+         True, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
         ([MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_SCHEMA2, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST],
          [{'platform': 'x86_64', 'architecture': 'amd64'},
           {'platform': 'arm64', 'architecture': 'arm64'}],
-         True, False, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_SCHEMA2,
+         True, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_SCHEMA2,
                        MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
         ([MEDIA_TYPE_DOCKER_V1],
          [{'platform': 'x86_64', 'architecture': 'amd64'},
           {'platform': 'arm64', 'architecture': 'arm64'}],
-         True, False, [MEDIA_TYPE_DOCKER_V1]),
+         True, [MEDIA_TYPE_DOCKER_V1]),
         # If group manifests didn't run, non-x86-64 builds can produce any type
         # Well, actually, the build will fail but if it didn't fail, they could produce any type
         ([MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST],
          [{'platform': 'arm64', 'architecture': 'arm64'}],
-         False, False, [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+         False, [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
         ([MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST],
          [{'platform': 'arm64', 'architecture': 'arm64'}],
-         False, False, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+         False, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
         ([MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_SCHEMA1,
           MEDIA_TYPE_DOCKER_V2_SCHEMA2, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST],
          [{'platform': 'arm64', 'architecture': 'arm64'}],
-         False, False, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_SCHEMA1,
+         False, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_SCHEMA1,
                         MEDIA_TYPE_DOCKER_V2_SCHEMA2, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
         ([MEDIA_TYPE_DOCKER_V1],
          [{'platform': 'arm64', 'architecture': 'arm64'}],
-         False, False, [MEDIA_TYPE_DOCKER_V1]),
+         False, [MEDIA_TYPE_DOCKER_V1]),
         ([MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST],
          [{'platform': 'x86_64', 'architecture': 'amd64'},
           {'platform': 'arm64', 'architecture': 'arm64'}],
-         False, False, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+         False, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
         ([MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_SCHEMA2, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST],
          [{'platform': 'x86_64', 'architecture': 'amd64'},
           {'platform': 'arm64', 'architecture': 'arm64'}],
-         False, False, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_SCHEMA2,
+         False, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_SCHEMA2,
                         MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
         ([MEDIA_TYPE_DOCKER_V1],
          [{'platform': 'x86_64', 'architecture': 'amd64'},
           {'platform': 'arm64', 'architecture': 'arm64'}],
-         False, False, [MEDIA_TYPE_DOCKER_V1]),
+         False, [MEDIA_TYPE_DOCKER_V1]),
     ])
     def test_verify_successful_complicated(self, registry_types,
-                                           platform_descriptors, group, no_amd64,
-                                           expected_results):
+                                           platform_descriptors, group, expected_results):
         workflow = self.workflow(registry_types=registry_types,
-                                 platform_descriptors=platform_descriptors, group=group,
-                                 no_amd64=no_amd64)
+                                 platform_descriptors=platform_descriptors, group=group)
         tasker = MockerTasker()
 
         plugin = VerifyMediaTypesPlugin(tasker, workflow)
@@ -355,7 +395,7 @@ class TestVerifyImageTypes(object):
     Two registries, everything behaves correctly
     """
     @responses.activate
-    @pytest.mark.parametrize(('registries', 'platform_descriptors', 'group', 'no_amd64',
+    @pytest.mark.parametrize(('registries', 'platform_descriptors', 'group',
                               'expected_results'), [
         ([{'url': 'https://container-registry.example.com/v2',
            'version': 'v2', 'insecure': True,
@@ -364,33 +404,7 @@ class TestVerifyImageTypes(object):
            'version': 'v2', 'insecure': True,
            'expected_media_types': [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]}],
          [{'platform': 'arm64', 'architecture': 'arm64'}],
-         True, True, [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
-        ([{'url': 'https://container-registry.example.com/v2',
-           'version': 'v2', 'insecure': True,
-           'expected_media_types': [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]},
-          {'url': 'https://container-registry-test.example.com/v2',
-           'version': 'v2', 'insecure': True,
-           'expected_media_types': [MEDIA_TYPE_DOCKER_V1]}],
-         [{'platform': 'arm64', 'architecture': 'arm64'}],
-         True, True, [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
-        ([{'url': 'https://container-registry.example.com/v2',
-           'version': 'v2', 'insecure': True,
-           'expected_media_types': [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]},
-          {'url': 'https://container-registry-test.example.com/v2',
-           'version': 'v2', 'insecure': True,
-           'expected_media_types': [MEDIA_TYPE_DOCKER_V1]}],
-         [{'platform': 'arm64', 'architecture': 'arm64'},
-          {'platform': 'x86_64', 'architecture': 'amd64'}],
-         True, False, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
-        ([{'url': 'https://container-registry.example.com/v2',
-           'version': 'v2', 'insecure': True,
-           'expected_media_types': [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]},
-          {'url': 'https://container-registry-test.example.com/v2',
-           'version': 'v2', 'insecure': True,
-           'expected_media_types': [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]}],
-         [{'platform': 'arm64', 'architecture': 'arm64'},
-          {'platform': 'x86_64', 'architecture': 'amd64'}],
-         True, False, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+         True, [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
         ([{'url': 'https://container-registry.example.com/v2',
            'version': 'v2', 'insecure': True,
            'expected_media_types': [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]},
@@ -398,15 +412,15 @@ class TestVerifyImageTypes(object):
            'version': 'v2', 'insecure': True,
            'expected_media_types': [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]}],
          [{'platform': 'arm64', 'architecture': 'arm64'}],
-         False, False, [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+         False, [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
         ([{'url': 'https://container-registry.example.com/v2',
            'version': 'v2', 'insecure': True,
            'expected_media_types': [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]},
           {'url': 'https://container-registry-test.example.com/v2',
            'version': 'v2', 'insecure': True,
-           'expected_media_types': [MEDIA_TYPE_DOCKER_V1]}],
+           'expected_media_types': []}],
          [{'platform': 'arm64', 'architecture': 'arm64'}],
-         False, False, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+         False, [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
         ([{'url': 'https://container-registry.example.com/v2',
            'version': 'v2', 'insecure': True,
            'expected_media_types': [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]},
@@ -415,7 +429,7 @@ class TestVerifyImageTypes(object):
            'expected_media_types': [MEDIA_TYPE_DOCKER_V1]}],
          [{'platform': 'arm64', 'architecture': 'arm64'},
           {'platform': 'x86_64', 'architecture': 'amd64'}],
-         False, False, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+         True, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
         ([{'url': 'https://container-registry.example.com/v2',
            'version': 'v2', 'insecure': True,
            'expected_media_types': [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]},
@@ -424,46 +438,58 @@ class TestVerifyImageTypes(object):
            'expected_media_types': [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]}],
          [{'platform': 'arm64', 'architecture': 'arm64'},
           {'platform': 'x86_64', 'architecture': 'amd64'}],
-         False, False, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+         True, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+        ([{'url': 'https://container-registry.example.com/v2',
+           'version': 'v2', 'insecure': True,
+           'expected_media_types': [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]},
+          {'url': 'https://container-registry-test.example.com/v2',
+           'version': 'v2', 'insecure': True,
+           'expected_media_types': [MEDIA_TYPE_DOCKER_V1]}],
+         [{'platform': 'arm64', 'architecture': 'arm64'},
+          {'platform': 'x86_64', 'architecture': 'amd64'}],
+         False, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+        ([{'url': 'https://container-registry.example.com/v2',
+           'version': 'v2', 'insecure': True,
+           'expected_media_types': [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]},
+          {'url': 'https://container-registry-test.example.com/v2',
+           'version': 'v2', 'insecure': True,
+           'expected_media_types': [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]}],
+         [{'platform': 'arm64', 'architecture': 'arm64'},
+          {'platform': 'x86_64', 'architecture': 'amd64'}],
+         False, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
     ])
     def test_verify_successful_two_registries(self, registries,
-                                              platform_descriptors, group, no_amd64,
-                                              expected_results):
+                                              platform_descriptors, group, expected_results):
         workflow = self.workflow(registries=registries,
-                                 platform_descriptors=platform_descriptors, group=group,
-                                 no_amd64=no_amd64)
+                                 platform_descriptors=platform_descriptors, group=group)
         tasker = MockerTasker()
 
         plugin = VerifyMediaTypesPlugin(tasker, workflow)
         results = plugin.run()
-
         assert results == sorted(expected_results)
-
-        """
-         """
 
     """
     Configuration is bad, but not so bad as to cause a problem
     """
     @responses.activate
     @pytest.mark.parametrize(('registries', 'platforms', 'platform_descriptors',
-                              'group', 'no_amd64',
-                              'expected_results'), [
+                              'group', 'expected_results'), [
         # Null registries and registries without expected_media_types return nothing
         ([],
          None, [{'platform': 'x86_64', 'architecture': 'amd64'}],
-         True, False, []),
+         True, []),
         ([{'url': 'https://container-registry.example.com/v2',
            'version': 'v2', 'insecure': True}],
          None, [{'platform': 'x86_64', 'architecture': 'amd64'}],
-         True, False, []),
+         True, []),
+
         ([{'url': 'https://container-registry.example.com/v2',
            'version': 'v2', 'insecure': True},
           {'url': 'https://container-registry-test.example.com/v2',
            'version': 'v2', 'insecure': True,
            'expected_media_types': [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]}],
          None, [{'platform': 'arm64', 'architecture': 'arm64'}],
-         True, False, [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+         False, [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
 
         # no platforms or platform descriptors, assume x86_64 wasn't build
         ([{'url': 'https://container-registry.example.com/v2',
@@ -473,7 +499,7 @@ class TestVerifyImageTypes(object):
            'version': 'v2', 'insecure': True,
            'expected_media_types': [MEDIA_TYPE_DOCKER_V1]}],
          ['x86_64', 'arm64'], [],
-         True, False, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+         True, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
         ([{'url': 'https://container-registry.example.com/v2',
            'version': 'v2', 'insecure': True,
            'expected_media_types': [MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]},
@@ -481,14 +507,12 @@ class TestVerifyImageTypes(object):
            'version': 'v2', 'insecure': True,
            'expected_media_types': [MEDIA_TYPE_DOCKER_V1]}],
          [], [{'platform': 'arm64', 'architecture': 'arm64'}],
-         True, False, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
+         True, [MEDIA_TYPE_DOCKER_V1, MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST]),
     ])
     def test_verify_malformed_two_registries(self, registries, platforms,
-                                             platform_descriptors, group, no_amd64,
-                                             expected_results):
+                                             platform_descriptors, group, expected_results):
         workflow = self.workflow(registries=registries, platforms=platforms,
-                                 platform_descriptors=platform_descriptors, group=group,
-                                 no_amd64=no_amd64)
+                                 platform_descriptors=platform_descriptors, group=group)
         tasker = MockerTasker()
 
         plugin = VerifyMediaTypesPlugin(tasker, workflow)
@@ -541,18 +565,25 @@ class TestVerifyImageTypes(object):
     All results are garbage, so fail
     """
     @responses.activate
-    def test_verify_fail_bad_results(self):
+    def test_verify_fail_bad_results(self, caplog):
         workflow = self.workflow(fail="bad_results")
         tasker = MockerTasker()
 
         plugin = VerifyMediaTypesPlugin(tasker, workflow)
         expect_media_types = [MEDIA_TYPE_DOCKER_V1]
         expect_missing_types = sorted([MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST,
-                                       MEDIA_TYPE_DOCKER_V2_SCHEMA1, MEDIA_TYPE_DOCKER_V2_SCHEMA2])
-        missing_msg = "expected media types {0} ".format(expect_missing_types)
-        media_msg = "not in available media types {0}".format(expect_media_types)
-        failmsg = missing_msg + media_msg
+                                       MEDIA_TYPE_DOCKER_V2_SCHEMA1,
+                                       MEDIA_TYPE_DOCKER_V2_SCHEMA2,
+                                       MEDIA_TYPE_OCI_V1,
+                                       MEDIA_TYPE_OCI_V1_INDEX])
+
+        expected_msg = "expected media types {0} ".format(expect_missing_types)
+        available_msg = "not in available media types {0}, ".format(expect_media_types)
+        registry_msg = "for registry {0}".format('container-registry.example.com')
+
+        failmsg = expected_msg + available_msg + registry_msg
 
         with pytest.raises(KeyError) as exc:
             plugin.run()
-        assert failmsg in str(exc.value)
+        assert 'expected media types were not found' in str(exc.value)
+        assert failmsg in caplog.text


### PR DESCRIPTION
or manifest list type only if x86_64 is missing,
also reports missing types expected for each registry

* OSBS-6961

Signed-off-by: Robert Cerven <rcerven@redhat.com>