### PR TITLE
Retry docker ops on ReadTimeoutError

### DIFF
--- a/atomic_reactor/core.py
+++ b/atomic_reactor/core.py
@@ -41,7 +41,8 @@ from atomic_reactor.source import get_source_instance_for
 from atomic_reactor.util import ImageName, figure_out_build_file, Dockercfg
 from osbs.utils import clone_git_repo
 
-from requests.packages.urllib3.exceptions import InsecureRequestWarning, ProtocolError
+from requests.packages.urllib3.exceptions import (InsecureRequestWarning, ProtocolError,
+                                                  ReadTimeoutError)
 
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
@@ -318,6 +319,9 @@ class DockerTasker(LastLogger):
             except APIError as e:
                 exc = e
                 context = e.response.content
+            except ReadTimeoutError as e:
+                exc = e
+                context = e.args
             else:
                 if cmd_result.is_failed():
                     exc = cmd_result.error_detail

--- a/tests/test_tasker.py
+++ b/tests/test_tasker.py
@@ -486,11 +486,11 @@ def test_retry_generator(exc, in_init, retry_times):
         error_message = 'cmd_error'
 
     if retry_times >= 0:
-        with pytest.raises(RetryGeneratorException) as exc:
+        with pytest.raises(RetryGeneratorException) as ex:
             t.retry_generator(lambda *args, **kwargs: simplegen(),
                               *my_args, **my_kwargs)
 
-        assert repr(error_message) in repr(exc.value)
+        assert repr(error_message) in repr(ex.value)
     else:
         t.retry_generator(lambda *args, **kwargs: simplegen(),
                           *my_args, **my_kwargs)


### PR DESCRIPTION
Note that We have been experiencing ReadTimeoutErrors on push operations. This PR proposes retrying any operation which errors with a ReadTimeout.