### PR TITLE
 Verify parent images manifest digests against koji 

### DIFF
--- a/atomic_reactor/build.py
+++ b/atomic_reactor/build.py
@@ -20,7 +20,7 @@ import docker.errors
 import atomic_reactor.util
 from atomic_reactor.core import DockerTasker, LastLogger
 from atomic_reactor.util import (ImageName, print_version_of_tools, df_parser,
-                                 base_image_is_scratch, DigestCollector, base_image_is_custom)
+                                 base_image_is_scratch, base_image_is_custom)
 from atomic_reactor.constants import DOCKERFILE_FILENAME
 
 logger = logging.getLogger(__name__)
@@ -154,7 +154,7 @@ class InsideBuilder(LastLogger, BuilderStateMachine):
         self.parent_images = {}  # dockerfile ImageName => locally available ImageName
         self._parent_images_inspect = {}  # locally available image => inspect
         self.parents_ordered = []
-        self.parent_images_digests = DigestCollector()
+        self.parent_images_digests = {}
         self.image_id = None
         self.built_image_info = None
         self.image = ImageName.parse(image)

--- a/atomic_reactor/plugins/build_orchestrate_build.py
+++ b/atomic_reactor/plugins/build_orchestrate_build.py
@@ -412,8 +412,7 @@ class OrchestrateBuildPlugin(BuildStepPlugin):
     def adjust_build_kwargs(self):
         self.build_kwargs['arrangement_version'] =\
             get_arrangement_version(self.workflow, self.build_kwargs['arrangement_version'])
-        self.build_kwargs['parent_images_digests'] =\
-            self.workflow.builder.parent_images_digests.to_dict()
+        self.build_kwargs['parent_images_digests'] = self.workflow.builder.parent_images_digests
         # All platforms should generate the same operator manifests. We can use any of them
         if self.platforms:
             self.build_kwargs['operator_manifests_extract_platform'] = list(self.platforms)[0]

--- a/atomic_reactor/plugins/pre_pull_base_image.py
+++ b/atomic_reactor/plugins/pre_pull_base_image.py
@@ -17,17 +17,18 @@ this build so that it isn't removed by other builds doing clean-up.
 from __future__ import unicode_literals, absolute_import
 
 import docker
-import platform
 
 from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.util import (get_build_json, get_manifest_list,
                                  get_config_from_registry, ImageName,
-                                 get_platforms, base_image_is_custom)
+                                 get_platforms, base_image_is_custom,
+                                 get_checksums, get_manifest_media_type,
+                                 get_all_manifests)
 from atomic_reactor.core import RetryGeneratorException
 from atomic_reactor.plugins.pre_reactor_config import (get_source_registry,
                                                        get_platform_to_goarch_mapping,
-                                                       get_goarch_to_platform_mapping,
                                                        get_registries_organization)
+from io import BytesIO
 from requests.exceptions import HTTPError, RetryError, Timeout
 from osbs.utils import RegistryURI
 
@@ -47,7 +48,7 @@ class PullBaseImagePlugin(PreBuildPlugin):
         :param parent_registry_insecure: allow connecting to the registry over plain http
         :param check_platforms: validate parent images provide all platforms expected for the build
         :param inspect_only: bool, if set to True, base images will not be pulled
