### PR TITLE
Build error messages from str(), not repr()

### DIFF
--- a/atomic_reactor/cli/main.py
+++ b/atomic_reactor/cli/main.py
@@ -23,7 +23,8 @@ from atomic_reactor.api import (build_image_here, build_image_in_privileged_cont
 from atomic_reactor.constants import DESCRIPTION, PROG
 from atomic_reactor.buildimage import BuildImageBuilder
 from atomic_reactor.inner import build_inside, BuildResults
-from atomic_reactor.util import process_substitutions, setup_introspection_signal_handler
+from atomic_reactor.util import (process_substitutions, setup_introspection_signal_handler,
+                                 exception_message)
 
 
 logger = logging.getLogger('atomic_reactor')
@@ -307,7 +308,7 @@ class CLI(object):
             if args.verbose:
                 raise
             else:
-                logger.error("exception caught: %r", ex)
+                logger.error("exception caught: %s", exception_message(ex))
 
 
 def run():

--- a/atomic_reactor/core.py
+++ b/atomic_reactor/core.py
@@ -90,8 +90,8 @@ class BuildContainerFactory(object):
             with open(os.path.join(args_path, BUILD_JSON)) as json_args:
                 logger.debug("build input: image = '%s', args = '%s'", image, json_args.read())
         except (IOError, OSError) as ex:
-            logger.error("unable to open json arguments: %r", ex)
-            raise RuntimeError("Unable to open json arguments: %r" % ex)
+            logger.error("unable to open json arguments: %s", ex)
+            raise RuntimeError("Unable to open json arguments: %s" % ex)
 
         if not self.tasker.image_exists(image):
             logger.error("provided build image doesn't exist: '%s'", image)
@@ -396,7 +396,7 @@ class DockerTasker(LastLogger):
                 shutil.rmtree(temp_dir)
             except (IOError, OSError) as ex:
                 # no idea why this is happening
-                logger.warning("Failed to remove dir '%s': %r", temp_dir, ex)
+                logger.warning("Failed to remove dir '%s': %s", temp_dir, ex)
         logger.info("build finished")
         return response
 
@@ -738,7 +738,7 @@ class DockerTasker(LastLogger):
         try:
             response = self.d.inspect_image(image_id)
         except APIError as ex:
-            logger.warning(repr(ex))
+            logger.warning(str(ex))
             response = False
         else:
             response = response is not None

--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -34,7 +34,7 @@ from atomic_reactor.plugin import (
 from atomic_reactor.source import get_source_instance_for
 from atomic_reactor.constants import INSPECT_ROOTFS, INSPECT_ROOTFS_LAYERS
 from atomic_reactor.constants import CONTAINER_DEFAULT_BUILD_METHOD
-from atomic_reactor.util import ImageName
+from atomic_reactor.util import ImageName, exception_message
 from atomic_reactor.build import BuildResult
 from atomic_reactor import get_logging_encoding
 
@@ -537,7 +537,7 @@ class DockerBuildWorkflow(object):
 
             return self.build_result
         except Exception as ex:
-            logger.debug("caught exception (%r) so running exit plugins", ex)
+            logger.debug("caught exception (%s) so running exit plugins", exception_message(ex))
             exception_being_handled = True
             raise
         finally:

--- a/atomic_reactor/outer.py
+++ b/atomic_reactor/outer.py
@@ -88,10 +88,10 @@ class BuildManager(BuilderStateMachine):
             #     with open(results_path, 'r') as results_fp:
             #         results = json.load(results_fp, cls=BuildResultsJSONDecoder)
             # except (IOError, OSError) as ex:
-            #     logger.error("Can't open results: '%s'", repr(ex))
+            #     logger.error("Can't open results: '%s'", ex)
             #     for l in self.dt.logs(self.build_container_id, stream=False):
             #         logger.debug(l.strip())
-            #     raise RuntimeError("Can't open results: '%s'" % repr(ex))
+            #     raise RuntimeError("Can't open results: '%s'" % ex)
             # results.dockerfile = open(df_path, 'r').read()
             results = BuildResults()
             results.build_logs = dt.logs(container_id, stream=False)

--- a/atomic_reactor/plugins/build_orchestrate_build.py
+++ b/atomic_reactor/plugins/build_orchestrate_build.py
@@ -192,7 +192,7 @@ class WorkerBuildInfo(object):
     def get_fail_reason(self):
         fail_reason = {}
         if self.monitor_exception:
-            fail_reason['general'] = repr(self.monitor_exception)
+            fail_reason['general'] = str(self.monitor_exception)
         elif not self.build:
             fail_reason['general'] = 'build not started'
 
@@ -202,7 +202,7 @@ class WorkerBuildInfo(object):
         build_annotations = self.build.get_annotations() or {}
         metadata = json.loads(build_annotations.get('plugins-metadata', '{}'))
         if self.monitor_exception:
-            fail_reason['general'] = repr(self.monitor_exception)
+            fail_reason['general'] = str(self.monitor_exception)
 
         try:
             fail_reason.update(metadata['errors'])
@@ -686,7 +686,7 @@ class OrchestrateBuildPlugin(BuildStepPlugin):
                 build_info = WorkerBuildInfo(build=None,
                                              cluster_info=cluster,
                                              logger=self.log)
-                build_info.monitor_exception = repr(ex)
+                build_info.monitor_exception = str(ex)
                 self.worker_builds.append(build_info)
                 return
 

--- a/atomic_reactor/plugins/exit_koji_promote.py
+++ b/atomic_reactor/plugins/exit_koji_promote.py
@@ -211,7 +211,7 @@ class KojiPromotePlugin(ExitPlugin):
             pod = self.osbs.get_pod_for_build(self.build_id)
             all_images = pod.get_container_image_ids()
         except OsbsException as ex:
-            self.log.error("unable to find image id: %r", ex)
+            self.log.error("unable to find image id: %s", ex)
             return buildroot_tag
 
         try:
@@ -280,7 +280,7 @@ class KojiPromotePlugin(ExitPlugin):
         try:
             logs = self.osbs.get_build_logs(self.build_id)
         except OsbsException as ex:
-            self.log.error("unable to get build logs: %r", ex)
+            self.log.error("unable to get build logs: %s", ex)
         else:
             # Deleted once closed
             logfile = NamedTemporaryFile(prefix=self.build_id,

--- a/atomic_reactor/plugins/post_koji_upload.py
+++ b/atomic_reactor/plugins/post_koji_upload.py
@@ -206,7 +206,7 @@ class KojiUploadPlugin(PostBuildPlugin):
             pod = self.osbs.get_pod_for_build(self.build_id)
             all_images = pod.get_container_image_ids()
         except OsbsException as ex:
-            self.log.error("unable to find image id: %r", ex)
+            self.log.error("unable to find image id: %s", ex)
             return buildroot_tag
 
         try:

--- a/atomic_reactor/plugins/post_pulp_sync.py
+++ b/atomic_reactor/plugins/post_pulp_sync.py
@@ -142,7 +142,7 @@ class PulpSyncPlugin(PostBuildPlugin):
             try:
                 logger.setLevel(loglevel)
             except (ValueError, TypeError) as ex:
-                self.log.error("Can't set provided log level %r: %r",
+                self.log.error("Can't set provided log level %r: %s",
                                loglevel, ex)
 
         self.publish = (publish and

--- a/atomic_reactor/plugins/pre_add_filesystem.py
+++ b/atomic_reactor/plugins/pre_add_filesystem.py
@@ -342,14 +342,15 @@ class AddFilesystemPlugin(PreBuildPlugin):
                 self.session.cancelTask(task_id)
                 self.log.info('task %s canceled', task_id)
             except Exception as exc:
-                self.log.info("Exception while canceling a task (ignored): %r", exc)
+                self.log.info("Exception while canceling a task (ignored): %s",
+                              util.exception_message(exc))
 
         if task.failed():
             try:
                 # Koji may re-raise the error that caused task to fail
                 task_result = self.session.getTaskResult(task_id)
             except Exception as exc:
-                task_result = repr(exc)
+                task_result = util.exception_message(exc)
             raise RuntimeError('image task, {}, failed: {}'
                                .format(task_id, task_result))
 

--- a/atomic_reactor/plugins/pre_add_help.py
+++ b/atomic_reactor/plugins/pre_add_help.py
@@ -107,7 +107,7 @@ class AddHelpPlugin(PreBuildPlugin):
 
             raise
         except CalledProcessError as e:
-            raise RuntimeError("Error running %s: %r, exit code: %s, output: '%s'" % (
+            raise RuntimeError("Error running %s: %s, exit code: %s, output: '%s'" % (
                 e.cmd, e, e.returncode, e.output))
 
         if not os.path.exists(man_path):

--- a/atomic_reactor/pulp_util.py
+++ b/atomic_reactor/pulp_util.py
@@ -69,7 +69,7 @@ class PulpHandler(object):
             try:
                 logger.setLevel(dockpulp_loglevel)
             except (ValueError, TypeError) as ex:
-                self.log.error("Can't set provided log level %r: %r", dockpulp_loglevel, ex)
+                self.log.error("Can't set provided log level %r: %s", dockpulp_loglevel, ex)
 
     def check_file(self, filename):
         # Sanity-check image

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -556,7 +556,7 @@ def get_version_of_tools():
         try:
             tool_module = import_module(pkg_name)
         except ImportError as ex:
-            logger.warning("can't import module %s: %r", pkg_name, ex)
+            logger.warning("can't import module %s: %s", pkg_name, ex)
         else:
             version = getattr(tool_module, "__version__", None)
             if version is None:
@@ -1441,7 +1441,7 @@ class OSBSLogs(object):
         try:
             logs = osbs.get_orchestrator_build_logs(build_id)
         except OsbsException as ex:
-            self.log.error("unable to get build logs: %r", ex)
+            self.log.error("unable to get build logs: %s", ex)
             return output
         except TypeError:
             # Older osbs-client has no get_orchestrator_build_logs
@@ -1511,3 +1511,11 @@ def dump_stacktraces(sig, frame):
 
 def setup_introspection_signal_handler():
     signal.signal(signal.SIGUSR1, dump_stacktraces)
+
+
+def exception_message(exc):
+    """
+    Take an exception and return an error message.
+    The message includes the type of the exception.
+    """
+    return '{exc.__class__.__name__}: {exc}'.format(exc=exc)

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def _get_requirements(path):
         with open(path) as f:
             packages = f.read().splitlines()
     except (IOError, OSError) as ex:
-        raise RuntimeError("Can't open file with requirements: %r", ex)
+        raise RuntimeError("Can't open file with requirements: %s", ex)
     packages = (p.strip() for p in packages if not re.match("^\s*#", p))
     packages = list(filter(None, packages))
     return packages

--- a/tests/docker_mock.py
+++ b/tests/docker_mock.py
@@ -210,7 +210,7 @@ def _find_image(img, ignore_registry=False):
 
 
 def _docker_exception(code=404, content='not found', exc_class=docker.errors.APIError):
-    response = flexmock(content=content, status_code=code)
+    response = flexmock(content=content, status_code=code, reason=content)
     return exc_class(code, response)
 
 

--- a/tests/plugins/test_add_filesystem.py
+++ b/tests/plugins/test_add_filesystem.py
@@ -413,7 +413,7 @@ def test_image_task_failure(tmpdir, build_cancel, error_during_cancel, raise_err
         if error_during_cancel:
             # We're checking last but one message, as the last one is
             # 'plugin 'add_filesystem' raised an exception'
-            assert "Exception while canceling a task (ignored): Exception("\
+            assert "Exception while canceling a task (ignored): Exception: "\
                 in caplog.records[-2].message
         else:
             msg = "task %s canceled" % FILESYSTEM_TASK_ID

--- a/tests/plugins/test_orchestrate_build.py
+++ b/tests/plugins/test_orchestrate_build.py
@@ -794,12 +794,12 @@ def test_orchestrate_build_unknown_platform(tmpdir, reactor_config_map):  # noqa
     with pytest.raises(PluginFailedException) as exc:
         runner.run()
     if reactor_config_map:
-        assert "'No clusters found for platform spam!'" in str(exc)
+        assert "No clusters found for platform spam!" in str(exc)
     else:
         count = 0
-        if "'No clusters found for platform x86_64!'" in str(exc):
+        if "No clusters found for platform x86_64!" in str(exc):
             count += 1
-        if "'No clusters found for platform spam!'" in str(exc):
+        if "No clusters found for platform spam!" in str(exc):
             count += 1
         assert count > 0
 

--- a/tests/plugins/test_tag_from_config.py
+++ b/tests/plugins/test_tag_from_config.py
@@ -110,9 +110,9 @@ def test_tag_from_config_plugin_generated(tmpdir, docker_tasker, tags, name,
 
 
 @pytest.mark.parametrize(('inspect', 'error'), [  # noqa
-    ({'Labels': {}}, "KeyError(<object"),
-    ({}, "KeyError('Labels'"),
-    (None, "RuntimeError('There is no inspect data"),
+    ({'Labels': {}}, "KeyError: <object"),
+    ({}, "KeyError: 'Labels'"),
+    (None, "RuntimeError: There is no inspect data"),
 ])
 def test_bad_inspect_data(tmpdir, docker_tasker, inspect, error):
     workflow = mock_workflow(tmpdir)

--- a/tests/test_inner.py
+++ b/tests/test_inner.py
@@ -1241,7 +1241,7 @@ def test_cancel_build(request, fail_at):
     # BaseException repr does not include trailing comma in Python >= 3.7
     # we look for a partial match in log strings for Python < 3.7 compatibility
     expected_entry = (
-        "plugin '{}_watched' raised an exception: BuildCanceledException('Build was canceled'"
+        "plugin '{}_watched' raised an exception: BuildCanceledException: Build was canceled"
     )
     if fail_at == 'buildstep':
         with pytest.raises(PluginFailedException):


### PR DESCRIPTION
OSBS-7183

In places where the exception handling was generic (`except Exception`), I decided to keep the class of exception in the error message (it can be useful, and is also tested in some tests).



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
