### PR TITLE
Use travis_wait to avoid CI build time out

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
 install:
   - pip install coveralls
 script:
-  - ./test.sh
+  - travis_wait ./test.sh
 after_success: coveralls
 notifications:
   email: false

--- a/test.sh
+++ b/test.sh
@@ -17,7 +17,7 @@ for dir in ${EXTRA_MOUNT:-}; do
 done
 
 CONTAINER_NAME="atomic-reactor-$OS-$OS_VERSION-py$PYTHON_VERSION"
-RUN="docker exec -ti $CONTAINER_NAME"
+RUN="docker exec -i $CONTAINER_NAME"
 if [[ $OS == "fedora" ]]; then
   PIP_PKG="python$PYTHON_VERSION-pip"
   PIP="pip$PYTHON_VERSION"


### PR DESCRIPTION
Travis builds have been frequently timing out while fetching packages
from Fedora or Pypi. This commit makes travis wait 20 minutes before
starting the timeout countdown. See
https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
for reference.

Signed-off-by: Athos Ribeiro <athos@redhat.com>