-        :param parent_images_digests: dict, parent images digests for all platforms
+        :param parent_images_digests: dict, parent images manifest digests
         """
         # call parent constructor
         super(PullBaseImagePlugin, self).__init__(tasker, workflow)
@@ -67,17 +68,17 @@ class PullBaseImagePlugin(PreBuildPlugin):
             self.parent_registry_insecure = False
             self.parent_registry_dockercfg_path = None
         if parent_images_digests:
-            self._load_parent_images_digests(parent_images_digests)
+            metadata = self.workflow.builder.parent_images_digests
+            metadata.update(parent_images_digests)
 
     def run(self):
         """
         Pull parent images and retag them uniquely for this build.
         """
         build_json = get_build_json()
-        current_platform = platform.processor() or 'x86_64'
         self.manifest_list_cache = {}
         organization = get_registries_organization(self.workflow)
-
+        digest_fetching_exceptions = []
         for nonce, parent in enumerate(sorted(self.workflow.builder.parent_images.keys(),
                                               key=str)):
             if base_image_is_custom(parent.to_str()):
@@ -99,122 +100,80 @@ class PullBaseImagePlugin(PreBuildPlugin):
             if self.check_platforms:
                 # run only at orchestrator
                 self._validate_platforms_in_image(image)
-                self._collect_image_digests(image)
+                try:
+                    self._store_manifest_digest(image)
+                except RuntimeError as exc:
+                    digest_fetching_exceptions.append(exc)
 
-            # try to stay with digests
-            image_with_digest = self._get_image_with_digest(image, current_platform)
+            image_with_digest = self._get_image_with_digest(image)
             if image_with_digest is None:
-                self.log.warning("Cannot resolve platform '%s' specific digest for image '%s'",
-                                 current_platform, image)
+                self.log.warning("Cannot resolve manifest digest for image '%s'", image)
             else:
                 self.log.info("Replacing image '%s' with '%s'", image, image_with_digest)
                 image = image_with_digest
 
-            if self.check_platforms:
-                new_arch_image = self._get_image_for_different_arch(image, current_platform)
-                if new_arch_image:
-                    image = new_arch_image
-
-            if self.inspect_only:
-                new_image = image
-            else:
-                new_image = self._pull_and_tag_image(image, build_json, str(nonce))
+            if not self.inspect_only:
+                image = self._pull_and_tag_image(image, build_json, str(nonce))
             self.workflow.builder.recreate_parent_images()
-            self.workflow.builder.parent_images[parent] = new_image
+            self.workflow.builder.parent_images[parent] = image
 
             if is_base_image:
                 if organization:
                     # we want to be sure we have original_base_image enclosed as well
                     self.workflow.builder.original_base_image.enclose(organization)
                 self.workflow.builder.set_base_image(
-                    str(new_image), insecure=self.parent_registry_insecure,
+                    str(image), insecure=self.parent_registry_insecure,
                     dockercfg_path=self.parent_registry_dockercfg_path
                 )
+
+        if digest_fetching_exceptions:
+            raise RuntimeError('Error when extracting parent images manifest digests: {}'
+                               .format(digest_fetching_exceptions))
         self.workflow.builder.parents_pulled = not self.inspect_only
         self.workflow.builder.base_image_insecure = self.parent_registry_insecure
 
-    def _get_image_with_digest(self, image, platform):
-        parents_digests = self.workflow.builder.parent_images_digests
-
+    def _get_image_with_digest(self, image):
+        image_str = image.to_str()
         try:
-            new_image = ImageName.parse(parents_digests.get_image_platform_digest(image, platform))
+            image_metadata = self.workflow.builder.parent_images_digests[image_str]
         except KeyError:
             return None
 
-        return new_image
+        v2_list_type = get_manifest_media_type('v2_list')
+        v2_type = get_manifest_media_type('v2')
+        raw_digest = image_metadata.get(v2_list_type) or image_metadata.get(v2_type)
+        if not raw_digest:
+            return None
 
-    def _load_parent_images_digests(self, images_digests):
-        assert isinstance(images_digests, dict)
-        parents_digests = self.workflow.builder.parent_images_digests
-        parents_digests.update_from_dict(images_digests)
+        digest = raw_digest.split(':', 1)[1]
+        image_name = image.to_str(tag=False)
+        new_image = '{}@sha256:{}'.format(image_name, digest)
+        return ImageName.parse(new_image)
 
-    def _collect_image_digests(self, image):
-        parents_digests = self.workflow.builder.parent_images_digests
-
-        if image in parents_digests:
-            # we already have recorded digests for the image, keep it the same
-            # to prevent race conditions at workers
-            return
-
+    def _store_manifest_digest(self, image):
+        """Store media type and digest for manifest list or v2 schema 2 manifest digest"""
+        image_str = image.to_str()
         manifest_list = self._get_manifest_list(image)
-
-        if not manifest_list:
-            self.log.warning(
-                "Empty manifest list for image %s. Collected image digests will be "
-                "incomplete and may cause race conditions during build", image
-            )
-            return
-
-        manifest_list_dict = manifest_list.json()
-
-        try:
-            arch_to_platform = get_goarch_to_platform_mapping(self.workflow)
-        except KeyError:
-            self.log.warning('Cannot collect platforms digests for parent images '
-                             'because platform descriptors are not defined')
-            return
-
-        for manifest in manifest_list_dict['manifests']:
-            arch = manifest['platform']['architecture']
+        if manifest_list:
+            digest_dict = get_checksums(BytesIO(manifest_list.content), ['sha256'])
+            media_type = get_manifest_media_type('v2_list')
+        else:
+            digests_dict = get_all_manifests(image, image.registry,
+                                             self.parent_registry_insecure,
+                                             self.parent_registry_dockercfg_path,
+                                             versions=('v2',))
+            media_type = get_manifest_media_type('v2')
             try:
-                present_platform = arch_to_platform[arch]
+                manifest_digest_response = digests_dict['v2']
             except KeyError:
-                self.log.warning("Cannot map architecture='{}' to platform".format(arch))
-                continue
-            else:
-                digest = manifest['digest']
-                self.log.info("Collecting digest for image '%s' ('%s'): '%s'",
-                              image, present_platform, digest)
-                parents_digests.update_image_digest(
-                    image, present_platform, digest
-                )
+                raise RuntimeError('Could not extract manifest list or '
+                                   'v2 schema 2 digest for {}'.format(image_str))
 
-    def _get_image_for_different_arch(self, image, platform):
-        """Get image from random arch
+            digest_dict = get_checksums(BytesIO(manifest_digest_response.content), ['sha256'])
 
