### PR TITLE
Revert "Make requirements.txt work for Fedora and RHEL/CentOS 7"

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include LICENSE
 include README.md
 include requirements.txt
+include requirements-py2.txt
 include docs/*.md
 include docs/manpage/atomic-reactor.1
 include atomic_reactor/schemas/*.json

--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -1,0 +1,1 @@
+backports.lzma

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,6 @@
-backports.lzma;python_version<="2.7" # to match available in RHEL/CentOS 7
-docker;python_version>="3.6" # to match available in Fedora
-docker-py;python_version<="2.7" # to match available in RHEL/CentOS 7
+docker-py
 docker-squash>=1.0.7
 dockerfile-parse>=0.0.13
-jsonschema;python_version>="3.6" # to match availabe in Fedora
-jsonschema==2.3.0;python_version<="2.7"  # to match available in RHEL/CentOS 7
+jsonschema==2.3.0  # to match available in RHEL/CentOS 7
 PyYAML
 six

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ of the BSD license. See the LICENSE file for details.
 """
 
 import re
+import sys
 
 from setuptools import setup, find_packages
 from atomic_reactor.constants import DESCRIPTION, HOMEPAGE
@@ -22,8 +23,7 @@ data_files = {
     ],
 }
 
-
-def get_requirements(path):
+def _get_requirements(path):
     try:
         with open(path) as f:
             packages = f.read().splitlines()
@@ -32,6 +32,12 @@ def get_requirements(path):
     packages = (p.strip() for p in packages if not re.match("^\s*#", p))
     packages = list(filter(None, packages))
     return packages
+
+def _install_requirements():
+    requirements = _get_requirements('requirements.txt')
+    if sys.version_info[0] < 3:
+        requirements += _get_requirements('requirements-py2.txt')
+    return requirements
 
 setup(
     name='atomic-reactor',
@@ -45,7 +51,7 @@ setup(
         'console_scripts': ['atomic-reactor=atomic_reactor.cli.main:run'],
     },
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
-    install_requires=get_requirements('requirements.txt'),
+    install_requires=_install_requirements(),
     package_data={'atomic_reactor': ['schemas/*.json']},
     data_files=data_files.items(),
 )

--- a/test.sh
+++ b/test.sh
@@ -94,6 +94,7 @@ $RUN $PIP install --upgrade --no-deps --force-reinstall git+https://github.com/p
 $RUN $PIP install --upgrade --no-deps --force-reinstall git+https://github.com/DBuildService/dockerfile-parse
 if [[ $PYTHON_VERSION == 2* ]]; then
   $RUN $PIP install git+https://github.com/release-engineering/dockpulp
+  $RUN $PIP install -r requirements-py2.txt
 fi
 
 # Install flatpak dependencies only on fedora


### PR DESCRIPTION
The syntax proposed on this change is not compatible with setuptools
version available in CentOS7, breaking RPM builds in such environments.

This was introduced in #1191 (see discussion in PR for reference).

@cverna  do you have any other ideas on how to deal with this? This breaks our RPM builds and integration tests ATM.