### PR TITLE
Make requirements.txt work for Fedora and RHEL/CentOS 7

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,6 @@
 include LICENSE
 include README.md
 include requirements.txt
-include requirements-py2.txt
 include docs/*.md
 include docs/manpage/atomic-reactor.1
 include atomic_reactor/schemas/*.json

--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -1,1 +1,0 @@
-backports.lzma

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
-docker-py
+backports.lzma;python_version<="2.7" # to match available in RHEL/CentOS 7
+docker;python_version>="3.6" # to match available in Fedora
+docker-py;python_version<="2.7" # to match available in RHEL/CentOS 7
 docker-squash>=1.0.7
 dockerfile-parse>=0.0.13
-jsonschema==2.3.0  # to match available in RHEL/CentOS 7
+jsonschema;python_version>="3.6" # to match availabe in Fedora
+jsonschema==2.3.0;python_version<="2.7"  # to match available in RHEL/CentOS 7
 PyYAML
 six

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ of the BSD license. See the LICENSE file for details.
 """
 
 import re
-import sys
 
 from setuptools import setup, find_packages
 from atomic_reactor.constants import DESCRIPTION, HOMEPAGE
@@ -23,7 +22,8 @@ data_files = {
     ],
 }
 
-def _get_requirements(path):
+
+def get_requirements(path):
     try:
         with open(path) as f:
             packages = f.read().splitlines()
@@ -32,12 +32,6 @@ def _get_requirements(path):
     packages = (p.strip() for p in packages if not re.match("^\s*#", p))
     packages = list(filter(None, packages))
     return packages
-
-def _install_requirements():
-    requirements = _get_requirements('requirements.txt')
-    if sys.version_info[0] < 3:
-        requirements += _get_requirements('requirements-py2.txt')
-    return requirements
 
 setup(
     name='atomic-reactor',
@@ -51,7 +45,7 @@ setup(
         'console_scripts': ['atomic-reactor=atomic_reactor.cli.main:run'],
     },
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
-    install_requires=_install_requirements(),
+    install_requires=get_requirements('requirements.txt'),
     package_data={'atomic_reactor': ['schemas/*.json']},
     data_files=data_files.items(),
 )

--- a/test.sh
+++ b/test.sh
@@ -94,7 +94,6 @@ $RUN $PIP install --upgrade --no-deps --force-reinstall git+https://github.com/p
 $RUN $PIP install --upgrade --no-deps --force-reinstall git+https://github.com/DBuildService/dockerfile-parse
 if [[ $PYTHON_VERSION == 2* ]]; then
   $RUN $PIP install git+https://github.com/release-engineering/dockpulp
-  $RUN $PIP install -r requirements-py2.txt
 fi
 
 # Install flatpak dependencies only on fedora


### PR DESCRIPTION
Currently in Fedora we have to carry a [patch](https://src.fedoraproject.org/rpms/atomic-reactor/blob/master/f/atomic-reactor-jsonschema-version.patch) to get the correct dependencies. This PR uses the conditional check on the python version to install the version of dependencies needed.

Also Python 3.6 is now available in EPEL 7 atomic-reactor does not have many dependencies so it would be interesting to check if we can run it with Python 3 in RHEL / CentOS 7. 