-        This is a workaround for aarch64 platform, because orchestrator cannot
-        get this arch from manifests lists so we have to provide digest of a
-        random platform to get image metadata for orchestrator.
-
-        For standard platforms like x86_64, ppc64le, ... this method returns
-        the corresponding digest
-
-        """
-        parents_digests = self.workflow.builder.parent_images_digests
-        try:
-            digests = parents_digests.get_image_digests(image)
-        except KeyError:
-            return None
-
-        if not digests:
-            return None
-        platform_digest = digests.get(platform)
-        if platform_digest is None:
-            # exact match is not found, get random platform
-            platform_digest = tuple(digests.values())[0]
-
-        new_image = ImageName.parse(platform_digest)
-        return new_image
+        manifest_digest = 'sha256:{}'.format(digest_dict['sha256sum'])
+        parent_digests = {media_type: manifest_digest}
+        self.workflow.builder.parent_images_digests[image_str] = parent_digests
 
     def _resolve_base_image(self, build_json):
         """If this is an auto-rebuild, adjust the base image to use the triggering build"""
@@ -344,10 +303,6 @@ class PullBaseImagePlugin(PreBuildPlugin):
             self.log.info('Skipping validation of available platforms '
                           'because expected platforms are unknown')
             return
-        if len(expected_platforms) == 1:
-            self.log.info('Skipping validation of available platforms for base image '
-                          'because this is a single platform build')
-            return
 
         if not image.registry:
             self.log.info('Cannot validate available platforms for base image '
@@ -364,7 +319,13 @@ class PullBaseImagePlugin(PreBuildPlugin):
         manifest_list = self._get_manifest_list(image)
 
         if not manifest_list:
-            raise RuntimeError('Unable to fetch manifest list for base image')
+            if len(expected_platforms) == 1:
+                self.log.warning('Skipping validation of available platforms for base image: '
+                                 'this is a single platform build and base image has no manifest '
+                                 'list')
+                return
+            else:
+                raise RuntimeError('Unable to fetch manifest list for base image')
 
         all_manifests = manifest_list.json()['manifests']
         manifest_list_arches = set(

--- a/atomic_reactor/schemas/user_params.json
+++ b/atomic_reactor/schemas/user_params.json
@@ -43,10 +43,10 @@
           "description": "Image with tags",
           "type": "object",
           "patternProperties": {
-            "^.": {
-              "description": "Platform specific image",
+            "^application/.*json$": {
+              "description": "Manifest digest",
               "type": "string",
-              "pattern": "@.+:"
+              "pattern": "^sha256:.+"
             }
           },
           "uniqueItems": true,

--- a/tests/plugins/test_koji_parent.py
+++ b/tests/plugins/test_koji_parent.py
@@ -36,7 +36,7 @@ from atomic_reactor.plugins.pre_koji_parent import KojiParentPlugin
 from atomic_reactor.plugins.pre_reactor_config import (ReactorConfigPlugin,
                                                        WORKSPACE_CONF_KEY,
                                                        ReactorConfig)
-from atomic_reactor.util import ImageName
+from atomic_reactor.util import ImageName, get_manifest_media_type
 from atomic_reactor.constants import SCRATCH_FROM
 from flexmock import flexmock
 from tests.constants import MOCK, MOCK_SOURCE
@@ -55,9 +55,13 @@ KOJI_BUILD_NVR = 'base-image-1.0-99'
 
 KOJI_STATE_COMPLETE = koji.BUILD_STATES['COMPLETE']
 
+V2_LIST = get_manifest_media_type('v2_list')
+KOJI_EXTRA = {'image': {'index': {'digests': {V2_LIST: 'stubDigest'}}}}
+
 KOJI_STATE_DELETED = koji.BUILD_STATES['DELETED']
 
-KOJI_BUILD = {'nvr': KOJI_BUILD_NVR, 'id': KOJI_BUILD_ID, 'state': KOJI_STATE_COMPLETE}
+KOJI_BUILD = {'nvr': KOJI_BUILD_NVR, 'id': KOJI_BUILD_ID, 'state': KOJI_STATE_COMPLETE,
+              'extra': KOJI_EXTRA}
 
 DELETED_KOJI_BUILD = {'nvr': KOJI_BUILD_NVR, 'id': KOJI_BUILD_ID, 'state': KOJI_STATE_DELETED}
 
@@ -84,8 +88,10 @@ class MockInsideBuilder(InsideBuilder):
         self.original_base_image = ImageName(repo='Fedora', tag='22')
         self.base_from_scratch = False
         self.custom_base_image = False
-        self.parent_images = {}  # don't want to handle inspections in most tests
-        self._parent_images_inspect = {}
+        self.parent_images = {ImageName.parse('base'): ImageName.parse('base:stubDigest')}
+        base_inspect = {INSPECT_CONFIG: {'Labels': BASE_IMAGE_LABELS.copy()}}
+        self._parent_images_inspect = {ImageName.parse('base:stubDigest'): base_inspect}
+        self.parent_images_digests = {'base:latest': {V2_LIST: 'stubDigest'}}
         self.image_id = 'image_id'
         self.image = 'image'
         self._df_path = 'df_path'
@@ -124,6 +130,16 @@ class TestKojiParent(object):
 
     def test_koji_build_found(self, workflow, koji_session, reactor_config_map):  # noqa
         self.run_plugin_with_args(workflow, reactor_config_map=reactor_config_map)
+
+    def test_koji_build_no_extra(self, workflow, koji_session, reactor_config_map):  # noqa
+        koji_no_extra = {'nvr': KOJI_BUILD_NVR, 'id': KOJI_BUILD_ID, 'state': KOJI_STATE_COMPLETE}
+        (flexmock(koji_session)
+            .should_receive('getBuild')
+            .with_args(KOJI_BUILD_NVR)
+            .and_return(koji_no_extra))
+        with pytest.raises(PluginFailedException) as exc_info:
+            self.run_plugin_with_args(workflow, reactor_config_map=reactor_config_map)
+        assert 'does not have manifest digest data' in str(exc_info)
 
     def test_koji_build_retry(self, workflow, koji_session, reactor_config_map):  # noqa
         (flexmock(koji_session)
@@ -196,25 +212,56 @@ class TestKojiParent(object):
     ])
     def test_base_image_missing_labels(self, workflow, koji_session, remove_labels, exp_result,
                                        reactor_config_map):
+        base_tag = ImageName.parse('base:stubDigest')
         workflow.builder.base_image_inspect[INSPECT_CONFIG]['Labels'] =\
+            BASE_IMAGE_LABELS_W_ALIASES.copy()
+        workflow.builder._parent_images_inspect[base_tag][INSPECT_CONFIG]['Labels'] =\
             BASE_IMAGE_LABELS_W_ALIASES.copy()
         for label in remove_labels:
             del workflow.builder.base_image_inspect[INSPECT_CONFIG]['Labels'][label]
-        self.run_plugin_with_args(workflow, expect_result=exp_result,
-                                  reactor_config_map=reactor_config_map)
+            del workflow.builder._parent_images_inspect[base_tag][INSPECT_CONFIG]['Labels'][label]
+        if not exp_result:
+            with pytest.raises(PluginFailedException) as exc:
+                self.run_plugin_with_args(workflow, expect_result=exp_result,
+                                          reactor_config_map=reactor_config_map)
+            assert 'Was this image built in OSBS?' in str(exc)
+        else:
+            self.run_plugin_with_args(workflow, expect_result=exp_result,
+                                      reactor_config_map=reactor_config_map)
 
+    @pytest.mark.parametrize('media_version', ['v2_list', 'v2'])
+    @pytest.mark.parametrize('parent_tags', [
+                             ['miss', 'stubDigest', 'stubDigest'],
+                             ['stubDigest', 'miss', 'stubDigest'],
+                             ['stubDigest', 'stubDigest', 'miss'],
+                             ['miss', 'miss', 'miss'],
+                             ['stubDigest', 'stubDigest', 'stubDigest']])
     @pytest.mark.parametrize('special_base', [False, 'scratch', 'custom'])  # noqa: F811
     def test_multiple_parent_images(self, workflow, koji_session, reactor_config_map,
-                                    special_base):
+                                    special_base, parent_tags, media_version):
         parent_images = {
-            ImageName.parse('somebuilder'): ImageName.parse('b1tag'),
-            ImageName.parse('otherbuilder'): ImageName.parse('b2tag'),
-            ImageName.parse('base'): ImageName.parse('basetag'),
+            ImageName.parse('somebuilder'): ImageName.parse('somebuilder:{}'
+                                                            .format(parent_tags[0])),
+            ImageName.parse('otherbuilder'): ImageName.parse('otherbuilder:{}'
+                                                             .format(parent_tags[1])),
+            ImageName.parse('base'): ImageName.parse('base:{}'.format(parent_tags[2])),
         }
+        media_type = get_manifest_media_type(media_version)
+        workflow.builder.parent_images_digests = {}
+        for parent in parent_images:
+            dgst = parent_images[parent].tag
+            workflow.builder.parent_images_digests[parent.to_str()] = {media_type: dgst}
+        extra = {'image': {'index': {'digests': {media_type: 'stubDigest'}}}}
         koji_builds = dict(
-            somebuilder=dict(nvr='somebuilder-1.0-1', id=42, state=KOJI_STATE_COMPLETE),
-            otherbuilder=dict(nvr='otherbuilder-2.0-1', id=43, state=KOJI_STATE_COMPLETE),
-            base=dict(nvr='base-16.0-1', id=16, state=KOJI_STATE_COMPLETE),
+            somebuilder=dict(nvr='somebuilder-1.0-1',
+                             id=42,
+                             state=KOJI_STATE_COMPLETE,
+                             extra=extra),
+            otherbuilder=dict(nvr='otherbuilder-2.0-1',
+                              id=43,
+                              state=KOJI_STATE_COMPLETE,
+                              extra=extra),
+            base=dict(nvr=KOJI_BUILD_NVR, id=KOJI_BUILD_ID, state=KOJI_STATE_COMPLETE, extra=extra),
             unresolved=None,
         )
         image_inspects = {}
@@ -224,7 +271,7 @@ class TestKojiParent(object):
         for img, build in koji_builds.items():
             if build is None:
                 continue
-            name, version, release = koji_builds[img]['nvr'].split('-')
+            name, version, release = koji_builds[img]['nvr'].rsplit('-', 2)
             labels = {'com.redhat.component': name, 'version': version, 'release': release}
             image_inspects[img] = {INSPECT_CONFIG: dict(Labels=labels)}
             (workflow.builder.tasker
@@ -253,9 +300,33 @@ class TestKojiParent(object):
         if special_base:
             del expected[BASE_IMAGE_KOJI_BUILD]
 
-        self.run_plugin_with_args(
-            workflow, expect_result=expected, reactor_config_map=reactor_config_map
-        )
+        if 'miss' in parent_tags:
+            with pytest.raises(PluginFailedException) as exc:
+                self.run_plugin_with_args(
+                    workflow, expect_result=expected, reactor_config_map=reactor_config_map
+                )
+            errors = []
+            error_msg = ('Manifest digest (miss) for parent image {}:latest does not match value '
+                         'in its koji reference (stubDigest). This parent image MUST be rebuilt')
+            if parent_tags[0] == 'miss':
+                errors.append(error_msg.format('somebuilder'))
+            if parent_tags[1] == 'miss':
+                errors.append(error_msg.format('otherbuilder'))
+            if parent_tags[2] == 'miss':
+                errors.append(error_msg.format('base'))
+            assert 'This parent image MUST be rebuilt' in str(exc)
+            for e in errors:
+                assert e in str(exc)
+        else:
+            self.run_plugin_with_args(
+                workflow, expect_result=expected, reactor_config_map=reactor_config_map
+            )
+
+    def test_unexpected_digest_data(self, workflow, koji_session, reactor_config_map):  # noqa
+        workflow.builder.parent_images_digests = {'base:latest': {'unexpected_type': 'stubDigest'}}
+        with pytest.raises(PluginFailedException) as exc_info:
+            self.run_plugin_with_args(workflow, reactor_config_map=reactor_config_map)
+        assert 'Unexpected parent image digest data' in str(exc_info)
 
     def run_plugin_with_args(self, workflow, plugin_args=None, expect_result=True,  # noqa
                              reactor_config_map=False):
@@ -285,7 +356,9 @@ class TestKojiParent(object):
 
         result = runner.run()
         if expect_result is True:
-            expected_result = {BASE_IMAGE_KOJI_BUILD: KOJI_BUILD}
+            expected_result = {BASE_IMAGE_KOJI_BUILD: KOJI_BUILD,
+                               PARENT_IMAGES_KOJI_BUILDS: {
+                                   ImageName.parse('base:latest'): KOJI_BUILD}}
         elif expect_result is False:
             expected_result = None
         else:  # param provided the expected result

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -56,7 +56,7 @@ from atomic_reactor.util import (ImageName, wait_for_command,
                                  read_yaml, read_yaml_from_file_path, OSBSLogs,
                                  get_platforms_in_limits, get_orchestrator_platforms,
                                  dump_stacktraces, setup_introspection_signal_handler,
-                                 DigestCollector, allow_repo_dir_in_dockerignore)
+                                 allow_repo_dir_in_dockerignore)
 from atomic_reactor import util
 from tests.constants import (DOCKERFILE_GIT,
                              INPUT_IMAGE, MOCK, MOCK_SOURCE,
@@ -1568,84 +1568,3 @@ def test_allow_repo_dir_in_dockerignore(tmpdir, dockerignore_exists):
 
         assert ignore_lines[0:len(ignore_content)] == ignore_content
         assert ignore_lines[-1] == added_lines
-
-
-class TestDigestCollector(object):
-    """Tests related to DigestCollector class"""
-
-    IMAGE_NAME = ImageName(registry='registry.fedoraproject.org', repo='fedora', tag='latest')
-    IMAGE_STR = IMAGE_NAME.to_str(tag=True)
-    IMAGE_STR_NO_TAG = IMAGE_NAME.to_str(tag=False)
-    IMAGE_PLATFORM = 'x86_64'
-    IMAGE_DIGEST = 'sha256:1dea7f21b45f566ba844b923e5047ab7cad640998fd0fa02938f81b4a3f56b60'
-    DATA = {
-        IMAGE_STR: {
-            IMAGE_PLATFORM: '{}@{}'.format(IMAGE_STR_NO_TAG, IMAGE_DIGEST)
-        }
-    }
-
-    def test_update_image_digest(self):
-        """Tests methods update_image_digest and to_dict"""
-        dc = DigestCollector()
-        assert dc.to_dict() == {}
-
-        dc.update_image_digest(self.IMAGE_NAME, self.IMAGE_PLATFORM, self.IMAGE_DIGEST)
-        assert dc.to_dict() == self.DATA
-
-    def test_bool(self):
-        """Test __bool__ method"""
-        dc = DigestCollector()
-
-        assert not dc
-
-        dc.update_image_digest(self.IMAGE_NAME, self.IMAGE_PLATFORM, self.IMAGE_DIGEST)
-        assert dc
-
-    def test_contains(self):
-        """Test operator *in*"""
-        dc = DigestCollector()
-
-        assert self.IMAGE_NAME not in dc
-
-        dc.update_image_digest(self.IMAGE_NAME, self.IMAGE_PLATFORM, self.IMAGE_DIGEST)
-        assert self.IMAGE_NAME in dc
-
-    def test_get_image_digests(self):
-        """Test method get_image_digests"""
-        dc = DigestCollector()
-
-        # test empty
-        with pytest.raises(KeyError):
-            dc.get_image_digests(self.IMAGE_NAME)
-
-        dc.update_image_digest(self.IMAGE_NAME, self.IMAGE_PLATFORM, self.IMAGE_DIGEST)
-        expected = self.DATA[self.IMAGE_STR]
-        assert dc.get_image_digests(self.IMAGE_NAME) == expected
-
-    def test_get_image_platform_digest(self):
-        """Test method get_image_platform_digests"""
-        dc = DigestCollector()
-
-        # test empty
-        with pytest.raises(KeyError):
-            dc.get_image_platform_digest(self.IMAGE_NAME, self.IMAGE_PLATFORM)
-
-        dc.update_image_digest(self.IMAGE_NAME, self.IMAGE_PLATFORM, self.IMAGE_DIGEST)
-
-        expected = self.DATA[self.IMAGE_STR][self.IMAGE_PLATFORM]
-        assert dc.get_image_platform_digest(self.IMAGE_NAME, self.IMAGE_PLATFORM) == expected
-
-        # test undefined platform
-        with pytest.raises(KeyError):
-            dc.get_image_platform_digest(self.IMAGE_NAME, "unknown")
-
-    def test_update_from_dict(self):
-        """Test method update_from_dict"""
-        dc = DigestCollector()
-        dc.update_from_dict(self.DATA)
-
-        assert dc.to_dict() == self.DATA
-        assert self.IMAGE_NAME in dc
-
-        expected = self.DATA[self.IMAGE_STR][self.IMAGE_PLATFORM]
-        assert dc.get_image_platform_digest(self.IMAGE_NAME, self.IMAGE_PLATFORM) == expected


### PR DESCRIPTION
#1198 was reverted due to errors introduced when a build would be triggered by a change in a parent image. This PR re-introduces those changes, including a patch for handling autorebuilds.

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
