### PR TITLE
Add option to allow non-OSBS build parent images

### DIFF
--- a/atomic_reactor/plugins/pre_reactor_config.py
+++ b/atomic_reactor/plugins/pre_reactor_config.py
@@ -364,6 +364,10 @@ def get_hide_files(workflow, fallback=NO_FALLBACK):
     return get_value(workflow, 'hide_files', fallback)
 
 
+def get_skip_koji_check_for_base_image(workflow, fallback=NO_FALLBACK):
+    return get_value(workflow, 'skip_koji_check_for_base_image', fallback)
+
+
 class ClusterConfig(object):
     """
     Configuration relating to a particular cluster

--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -441,6 +441,10 @@
         "description": "Proxy to access yum repositories",
         "type": "string"
     },
+    "skip_koji_check_for_base_image": {
+        "description": "Allow base image without related koji build (insecure)",
+        "type": "boolean"
+    },
     "hide_files": {
         "description": "Hide files during build for each stage",
         "type": "object",

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -171,6 +171,8 @@ hide_files:
     - /etc/yum.repos.d/repo_ignore_1.repo
     - /etc/yum.repos.d/repo_ignore_2.repo
 
+skip_koji_check_for_base_image: False
+
 clusters:
   foo:
    - name: blah

--- a/tests/plugins/test_reactor_config.py
+++ b/tests/plugins/test_reactor_config.py
@@ -513,7 +513,8 @@ class TestReactorConfigPlugin(object):
         'image_label_info_url_format', 'image_equal_labels',
         'openshift', 'group_manifests', 'platform_descriptors', 'prefer_schema1_digest',
         'content_versions', 'registries', 'yum_proxy', 'source_registry', 'sources_command',
-        'required_secrets', 'worker_token_secrets', 'clusters', 'hide_files'
+        'required_secrets', 'worker_token_secrets', 'clusters', 'hide_files',
+        'skip_koji_check_for_base_image'
     ])
     def test_get_methods(self, fallback, method):
         tasker, workflow = self.prepare()


### PR DESCRIPTION
With the allow_external_base_image option set to True, do not stop
(fail) builds when a parent image is not found in Koji. Instead, raise a
working, skip digests checking and continue.

Signed-off-by: Athos Ribeiro <athos@redhat.com>